### PR TITLE
Add Dependabot configuration for daily dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 21
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 21
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,6 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+      interval: "daily"
+    open-pull-requests-limit: 10
+


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable automated dependency update checks on a daily schedule with open-pull-requests-limit configured.