### PR TITLE
Add least-privilege GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,9 @@ on:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   security_audit:
     name: Security Audit


### PR DESCRIPTION
Fixes CodeQL `actions/missing-workflow-permissions` alert.

## Changes
- **.github/workflows/ci.yml**: added top-level `permissions: contents: read`. All jobs (test, fmt, clippy, build, doc) only build/test/document; read-only is sufficient.
- **.github/workflows/security.yml**: added top-level `permissions: contents: read`. All jobs (security_audit, cargo_deny, vet) are read-only supply-chain audits.

## Already-compliant workflows (no change needed)
- `docs.yml` already declares explicit `permissions` (contents: read, pages: write, id-token: write).
- `release.yml` already declares `permissions: contents: write` (needed to create releases and upload assets).

Does not merge / no auto-merge.