### PR TITLE
Fix CI: add explicit toolchain input to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
+          toolchain: stable
           components: rustfmt
 
       - name: Check formatting
@@ -73,6 +74,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
+          toolchain: stable
           components: clippy
 
       - name: Run clippy
@@ -89,6 +91,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Build debug
         run: cargo build --lib --verbose
@@ -107,6 +111,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Build documentation
         run: cargo doc --no-deps --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Build release

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -39,6 +41,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
@@ -60,5 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      with:
+        toolchain: stable
     - run: cargo install cargo-vet --locked
     - run: cargo vet --locked


### PR DESCRIPTION
## Summary

- All CI jobs using `dtolnay/rust-toolchain@3c5f7ea...` (the SHA-pinned master branch) were failing with `'toolchain' is a required input` because the recent dependabot update (#10) switched from convenience tag references (`@stable`) to a master branch commit that enforces `toolchain` as a required input.
- Added `toolchain: stable` to all 8 affected job steps across `ci.yml`, `security.yml`, and `release.yml`.
- The `test` job in `ci.yml` was unaffected since it already specified `toolchain: ${{ matrix.rust }}`.

## Affected Jobs

- **ci.yml**: Rustfmt, Clippy, Build (ubuntu/macos/windows), Documentation
- **security.yml**: Security Audit, Cargo Deny, vet
- **release.yml**: Build and Release

## Root Cause

The `dtolnay/rust-toolchain` action at commit `3c5f7ea` (master branch) requires the `toolchain` input explicitly. Previously the action inferred the toolchain from the tag name (e.g., `@stable`), but when dependabot updated to a specific SHA on master, that inference mechanism was lost.

## Test plan

- [ ] Verify CI workflow passes (Rustfmt, Clippy, Build, Documentation, Tests)
- [ ] Verify Security Audit workflow passes (audit, deny, vet)
- [ ] Verify Release workflow YAML is valid (only triggers on tag push)