### PR TITLE
Release v0.5.0: schema-conformant config rows (fixes SENZ9117; 2 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-21
+
+### Fixed
+
+- **Config rows are now always written with every key present.** `set_rule` dropped a
+  null `DISQ_ERFRAG_CODE` when updating a rule, producing a `CFG_ERRULE` row missing that
+  key; the Senzing engine's config loader then rejected the saved config with
+  `SENZ9117 (CONFIG information for DISQ_ERFRAG_CODE not found in CFG_ERRULE)`. Fixed here
+  and generalized across the crate.
+- **Schema conformance** against the authoritative Senzing v4 column set for each
+  `CFG_*` section (from `config/engine/*.data`, confirmed against a real engine template):
+  - `CFG_DFUNC` now always includes `ANON_SUPPORT` (default `"No"`), which
+    `add_distinct_function` previously omitted. `list_distinct_functions` already read it.
+  - `CFG_DFCALL` is now written with exactly its three authoritative columns
+    (`DFCALL_ID, FTYPE_ID, DFUNC_ID`). Both builders previously added spurious `FELEM_ID`
+    and/or `EXEC_ORDER` keys to the header row; those belong to `CFG_DFBOM`, which is
+    unchanged. Distinct-call identity is now `(FTYPE_ID, DFUNC_ID)`.
+
+### Changed
+
+- Config-section rows are now built from typed serde row structs. The row structs for
+  the eight sections that previously had **two** independent definitions (one in
+  `features.rs`, one in a `calls/*` or `elements` module) — `FelemRow`, `SfcallRow`,
+  `EfcallRow`, `CfcallRow`, `EfbomRow`, `CfbomRow`, `DfcallRow`, `DfbomRow`, plus the
+  single-definition `FtypeRow`/`FbomRow` — are now consolidated into one crate-internal
+  `src/config_rows.rs` module (one `pub(crate)` struct per section). The remaining
+  per-module row structs (`ErruleRow`, `ErfragRow`, `AttrRow`, `DsrcRow`, `FbovrRow`,
+  `GplanRow`, `CfrtnRow`, and the function rows) are unchanged. All structs derive
+  `Serialize` with no `skip_serializing_if`, so optional fields serialize as JSON `null`
+  instead of being omitted — every section key is always present in the emitted JSON.
+- `fragments::set_fragment` now carries `ERFRAG_ID` and `ERFRAG_DESC` (and
+  `ERFRAG_SOURCE`/`ERFRAG_DEPENDS` when the source is not being updated) forward from the
+  existing row rather than dropping them.
+
+### Removed
+
+- **BREAKING:** `CFG_FELEM` no longer carries a `TOKENIZE`/`TOKENIZED` field — it is not a
+  column in the Senzing v4 schema. Following the v0.4.0 approach for the deprecated
+  data-source fields, the `tokenized` parameter has been removed from `AddElementParams`
+  and `SetElementParams` (and their `TryFrom<&Value>` impls), `add_element` no longer
+  emits `TOKENIZE`, `set_element` no longer writes `TOKENIZED`, and the FFI element
+  wrappers no longer read `tokenized`/`TOKENIZED`.
+- **BREAKING:** Removed `functions::comparison::add_comparison_func_return_code` (and its
+  re-export). It wrote a non-existent `CFG_CFRTN` shape (`{CFRTN_ID, CFUNC_ID, CFRTN_CODE,
+  CFRTN_DESC}`). `CFG_CFRTN` is the 10-column score row owned by `thresholds.rs`, which is
+  unchanged.
+
+### Added
+
+- `src/config_rows.rs`: one crate-internal serde row struct per consolidated `CFG_*`
+  section (see Changed), eliminating the duplicate/divergent struct definitions.
+- `helpers::field_as_string` (crate-internal) to carry an existing string/nullable field
+  forward during updates.
+- Per-module "all keys present" unit tests and a `tests/roundtrip_completeness.rs`
+  integration test. The real-config round-trip now runs by **default** against the
+  committed engine template `tests/fixtures/g2config_template.json` (resolved via
+  `CARGO_MANIFEST_DIR`), running every `CFG_ERRULE` row through `set_rule` and every
+  `CFG_ERFRAG` row through `set_fragment` and asserting no row loses a key.
+  `SZ_CONFIG_FIXTURE=/path/to/g2config.json` overrides the fixture with your own config
+  (optionally `SZ_CONFIG_OUT=/path` to write the round-tripped result).
+
 ## [0.4.0] - 2026-08-20
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pure Rust library for manipulating Senzing configuration JSON documents.
 
 ## Overview
 
-`sz_configtool_lib` provides 147 functions across 30 modules for programmatic manipulation of Senzing configuration documents (g2config.json). The library contains only pure business logic with no display formatting, making it ideal for automation scripts, migration tools, and external integrations.
+`sz_configtool_lib` provides 146 functions across 30 modules for programmatic manipulation of Senzing configuration documents (g2config.json). The library contains only pure business logic with no display formatting, making it ideal for automation scripts, migration tools, and external integrations.
 
 ### ⚠️ Important Note on Usage
 
@@ -188,13 +188,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **`system_params`** (2 functions) - System parameter operations
 - **`versioning`** (4 functions) - Version management
 
-### Functions & Calls (60 functions)
+### Functions & Calls (59 functions)
 
-#### Function Modules (28 functions)
+#### Function Modules (27 functions)
 
 - **`functions/standardize`** (6) - Standardization functions (CFG_SFUNC)
 - **`functions/expression`** (6) - Expression functions (CFG_EFUNC)
-- **`functions/comparison`** (7) - Comparison functions (CFG_CFUNC)
+- **`functions/comparison`** (6) - Comparison functions (CFG_CFUNC)
 - **`functions/distinct`** (6) - Distinct functions (CFG_DFUNC)
 - **`functions/matching`** (1) - Matching functions (CFG_RTYPE)
 - **`functions/scoring`** (0) - Scoring functions (stubs)

--- a/examples/feature_operations.rs
+++ b/examples/feature_operations.rs
@@ -52,7 +52,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         code: "EMAIL",
         description: Some("Email Address"),
         data_type: Some("string"),
-        tokenized: None,
     };
 
     config = elements::add_element(&config, add_params)?;

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,6 +1,37 @@
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_ATTR row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted (the nullable `DEFAULT_VALUE` serializes as JSON `null` rather than
+/// being dropped). The Senzing engine's config loader requires every key to be
+/// present, so partial rows must never be written.
+#[derive(Debug, Clone, Serialize)]
+struct AttrRow {
+    #[serde(rename = "ATTR_ID")]
+    attr_id: i64,
+    #[serde(rename = "ATTR_CODE")]
+    attr_code: String,
+    #[serde(rename = "ATTR_CLASS")]
+    attr_class: String,
+    #[serde(rename = "FTYPE_CODE")]
+    ftype_code: String,
+    #[serde(rename = "FELEM_CODE")]
+    felem_code: String,
+    #[serde(rename = "FELEM_REQ")]
+    felem_req: String,
+    #[serde(rename = "DEFAULT_VALUE")]
+    default_value: Option<String>,
+    #[serde(rename = "INTERNAL")]
+    internal: String,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -171,17 +202,20 @@ pub fn add_attribute(config_json: &str, params: AddAttributeParams) -> Result<(S
     // Get next ATTR_ID
     let next_attr_id = helpers::get_next_id_from_array(attrs, "ATTR_ID")?;
 
-    // Create CFG_ATTR entry (matching Python lines 2342-2350)
-    let new_attribute = json!({
-        "ATTR_ID": next_attr_id,
-        "ATTR_CODE": attribute_upper.clone(),
-        "ATTR_CLASS": params.class,
-        "FTYPE_CODE": feature_upper,  // Use actual feature code, not Null
-        "FELEM_CODE": element_upper,  // Use actual element code, not Null
-        "FELEM_REQ": required,
-        "DEFAULT_VALUE": params.default_value.map(|v| json!(v)).unwrap_or(Value::Null),
-        "INTERNAL": internal
-    });
+    // Build a complete row via AttrRow so every CFG_ATTR key is present
+    // (the nullable DEFAULT_VALUE serializes as null) matching Python lines
+    // 2342-2350. FTYPE_CODE/FELEM_CODE use the actual codes, not Null.
+    let row = AttrRow {
+        attr_id: next_attr_id,
+        attr_code: attribute_upper.clone(),
+        attr_class: params.class.to_string(),
+        ftype_code: feature_upper,
+        felem_code: element_upper,
+        felem_req: required.to_string(),
+        default_value: params.default_value.map(str::to_string),
+        internal: internal.to_string(),
+    };
+    let new_attribute = serde_json::to_value(&row)?;
 
     // Add to CFG_ATTR only (Python does not create FBOM in addAttribute)
     let modified_json =
@@ -289,6 +323,7 @@ pub fn list_attributes(config_json: &str) -> Result<Vec<Value>> {
 /// - `JsonParse` if config_json is invalid
 /// - `MissingSection` if CFG_ATTR section doesn't exist
 pub fn set_attribute(config_json: &str, params: SetAttributeParams) -> Result<String> {
+    // In-place update of a complete existing row; all keys preserved.
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
@@ -340,4 +375,87 @@ pub fn set_attribute(config_json: &str, params: SetAttributeParams) -> Result<St
     }
 
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ATTR_KEYS: [&str; 8] = [
+        "ATTR_ID",
+        "ATTR_CODE",
+        "ATTR_CLASS",
+        "FTYPE_CODE",
+        "FELEM_CODE",
+        "FELEM_REQ",
+        "DEFAULT_VALUE",
+        "INTERNAL",
+    ];
+
+    const TEST_CONFIG: &str = r#"{
+        "G2_CONFIG": {
+            "CFG_ATTR": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 1, "FELEM_CODE": "FULL_NAME"}]
+        }
+    }"#;
+
+    fn assert_all_keys(attr: &Value) {
+        let obj = attr.as_object().unwrap();
+        for key in ATTR_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+    }
+
+    #[test]
+    fn test_add_attribute_emits_all_keys() {
+        let params = AddAttributeParams {
+            attribute: "my_attr",
+            feature: "NAME",
+            element: "FULL_NAME",
+            class: "NAME",
+            default_value: None,
+            internal: None,
+            required: None,
+        };
+
+        let (modified, returned) = add_attribute(TEST_CONFIG, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let attr = &value["G2_CONFIG"]["CFG_ATTR"][0];
+
+        assert_all_keys(attr);
+        // The returned Value must carry every key too (used for display).
+        assert_all_keys(&returned);
+
+        assert_eq!(attr["ATTR_CODE"], json!("MY_ATTR"));
+        assert_eq!(attr["ATTR_CLASS"], json!("NAME"));
+        assert_eq!(attr["FTYPE_CODE"], json!("NAME"));
+        assert_eq!(attr["FELEM_CODE"], json!("FULL_NAME"));
+        assert_eq!(attr["FELEM_REQ"], json!("No"));
+        assert_eq!(attr["INTERNAL"], json!("No"));
+        // Nullable default surfaces as null (present, not dropped).
+        assert_eq!(attr["DEFAULT_VALUE"], Value::Null);
+    }
+
+    #[test]
+    fn test_add_attribute_with_default_value() {
+        let params = AddAttributeParams {
+            attribute: "my_attr",
+            feature: "NAME",
+            element: "FULL_NAME",
+            class: "NAME",
+            default_value: Some("DFLT"),
+            internal: Some("Yes"),
+            required: Some("Desired"),
+        };
+
+        let (modified, _returned) = add_attribute(TEST_CONFIG, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let attr = &value["G2_CONFIG"]["CFG_ATTR"][0];
+
+        assert_all_keys(attr);
+        assert_eq!(attr["DEFAULT_VALUE"], json!("DFLT"));
+        assert_eq!(attr["INTERNAL"], json!("Yes"));
+        assert_eq!(attr["FELEM_REQ"], json!("Desired"));
+    }
 }

--- a/src/behavior_overrides.rs
+++ b/src/behavior_overrides.rs
@@ -6,7 +6,31 @@
 
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_FBOVR row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted. The Senzing engine's config loader requires every key to be
+/// present, so partial rows must never be written.
+#[derive(Debug, Clone, Serialize)]
+struct FbovrRow {
+    #[serde(rename = "FTYPE_ID")]
+    ftype_id: i64,
+    #[serde(rename = "UTYPE_CODE")]
+    utype_code: String,
+    #[serde(rename = "FTYPE_FREQ")]
+    ftype_freq: String,
+    #[serde(rename = "FTYPE_EXCL")]
+    ftype_excl: String,
+    #[serde(rename = "FTYPE_STAB")]
+    ftype_stab: String,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -86,14 +110,15 @@ pub fn add_behavior_override(
         )));
     }
 
-    // Create override record
-    let override_record = json!({
-        "FTYPE_ID": ftype_id,
-        "UTYPE_CODE": utype_upper,
-        "FTYPE_FREQ": frequency,
-        "FTYPE_EXCL": exclusivity,
-        "FTYPE_STAB": stability
-    });
+    // Build a complete row via FbovrRow so every CFG_FBOVR key is present.
+    let row = FbovrRow {
+        ftype_id,
+        utype_code: utype_upper,
+        ftype_freq: frequency.to_string(),
+        ftype_excl: exclusivity.to_string(),
+        ftype_stab: stability.to_string(),
+    };
+    let override_record = serde_json::to_value(&row)?;
 
     // Add to CFG_FBOVR
     helpers::add_to_config_array(config_json, "CFG_FBOVR", override_record)
@@ -260,6 +285,7 @@ fn parse_behavior_code(behavior: &str) -> Result<(&'static str, &'static str, &'
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     const TEST_CONFIG: &str = r#"{
   "G2_CONFIG": {
@@ -273,6 +299,36 @@ mod tests {
     "CFG_FBOVR": []
   }
 }"#;
+
+    const FBOVR_KEYS: [&str; 5] = [
+        "FTYPE_ID",
+        "UTYPE_CODE",
+        "FTYPE_FREQ",
+        "FTYPE_EXCL",
+        "FTYPE_STAB",
+    ];
+
+    #[test]
+    fn test_add_behavior_override_emits_all_keys() {
+        let config = add_behavior_override(
+            TEST_CONFIG,
+            AddBehaviorOverrideParams::new("TEST_FEATURE", "BUSINESS", "F1E"),
+        )
+        .expect("Failed to add behavior override");
+
+        let config_val: Value = serde_json::from_str(&config).unwrap();
+        let override_rec = &config_val["G2_CONFIG"]["CFG_FBOVR"][0];
+        let obj = override_rec.as_object().unwrap();
+
+        for key in FBOVR_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(override_rec["FTYPE_ID"], json!(1));
+        assert_eq!(override_rec["UTYPE_CODE"], json!("BUSINESS"));
+        assert_eq!(override_rec["FTYPE_FREQ"], json!("F1"));
+        assert_eq!(override_rec["FTYPE_EXCL"], json!("Yes"));
+        assert_eq!(override_rec["FTYPE_STAB"], json!("No"));
+    }
 
     #[test]
     fn test_add_behavior_override() {

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -3,6 +3,7 @@
 //! Functions for managing CFG_CFCALL (comparison calls) and CFG_CFBOM
 //! (comparison bill of materials) configuration sections.
 
+use crate::config_rows::{CfbomRow, CfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
     find_in_config_array, get_next_id, lookup_cfunc_id, lookup_element_id, lookup_feature_id,
@@ -180,11 +181,8 @@ pub fn add_comparison_call(
 
     // Process element list and create CFBOM records
     let mut cfbom_records = Vec::new();
-    let mut exec_order = 0;
 
     for (idx, element_code) in params.element_list.iter().enumerate() {
-        exec_order += 1;
-
         // Validate element is not blank
         if element_code.trim().is_empty() {
             return Err(SzConfigError::InvalidInput(format!(
@@ -196,21 +194,24 @@ pub fn add_comparison_call(
         // Lookup element ID (global lookup - Python allows any element in call)
         let bom_felem_id = lookup_element_id(config, element_code)?;
 
-        // Create CFBOM record
-        cfbom_records.push(json!({
-            "CFCALL_ID": cfcall_id,
-            "FTYPE_ID": ftype_id,
-            "FELEM_ID": bom_felem_id,
-            "EXEC_ORDER": exec_order
-        }));
+        // Create CFBOM record via CfbomRow so every key is always present.
+        // EXEC_ORDER is 1-based over the element list.
+        let bom_row = CfbomRow {
+            cfcall_id,
+            ftype_id,
+            felem_id: bom_felem_id,
+            exec_order: idx as i64 + 1,
+        };
+        cfbom_records.push(serde_json::to_value(&bom_row)?);
     }
 
-    // Create new CFG_CFCALL record
-    let new_record = json!({
-        "CFCALL_ID": cfcall_id,
-        "FTYPE_ID": ftype_id,
-        "CFUNC_ID": cfunc_id
-    });
+    // Create new CFG_CFCALL record via CfcallRow so every key is always present.
+    let cfcall_row = CfcallRow {
+        cfcall_id,
+        ftype_id,
+        cfunc_id,
+    };
+    let new_record = serde_json::to_value(&cfcall_row)?;
 
     // Add to config
     if let Some(cfcall_array) = config_data["G2_CONFIG"]["CFG_CFCALL"].as_array_mut() {
@@ -424,13 +425,15 @@ pub fn add_comparison_call_element(
         }
     }
 
-    // Create new CBOM record (use params.exec_order directly - no auto-assignment)
-    let new_record = json!({
-        "CFCALL_ID": params.cfcall_id,
-        "FTYPE_ID": params.ftype_id,
-        "FELEM_ID": params.felem_id,
-        "EXEC_ORDER": params.exec_order
-    });
+    // Create new CBOM record via CfbomRow (use params.exec_order directly - no
+    // auto-assignment) so every key is always present.
+    let row = CfbomRow {
+        cfcall_id: params.cfcall_id,
+        ftype_id: params.ftype_id,
+        felem_id: params.felem_id,
+        exec_order: params.exec_order,
+    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_CFBOM
     if let Some(cbom_array) = config_data["G2_CONFIG"]["CFG_CFBOM"].as_array_mut() {
@@ -510,4 +513,76 @@ pub fn set_comparison_call_element(
 ) -> Result<String> {
     // This is a stub - not commonly used
     Ok(config.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CFCALL_KEYS: [&str; 3] = ["CFCALL_ID", "FTYPE_ID", "CFUNC_ID"];
+    const CFBOM_KEYS: [&str; 4] = ["CFCALL_ID", "FTYPE_ID", "FELEM_ID", "EXEC_ORDER"];
+
+    fn assert_all_keys(obj: &Value, keys: &[&str]) {
+        let map = obj.as_object().unwrap();
+        for key in keys {
+            assert!(map.contains_key(*key), "{key} key must be present");
+        }
+    }
+
+    fn base_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_CFCALL": [],
+            "CFG_CFBOM": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_CFUNC": [{"CFUNC_ID": 7, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_add_comparison_call_emits_all_keys() {
+        let config = base_config();
+        let params = AddComparisonCallParams {
+            ftype_code: "NAME".to_string(),
+            cfunc_code: "GNR_COMP".to_string(),
+            element_list: vec!["FIRST_NAME".to_string()],
+        };
+
+        let (modified, new_record) = add_comparison_call(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+
+        // CFG_CFCALL row: exactly the 3 keys, no EXEC_ORDER (flagged discrepancy).
+        let cfcall = &value["G2_CONFIG"]["CFG_CFCALL"][0];
+        assert_all_keys(cfcall, &CFCALL_KEYS);
+        assert!(!cfcall.as_object().unwrap().contains_key("EXEC_ORDER"));
+        assert_eq!(cfcall["FTYPE_ID"], json!(5));
+        assert_eq!(cfcall["CFUNC_ID"], json!(7));
+        assert_all_keys(&new_record, &CFCALL_KEYS);
+
+        // CFG_CFBOM row: all 4 keys.
+        let cfbom = &value["G2_CONFIG"]["CFG_CFBOM"][0];
+        assert_all_keys(cfbom, &CFBOM_KEYS);
+        assert_eq!(cfbom["FELEM_ID"], json!(11));
+        assert_eq!(cfbom["EXEC_ORDER"], json!(1));
+    }
+
+    #[test]
+    fn test_add_comparison_call_element_emits_all_keys() {
+        let config = base_config();
+        let params = AddComparisonCallElementParams {
+            cfcall_id: 1000,
+            ftype_id: 5,
+            felem_id: 11,
+            exec_order: 2,
+        };
+
+        let (modified, new_record) = add_comparison_call_element(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let cfbom = &value["G2_CONFIG"]["CFG_CFBOM"][0];
+
+        assert_all_keys(cfbom, &CFBOM_KEYS);
+        assert_all_keys(&new_record, &CFBOM_KEYS);
+        assert_eq!(cfbom["EXEC_ORDER"], json!(2));
+    }
 }

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -3,6 +3,7 @@
 //! Functions for managing CFG_DFCALL (distinct calls) and CFG_DFBOM
 //! (distinct bill of materials) configuration sections.
 
+use crate::config_rows::{DfbomRow, DfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
     find_in_config_array, get_next_id, lookup_dfunc_id, lookup_element_id, lookup_feature_id,
@@ -164,11 +165,8 @@ pub fn add_distinct_call(config: &str, params: AddDistinctCallParams) -> Result<
 
     // Process element list and create DFBOM records
     let mut dfbom_records = Vec::new();
-    let mut exec_order = 0;
 
     for (idx, element_code) in params.element_list.iter().enumerate() {
-        exec_order += 1;
-
         // Validate element is not blank (already checked in add_distinct_call, defensive)
         if element_code.trim().is_empty() {
             return Err(SzConfigError::InvalidInput(format!(
@@ -180,22 +178,26 @@ pub fn add_distinct_call(config: &str, params: AddDistinctCallParams) -> Result<
         // Lookup element ID (global lookup - Python allows any element in call)
         let bom_felem_id = lookup_element_id(config, element_code)?;
 
-        // Create DFBOM record
-        dfbom_records.push(json!({
-            "DFCALL_ID": dfcall_id,
-            "FTYPE_ID": ftype_id,
-            "FELEM_ID": bom_felem_id,
-            "EXEC_ORDER": exec_order
-        }));
+        // Create DFBOM record via DfbomRow so every key is always present.
+        // EXEC_ORDER is 1-based over the element list.
+        let bom_row = DfbomRow {
+            dfcall_id,
+            ftype_id,
+            felem_id: bom_felem_id,
+            exec_order: idx as i64 + 1,
+        };
+        dfbom_records.push(serde_json::to_value(&bom_row)?);
     }
 
-    // Create new CFG_DFCALL record (EXEC_ORDER is always 1 for distinct calls)
-    let new_record = json!({
-        "DFCALL_ID": dfcall_id,
-        "FTYPE_ID": ftype_id,
-        "DFUNC_ID": dfunc_id,
-        "EXEC_ORDER": 1
-    });
+    // Create new CFG_DFCALL record via DfcallRow. CFG_DFCALL is exactly
+    // DFCALL_ID, FTYPE_ID, DFUNC_ID per the authoritative Senzing v4 schema;
+    // FELEM_ID and EXEC_ORDER live on the CFG_DFBOM rows built above.
+    let dfcall_row = DfcallRow {
+        dfcall_id,
+        ftype_id,
+        dfunc_id,
+    };
+    let new_record = serde_json::to_value(&dfcall_row)?;
 
     // Add to config
     if let Some(dfcall_array) = config_data["G2_CONFIG"]["CFG_DFCALL"].as_array_mut() {
@@ -399,13 +401,14 @@ pub fn add_distinct_call_element(
         }
     }
 
-    // Create new DBOM record
-    let new_record = json!({
-        "DFCALL_ID": params.dfcall_id,
-        "FTYPE_ID": params.ftype_id,
-        "FELEM_ID": params.felem_id,
-        "EXEC_ORDER": params.exec_order
-    });
+    // Create new DBOM record via DfbomRow so every key is always present.
+    let row = DfbomRow {
+        dfcall_id: params.dfcall_id,
+        ftype_id: params.ftype_id,
+        felem_id: params.felem_id,
+        exec_order: params.exec_order,
+    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_DFBOM
     if let Some(dbom_array) = config_data["G2_CONFIG"]["CFG_DFBOM"].as_array_mut() {
@@ -481,4 +484,84 @@ pub fn set_distinct_call_element(
 ) -> Result<String> {
     // This is a stub - not commonly used
     Ok(config.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // CFG_DFCALL is exactly DFCALL_ID, FTYPE_ID, DFUNC_ID per the Senzing v4
+    // schema; FELEM_ID and EXEC_ORDER belong to CFG_DFBOM.
+    const DFCALL_KEYS: [&str; 3] = ["DFCALL_ID", "FTYPE_ID", "DFUNC_ID"];
+    const DFBOM_KEYS: [&str; 4] = ["DFCALL_ID", "FTYPE_ID", "FELEM_ID", "EXEC_ORDER"];
+
+    fn assert_all_keys(obj: &Value, keys: &[&str]) {
+        let map = obj.as_object().unwrap();
+        for key in keys {
+            assert!(map.contains_key(*key), "{key} key must be present");
+        }
+    }
+
+    fn base_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_DFCALL": [],
+            "CFG_DFBOM": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_DFUNC": [{"DFUNC_ID": 7, "DFUNC_CODE": "FELEM_EXP"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_add_distinct_call_emits_all_keys() {
+        let config = base_config();
+        let params = AddDistinctCallParams {
+            ftype_code: "NAME".to_string(),
+            dfunc_code: "FELEM_EXP".to_string(),
+            element_list: vec!["FIRST_NAME".to_string()],
+        };
+
+        let (modified, new_record) = add_distinct_call(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+
+        // CFG_DFCALL row: exactly 3 keys (no FELEM_ID, no EXEC_ORDER).
+        let dfcall = &value["G2_CONFIG"]["CFG_DFCALL"][0];
+        assert_all_keys(dfcall, &DFCALL_KEYS);
+        assert_eq!(
+            dfcall.as_object().unwrap().len(),
+            3,
+            "DFCALL is exactly 3 columns"
+        );
+        assert!(!dfcall.as_object().unwrap().contains_key("FELEM_ID"));
+        assert!(!dfcall.as_object().unwrap().contains_key("EXEC_ORDER"));
+        assert_eq!(dfcall["FTYPE_ID"], json!(5));
+        assert_eq!(dfcall["DFUNC_ID"], json!(7));
+        assert_all_keys(&new_record, &DFCALL_KEYS);
+
+        // CFG_DFBOM row: all 4 keys.
+        let dfbom = &value["G2_CONFIG"]["CFG_DFBOM"][0];
+        assert_all_keys(dfbom, &DFBOM_KEYS);
+        assert_eq!(dfbom["FELEM_ID"], json!(11));
+        assert_eq!(dfbom["EXEC_ORDER"], json!(1));
+    }
+
+    #[test]
+    fn test_add_distinct_call_element_emits_all_keys() {
+        let config = base_config();
+        let params = AddDistinctCallElementParams {
+            dfcall_id: 1000,
+            ftype_id: 5,
+            felem_id: 11,
+            exec_order: 3,
+        };
+
+        let (modified, new_record) = add_distinct_call_element(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dfbom = &value["G2_CONFIG"]["CFG_DFBOM"][0];
+
+        assert_all_keys(dfbom, &DFBOM_KEYS);
+        assert_all_keys(&new_record, &DFBOM_KEYS);
+        assert_eq!(dfbom["EXEC_ORDER"], json!(3));
+    }
 }

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -3,6 +3,7 @@
 //! Functions for managing CFG_EFCALL (expression calls) and CFG_EFBOM
 //! (expression bill of materials) configuration sections.
 
+use crate::config_rows::{EfbomRow, EfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
     find_in_config_array, get_next_id, lookup_efunc_id, lookup_element_id, lookup_feature_id,
@@ -198,10 +199,11 @@ pub fn add_expression_call(
 
     // Process element list and create EFBOM records
     let mut efbom_records = Vec::new();
-    let mut bom_exec_order = 0;
 
-    for (element_code, required, feature_opt) in params.element_list {
-        bom_exec_order += 1;
+    for (idx, (element_code, required, feature_opt)) in params.element_list.into_iter().enumerate()
+    {
+        // EXEC_ORDER is 1-based over the element list.
+        let bom_exec_order = idx as i64 + 1;
 
         // Keep feature name for error messages (clone before consuming)
         let _bom_feature_name_for_errors = feature_opt.clone();
@@ -221,26 +223,28 @@ pub fn add_expression_call(
         // Lookup element ID (always global lookup - feature field is just metadata for EFBOM)
         let bom_felem_id = lookup_element_id(config, &element_code)?;
 
-        // Create EFBOM record
-        efbom_records.push(json!({
-            "EFCALL_ID": efcall_id,
-            "FTYPE_ID": bom_ftype_id,
-            "FELEM_ID": bom_felem_id,
-            "EXEC_ORDER": bom_exec_order,
-            "FELEM_REQ": required
-        }));
+        // Create EFBOM record via EfbomRow so every key is always present.
+        let bom_row = EfbomRow {
+            efcall_id,
+            ftype_id: bom_ftype_id,
+            felem_id: bom_felem_id,
+            exec_order: bom_exec_order,
+            felem_req: required,
+        };
+        efbom_records.push(serde_json::to_value(&bom_row)?);
     }
 
-    // Create new CFG_EFCALL record
-    let new_record = json!({
-        "EFCALL_ID": efcall_id,
-        "FTYPE_ID": ftype_id,
-        "FELEM_ID": felem_id,
-        "EFUNC_ID": efunc_id,
-        "EXEC_ORDER": final_exec_order,
-        "EFEAT_FTYPE_ID": efeat_ftype_id,
-        "IS_VIRTUAL": params.is_virtual
-    });
+    // Create new CFG_EFCALL record via EfcallRow so every key is always present.
+    let efcall_row = EfcallRow {
+        efcall_id,
+        ftype_id,
+        felem_id,
+        efunc_id,
+        exec_order: final_exec_order,
+        efeat_ftype_id,
+        is_virtual: params.is_virtual.to_string(),
+    };
+    let new_record = serde_json::to_value(&efcall_row)?;
 
     // Add to config
     if let Some(efcall_array) = config_data["G2_CONFIG"]["CFG_EFCALL"].as_array_mut() {
@@ -488,14 +492,16 @@ pub fn add_expression_call_element(
         }
     }
 
-    // Create new EBOM record (use params.exec_order directly - no auto-assignment)
-    let new_record = json!({
-        "EFCALL_ID": efcall_id,
-        "FTYPE_ID": params.ftype_id,
-        "FELEM_ID": params.felem_id,
-        "EXEC_ORDER": params.exec_order,
-        "FELEM_REQ": params.felem_req
-    });
+    // Create new EBOM record via EfbomRow (use params.exec_order directly - no
+    // auto-assignment) so every key is always present.
+    let row = EfbomRow {
+        efcall_id,
+        ftype_id: params.ftype_id,
+        felem_id: params.felem_id,
+        exec_order: params.exec_order,
+        felem_req: params.felem_req,
+    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_EFBOM
     if let Some(ebom_array) = config_data["G2_CONFIG"]["CFG_EFBOM"].as_array_mut() {
@@ -573,4 +579,92 @@ pub fn set_expression_call_element(
 ) -> Result<String> {
     // This is a stub - not commonly used
     Ok(config.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EFCALL_KEYS: [&str; 7] = [
+        "EFCALL_ID",
+        "FTYPE_ID",
+        "FELEM_ID",
+        "EFUNC_ID",
+        "EXEC_ORDER",
+        "EFEAT_FTYPE_ID",
+        "IS_VIRTUAL",
+    ];
+    const EFBOM_KEYS: [&str; 5] = [
+        "EFCALL_ID",
+        "FTYPE_ID",
+        "FELEM_ID",
+        "EXEC_ORDER",
+        "FELEM_REQ",
+    ];
+
+    fn assert_all_keys(obj: &Value, keys: &[&str]) {
+        let map = obj.as_object().unwrap();
+        for key in keys {
+            assert!(map.contains_key(*key), "{key} key must be present");
+        }
+    }
+
+    fn base_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_EFCALL": [],
+            "CFG_EFBOM": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_EFUNC": [{"EFUNC_ID": 7, "EFUNC_CODE": "EXPRESS_BOM"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_add_expression_call_emits_all_keys() {
+        let config = base_config();
+        let params = AddExpressionCallParams::new(
+            "EXPRESS_BOM",
+            vec![("FIRST_NAME".to_string(), "No".to_string(), None)],
+        );
+        let params = AddExpressionCallParams {
+            ftype_code: Some("NAME"),
+            ..params
+        };
+
+        let (modified, new_record) = add_expression_call(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+
+        // CFG_EFCALL row: all 7 keys.
+        let efcall = &value["G2_CONFIG"]["CFG_EFCALL"][0];
+        assert_all_keys(efcall, &EFCALL_KEYS);
+        assert_all_keys(&new_record, &EFCALL_KEYS);
+        assert_eq!(efcall["FTYPE_ID"], json!(5));
+        assert_eq!(efcall["EFUNC_ID"], json!(7));
+        assert_eq!(efcall["FELEM_ID"], json!(-1));
+        assert_eq!(efcall["EFEAT_FTYPE_ID"], json!(-1));
+        assert_eq!(efcall["IS_VIRTUAL"], json!("No"));
+
+        // CFG_EFBOM row: all 5 keys.
+        let efbom = &value["G2_CONFIG"]["CFG_EFBOM"][0];
+        assert_all_keys(efbom, &EFBOM_KEYS);
+        assert_eq!(efbom["FELEM_ID"], json!(11));
+        assert_eq!(efbom["FELEM_REQ"], json!("No"));
+        assert_eq!(efbom["EXEC_ORDER"], json!(1));
+    }
+
+    #[test]
+    fn test_add_expression_call_element_emits_all_keys() {
+        let config = base_config();
+        let params = ExpressionCallElementParams::new(5, 11, 2, "Yes".to_string());
+
+        let (modified, new_record) = add_expression_call_element(&config, 1000, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let efbom = &value["G2_CONFIG"]["CFG_EFBOM"][0];
+
+        assert_all_keys(efbom, &EFBOM_KEYS);
+        assert_all_keys(&new_record, &EFBOM_KEYS);
+        assert_eq!(efbom["FELEM_REQ"], json!("Yes"));
+        assert_eq!(efbom["EXEC_ORDER"], json!(2));
+    }
 }

--- a/src/calls/standardize.rs
+++ b/src/calls/standardize.rs
@@ -3,6 +3,7 @@
 //! Functions for managing CFG_SFCALL (standardize calls) and CFG_SBOM
 //! (standardize bill of materials) configuration sections.
 
+use crate::config_rows::SfcallRow;
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
     find_in_config_array, get_next_id, lookup_element_id, lookup_feature_id, lookup_sfunc_id,
@@ -168,14 +169,15 @@ pub fn add_standardize_call(
             .unwrap_or(1)
     };
 
-    // Create new CFG_SFCALL record
-    let new_record = json!({
-        "SFCALL_ID": sfcall_id,
-        "FTYPE_ID": ftype_id,
-        "FELEM_ID": felem_id,
-        "SFUNC_ID": sfunc_id,
-        "EXEC_ORDER": final_exec_order
-    });
+    // Create new CFG_SFCALL record via SfcallRow so every key is always present.
+    let row = SfcallRow {
+        sfcall_id,
+        ftype_id,
+        felem_id,
+        sfunc_id,
+        exec_order: Some(final_exec_order),
+    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to config
     if let Some(sfcall_array) = config_data["G2_CONFIG"]["CFG_SFCALL"].as_array_mut() {
@@ -395,19 +397,16 @@ pub fn add_standardize_call_element(
     // Get next SFCALL_ID
     let sfcall_id = get_next_id(&config_data, "G2_CONFIG.CFG_SFCALL", "SFCALL_ID", 1000)?;
 
-    // Create new call element record
-    let mut new_record = json!({
-        "SFCALL_ID": sfcall_id,
-        "FTYPE_ID": params.ftype_id,
-        "FELEM_ID": final_felem_id,
-        "SFUNC_ID": params.sfunc_id,
-    });
-
-    // Add exec_order (always present, null when not specified)
-    new_record["EXEC_ORDER"] = match params.exec_order {
-        Some(order) => json!(order),
-        None => Value::Null,
+    // Create new call element record via SfcallRow so every key is always
+    // present (EXEC_ORDER null when not specified - seed-then-null pattern).
+    let row = SfcallRow {
+        sfcall_id,
+        ftype_id: params.ftype_id,
+        felem_id: final_felem_id,
+        sfunc_id: params.sfunc_id,
+        exec_order: params.exec_order,
     };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_SFCALL
     if let Some(sfcall_array) = config_data["G2_CONFIG"]["CFG_SFCALL"].as_array_mut() {
@@ -483,4 +482,97 @@ pub fn set_standardize_call_element(
 ) -> Result<String> {
     // This is a stub - not commonly used
     Ok(config.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SFCALL_KEYS: [&str; 5] = [
+        "SFCALL_ID",
+        "FTYPE_ID",
+        "FELEM_ID",
+        "SFUNC_ID",
+        "EXEC_ORDER",
+    ];
+
+    fn assert_all_keys(obj: &Value, keys: &[&str]) {
+        let map = obj.as_object().unwrap();
+        for key in keys {
+            assert!(map.contains_key(*key), "{key} key must be present");
+        }
+    }
+
+    fn base_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_SFCALL": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_SFUNC": [{"SFUNC_ID": 7, "SFUNC_CODE": "PARSE_NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_add_standardize_call_emits_all_keys() {
+        let config = base_config();
+        let params = AddStandardizeCallParams {
+            ftype_code: Some("NAME"),
+            felem_code: None,
+            exec_order: None,
+            sfunc_code: "PARSE_NAME",
+        };
+
+        let (modified, new_record) = add_standardize_call(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let sfcall = &value["G2_CONFIG"]["CFG_SFCALL"][0];
+
+        assert_all_keys(sfcall, &SFCALL_KEYS);
+        assert_all_keys(&new_record, &SFCALL_KEYS);
+        assert_eq!(sfcall["FTYPE_ID"], json!(5));
+        assert_eq!(sfcall["SFUNC_ID"], json!(7));
+        assert_eq!(sfcall["FELEM_ID"], json!(-1));
+        // add_standardize_call always assigns a concrete EXEC_ORDER.
+        assert_eq!(sfcall["EXEC_ORDER"], json!(1));
+    }
+
+    #[test]
+    fn test_add_standardize_call_element_emits_all_keys_exec_order_present() {
+        let config = base_config();
+        let params = AddStandardizeCallElementParams {
+            ftype_id: 5,
+            sfunc_id: 7,
+            felem_id: Some(11),
+            exec_order: Some(4),
+        };
+
+        let (modified, new_record) = add_standardize_call_element(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let sfcall = &value["G2_CONFIG"]["CFG_SFCALL"][0];
+
+        assert_all_keys(sfcall, &SFCALL_KEYS);
+        assert_all_keys(&new_record, &SFCALL_KEYS);
+        assert_eq!(sfcall["FELEM_ID"], json!(11));
+        assert_eq!(sfcall["EXEC_ORDER"], json!(4));
+    }
+
+    #[test]
+    fn test_add_standardize_call_element_emits_exec_order_null_when_absent() {
+        let config = base_config();
+        let params = AddStandardizeCallElementParams {
+            ftype_id: 5,
+            sfunc_id: 7,
+            felem_id: None,
+            exec_order: None,
+        };
+
+        let (modified, _new_record) = add_standardize_call_element(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let sfcall = &value["G2_CONFIG"]["CFG_SFCALL"][0];
+
+        // EXEC_ORDER key present but null (seed-then-null preserved); FELEM_ID -1.
+        assert_all_keys(sfcall, &SFCALL_KEYS);
+        assert_eq!(sfcall["EXEC_ORDER"], Value::Null);
+        assert_eq!(sfcall["FELEM_ID"], json!(-1));
+    }
 }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -262,7 +262,6 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                 code: element,
                 description: None, // Will default to code
                 data_type: datatype,
-                tokenized: None,
             };
 
             crate::elements::add_element(config, add_params)

--- a/src/config_rows.rs
+++ b/src/config_rows.rs
@@ -1,0 +1,196 @@
+//! Shared config-row structs.
+//!
+//! One `pub(crate)` serde struct per CFG_* section that is written by more than
+//! one builder module. Centralizing them here guarantees a single source of
+//! truth for each section's on-disk shape — previously several sections had two
+//! independent struct definitions (one in `features.rs`, one in a `calls/*` or
+//! `elements` module) that could drift apart.
+//!
+//! Every struct derives `Serialize` with **no** `skip_serializing_if`, so every
+//! key is always emitted — optional/nullable fields serialize as JSON `null`
+//! rather than being dropped. The Senzing engine's config loader requires every
+//! key of every row to be present (a missing key yields SENZ9117), so partial
+//! rows must never be written.
+//!
+//! The key set of each struct is exactly the authoritative Senzing v4 column set
+//! for that section (from `config/engine/*.data`) — no more, no less.
+
+use serde::Serialize;
+
+/// Complete CFG_FTYPE row (feature type).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FtypeRow {
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FTYPE_CODE")]
+    pub(crate) ftype_code: String,
+    #[serde(rename = "FTYPE_DESC")]
+    pub(crate) ftype_desc: String,
+    #[serde(rename = "FCLASS_ID")]
+    pub(crate) fclass_id: i64,
+    #[serde(rename = "FTYPE_FREQ")]
+    pub(crate) ftype_freq: String,
+    #[serde(rename = "FTYPE_EXCL")]
+    pub(crate) ftype_excl: String,
+    #[serde(rename = "FTYPE_STAB")]
+    pub(crate) ftype_stab: String,
+    #[serde(rename = "ANONYMIZE")]
+    pub(crate) anonymize: String,
+    #[serde(rename = "DERIVED")]
+    pub(crate) derived: String,
+    #[serde(rename = "USED_FOR_CAND")]
+    pub(crate) used_for_cand: String,
+    #[serde(rename = "SHOW_IN_MATCH_KEY")]
+    pub(crate) show_in_match_key: String,
+    #[serde(rename = "PERSIST_HISTORY")]
+    pub(crate) persist_history: String,
+    #[serde(rename = "VERSION")]
+    pub(crate) version: i64,
+    #[serde(rename = "RTYPE_ID")]
+    pub(crate) rtype_id: i64,
+}
+
+/// Complete CFG_FELEM row (feature element).
+///
+/// Authoritative columns: `FELEM_ID, FELEM_CODE, FELEM_DESC, DATA_TYPE`. There is
+/// no `TOKENIZE`/`TOKENIZED` column in the Senzing v4 schema.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FelemRow {
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "FELEM_CODE")]
+    pub(crate) felem_code: String,
+    #[serde(rename = "FELEM_DESC")]
+    pub(crate) felem_desc: String,
+    #[serde(rename = "DATA_TYPE")]
+    pub(crate) data_type: String,
+}
+
+/// Complete CFG_SFCALL row (standardize call).
+///
+/// `EXEC_ORDER` is `Option<i64>` because `add_standardize_call_element` uses the
+/// seed-then-null pattern (null when not supplied); `add_standardize_call` and
+/// `add_feature` always supply a concrete value.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SfcallRow {
+    #[serde(rename = "SFCALL_ID")]
+    pub(crate) sfcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "SFUNC_ID")]
+    pub(crate) sfunc_id: i64,
+    #[serde(rename = "EXEC_ORDER")]
+    pub(crate) exec_order: Option<i64>,
+}
+
+/// Complete CFG_EFCALL row (expression call).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EfcallRow {
+    #[serde(rename = "EFCALL_ID")]
+    pub(crate) efcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "EFUNC_ID")]
+    pub(crate) efunc_id: i64,
+    #[serde(rename = "EXEC_ORDER")]
+    pub(crate) exec_order: i64,
+    #[serde(rename = "EFEAT_FTYPE_ID")]
+    pub(crate) efeat_ftype_id: i64,
+    #[serde(rename = "IS_VIRTUAL")]
+    pub(crate) is_virtual: String,
+}
+
+/// Complete CFG_CFCALL row (comparison call).
+///
+/// Authoritative columns: `CFCALL_ID, FTYPE_ID, CFUNC_ID` — the schema has no
+/// `EXEC_ORDER` column for this section.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CfcallRow {
+    #[serde(rename = "CFCALL_ID")]
+    pub(crate) cfcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "CFUNC_ID")]
+    pub(crate) cfunc_id: i64,
+}
+
+/// Complete CFG_EFBOM row (expression bill-of-materials entry).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EfbomRow {
+    #[serde(rename = "EFCALL_ID")]
+    pub(crate) efcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "EXEC_ORDER")]
+    pub(crate) exec_order: i64,
+    #[serde(rename = "FELEM_REQ")]
+    pub(crate) felem_req: String,
+}
+
+/// Complete CFG_CFBOM row (comparison bill-of-materials entry).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CfbomRow {
+    #[serde(rename = "CFCALL_ID")]
+    pub(crate) cfcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "EXEC_ORDER")]
+    pub(crate) exec_order: i64,
+}
+
+/// Complete CFG_DFCALL row (distinct call).
+///
+/// Authoritative columns: `DFCALL_ID, FTYPE_ID, DFUNC_ID` — no `FELEM_ID` and no
+/// `EXEC_ORDER` on the header row (those belong to CFG_DFBOM).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DfcallRow {
+    #[serde(rename = "DFCALL_ID")]
+    pub(crate) dfcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "DFUNC_ID")]
+    pub(crate) dfunc_id: i64,
+}
+
+/// Complete CFG_DFBOM row (distinct bill-of-materials entry).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DfbomRow {
+    #[serde(rename = "DFCALL_ID")]
+    pub(crate) dfcall_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "EXEC_ORDER")]
+    pub(crate) exec_order: i64,
+}
+
+/// Complete CFG_FBOM row (feature bill-of-materials entry).
+///
+/// Shared by `add_feature` (which fills EXEC_ORDER/DISPLAY_LEVEL/DERIVED with
+/// concrete values and only DISPLAY_DELIM may be null) and
+/// `add_feature_comparison` (which may leave any of them null via seed-then-null).
+/// Nullable fields are `Option` so both callers keep every key present.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FbomRow {
+    #[serde(rename = "FTYPE_ID")]
+    pub(crate) ftype_id: i64,
+    #[serde(rename = "FELEM_ID")]
+    pub(crate) felem_id: i64,
+    #[serde(rename = "EXEC_ORDER")]
+    pub(crate) exec_order: Option<i64>,
+    #[serde(rename = "DISPLAY_LEVEL")]
+    pub(crate) display_level: Option<i64>,
+    #[serde(rename = "DISPLAY_DELIM")]
+    pub(crate) display_delim: Option<String>,
+    #[serde(rename = "DERIVED")]
+    pub(crate) derived: Option<String>,
+}

--- a/src/datasources.rs
+++ b/src/datasources.rs
@@ -1,6 +1,28 @@
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_DSRC row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted. The Senzing engine's config loader requires every key to be
+/// present, so partial rows must never be written.
+#[derive(Debug, Clone, Serialize)]
+struct DsrcRow {
+    #[serde(rename = "DSRC_ID")]
+    dsrc_id: i64,
+    #[serde(rename = "DSRC_CODE")]
+    dsrc_code: String,
+    #[serde(rename = "DSRC_DESC")]
+    dsrc_desc: String,
+    #[serde(rename = "RETENTION_LEVEL")]
+    retention_level: String,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -105,12 +127,15 @@ pub fn add_data_source(config_json: &str, params: AddDataSourceParams) -> Result
         "Remember"
     };
 
-    dsrcs.push(json!({
-        "DSRC_ID": next_id,
-        "DSRC_CODE": code_upper.clone(),
-        "DSRC_DESC": code_upper,  // Python uses code as description, not formatted string
-        "RETENTION_LEVEL": retention,
-    }));
+    // Build a complete row via DsrcRow so every CFG_DSRC key is present.
+    // Python uses the code as the description (not a formatted string).
+    let row = DsrcRow {
+        dsrc_id: next_id,
+        dsrc_code: code_upper.clone(),
+        dsrc_desc: code_upper,
+        retention_level: retention.to_string(),
+    };
+    dsrcs.push(serde_json::to_value(&row)?);
 
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
@@ -245,6 +270,7 @@ pub fn list_data_sources(config_json: &str) -> Result<Vec<Value>> {
 /// - `JsonParse` if config_json is invalid
 /// - `MissingSection` if CFG_DSRC section doesn't exist
 pub fn set_data_source(config_json: &str, params: SetDataSourceParams) -> Result<String> {
+    // In-place update of a complete existing row; all keys preserved.
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
@@ -268,4 +294,51 @@ pub fn set_data_source(config_json: &str, params: SetDataSourceParams) -> Result
     }
 
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DSRC_KEYS: [&str; 4] = ["DSRC_ID", "DSRC_CODE", "DSRC_DESC", "RETENTION_LEVEL"];
+
+    const TEST_CONFIG: &str = r#"{"G2_CONFIG": {"CFG_DSRC": []}}"#;
+
+    #[test]
+    fn test_add_data_source_emits_all_keys() {
+        let params = AddDataSourceParams {
+            code: "customers",
+            retention_level: None,
+        };
+
+        let modified = add_data_source(TEST_CONFIG, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dsrc = &value["G2_CONFIG"]["CFG_DSRC"][0];
+        let obj = dsrc.as_object().unwrap();
+
+        for key in DSRC_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(dsrc["DSRC_CODE"], json!("CUSTOMERS"));
+        assert_eq!(dsrc["DSRC_DESC"], json!("CUSTOMERS"));
+        assert_eq!(dsrc["RETENTION_LEVEL"], json!("Remember"));
+    }
+
+    #[test]
+    fn test_add_data_source_with_retention() {
+        let params = AddDataSourceParams {
+            code: "watchlist",
+            retention_level: Some("forget"),
+        };
+
+        let modified = add_data_source(TEST_CONFIG, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dsrc = &value["G2_CONFIG"]["CFG_DSRC"][0];
+        let obj = dsrc.as_object().unwrap();
+
+        for key in DSRC_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(dsrc["RETENTION_LEVEL"], json!("Forget"));
+    }
 }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,3 +1,4 @@
+use crate::config_rows::FelemRow;
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
 use serde_json::{Value, json};
@@ -12,7 +13,6 @@ pub struct AddElementParams<'a> {
     pub code: &'a str,
     pub description: Option<&'a str>,
     pub data_type: Option<&'a str>,
-    pub tokenized: Option<&'a str>,
 }
 
 impl<'a> TryFrom<&'a Value> for AddElementParams<'a> {
@@ -28,7 +28,6 @@ impl<'a> TryFrom<&'a Value> for AddElementParams<'a> {
             code,
             description: json.get("description").and_then(|v| v.as_str()),
             data_type: json.get("dataType").and_then(|v| v.as_str()),
-            tokenized: json.get("tokenized").and_then(|v| v.as_str()),
         })
     }
 }
@@ -39,7 +38,6 @@ pub struct SetElementParams<'a> {
     pub code: &'a str,
     pub description: Option<&'a str>,
     pub data_type: Option<&'a str>,
-    pub tokenized: Option<&'a str>,
 }
 
 impl<'a> TryFrom<&'a Value> for SetElementParams<'a> {
@@ -55,7 +53,6 @@ impl<'a> TryFrom<&'a Value> for SetElementParams<'a> {
             code,
             description: json.get("description").and_then(|v| v.as_str()),
             data_type: json.get("dataType").and_then(|v| v.as_str()),
-            tokenized: json.get("tokenized").and_then(|v| v.as_str()),
         })
     }
 }
@@ -196,37 +193,18 @@ pub fn add_element(config_json: &str, params: AddElementParams) -> Result<String
         "string" // Default
     };
 
-    // Validate and normalize tokenized (Python lines 1983-1986)
-    let tokenized = if let Some(tok) = params.tokenized {
-        let tok_upper = tok.to_uppercase();
-        match tok_upper.as_str() {
-            "YES" => "Yes",
-            "NO" => "No",
-            _ => {
-                return Err(SzConfigError::InvalidInput(format!(
-                    "Invalid TOKENIZED value '{tok}'. Must be 'Yes' or 'No'"
-                )));
-            }
-        }
-    } else {
-        "No" // Default
+    // Build a complete row via FelemRow so every CFG_FELEM key is present.
+    // FELEM_DESC uses the supplied description or falls back to the code.
+    let row = FelemRow {
+        felem_id,
+        felem_code: code_upper.clone(),
+        data_type: data_type.to_string(),
+        felem_desc: params
+            .description
+            .map(str::to_string)
+            .unwrap_or_else(|| code_upper.clone()),
     };
-
-    // Build record from params (Python parity: TOKENIZE not TOKENIZED)
-    let mut new_record = json!({
-        "FELEM_ID": felem_id,
-        "FELEM_CODE": code_upper.clone(),
-        "DATA_TYPE": data_type,
-        "TOKENIZE": tokenized,
-    });
-
-    if let Some(obj) = new_record.as_object_mut() {
-        if let Some(desc) = params.description {
-            obj.insert("FELEM_DESC".to_string(), json!(desc));
-        } else {
-            obj.insert("FELEM_DESC".to_string(), json!(code_upper));
-        }
-    }
+    let new_record = serde_json::to_value(&row)?;
 
     helpers::add_to_config_array(config_json, "CFG_FELEM", new_record)
 }
@@ -382,6 +360,7 @@ pub fn list_elements(config_json: &str) -> Result<Vec<Value>> {
 /// # Returns
 /// Modified configuration JSON string
 pub fn set_element(config_json: &str, params: SetElementParams) -> Result<String> {
+    // In-place update of a complete existing row; all keys preserved.
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
@@ -404,9 +383,6 @@ pub fn set_element(config_json: &str, params: SetElementParams) -> Result<String
         }
         if let Some(dt) = params.data_type {
             dest_obj.insert("DATA_TYPE".to_string(), json!(dt));
-        }
-        if let Some(tok) = params.tokenized {
-            dest_obj.insert("TOKENIZED".to_string(), json!(tok));
         }
     }
 
@@ -435,6 +411,7 @@ pub fn set_element(config_json: &str, params: SetElementParams) -> Result<String
 /// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
 /// ```
 pub fn set_feature_element(config_json: &str, params: SetFeatureElementParams) -> Result<String> {
+    // In-place update of a complete existing CFG_FBOM row; all keys preserved.
     // Resolve codes to IDs
     let feature_code = params
         .feature_code
@@ -519,6 +496,7 @@ pub fn set_feature_element_display_level(
     element_code: &str,
     display_level: i64,
 ) -> Result<String> {
+    // Delegates to set_feature_element: in-place CFG_FBOM update, all keys preserved.
     set_feature_element(
         config_json,
         SetFeatureElementParams::new(feature_code, element_code).with_display_level(display_level),
@@ -550,6 +528,7 @@ pub fn set_feature_element_derived(
     element_code: &str,
     derived: &str,
 ) -> Result<String> {
+    // Delegates to set_feature_element: in-place CFG_FBOM update, all keys preserved.
     set_feature_element(
         config_json,
         SetFeatureElementParams::new(feature_code, element_code).with_derived(derived),
@@ -664,6 +643,57 @@ mod tests {
         let config: Value = serde_json::from_str(&result.unwrap()).unwrap();
         let fbom = &config["G2_CONFIG"]["CFG_FBOM"][0];
         assert_eq!(fbom["DERIVED"], "Yes");
+    }
+
+    const FELEM_KEYS: [&str; 4] = ["FELEM_ID", "FELEM_CODE", "DATA_TYPE", "FELEM_DESC"];
+
+    #[test]
+    fn test_add_element_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_FELEM": []}}"#;
+        let params = AddElementParams {
+            code: "my_elem",
+            description: None,
+            data_type: None,
+        };
+
+        let modified = add_element(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let felem = &value["G2_CONFIG"]["CFG_FELEM"][0];
+        let obj = felem.as_object().unwrap();
+
+        assert_eq!(obj.len(), 4, "CFG_FELEM is exactly 4 columns");
+        for key in FELEM_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(felem["FELEM_CODE"], json!("MY_ELEM"));
+        assert_eq!(felem["DATA_TYPE"], json!("string"));
+        // CFG_FELEM has no TOKENIZE/TOKENIZED column in the Senzing v4 schema.
+        assert!(!obj.contains_key("TOKENIZE"));
+        assert!(!obj.contains_key("TOKENIZED"));
+        // FELEM_DESC falls back to the code when no description is supplied.
+        assert_eq!(felem["FELEM_DESC"], json!("MY_ELEM"));
+    }
+
+    #[test]
+    fn test_add_element_with_all_fields() {
+        let config = r#"{"G2_CONFIG": {"CFG_FELEM": []}}"#;
+        let params = AddElementParams {
+            code: "my_elem",
+            description: Some("My element"),
+            data_type: Some("number"),
+        };
+
+        let modified = add_element(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let felem = &value["G2_CONFIG"]["CFG_FELEM"][0];
+        let obj = felem.as_object().unwrap();
+
+        for key in FELEM_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert!(!obj.contains_key("TOKENIZE"));
+        assert_eq!(felem["DATA_TYPE"], json!("number"));
+        assert_eq!(felem["FELEM_DESC"], json!("My element"));
     }
 
     #[test]

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,3 +1,6 @@
+use crate::config_rows::{
+    CfbomRow, CfcallRow, DfcallRow, EfbomRow, EfcallRow, FbomRow, FelemRow, FtypeRow, SfcallRow,
+};
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
 use serde_json::{Value, json};
@@ -511,23 +514,24 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
         }
     }
 
-    // Create CFG_FTYPE record
-    let ftype_record = json!({
-        "FTYPE_ID": ftype_id,
-        "FTYPE_CODE": feature_upper.clone(),
-        "FTYPE_DESC": feature_upper.clone(),
-        "FCLASS_ID": fclass_id,
-        "FTYPE_FREQ": frequency,
-        "FTYPE_EXCL": exclusivity,
-        "FTYPE_STAB": stability,
-        "ANONYMIZE": anonymize_val,
-        "DERIVED": derived_val,
-        "USED_FOR_CAND": candidates_val,
-        "SHOW_IN_MATCH_KEY": matchkey_val,
-        "PERSIST_HISTORY": history_val,
-        "VERSION": params.version.unwrap_or(1),
-        "RTYPE_ID": params.rtype_id.unwrap_or(0)
-    });
+    // Create CFG_FTYPE record via FtypeRow so every key is always present.
+    let ftype_row = FtypeRow {
+        ftype_id,
+        ftype_code: feature_upper.clone(),
+        ftype_desc: feature_upper.clone(),
+        fclass_id,
+        ftype_freq: frequency.to_string(),
+        ftype_excl: exclusivity.to_string(),
+        ftype_stab: stability.to_string(),
+        anonymize: anonymize_val.to_string(),
+        derived: derived_val.to_string(),
+        used_for_cand: candidates_val.to_string(),
+        show_in_match_key: matchkey_val.to_string(),
+        persist_history: history_val.to_string(),
+        version: params.version.unwrap_or(1),
+        rtype_id: params.rtype_id.unwrap_or(0),
+    };
+    let ftype_record = serde_json::to_value(&ftype_row)?;
 
     // Add to CFG_FTYPE
     if let Some(ftype_array) = config["G2_CONFIG"]["CFG_FTYPE"].as_array_mut() {
@@ -540,13 +544,13 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
             .as_array()
             .ok_or_else(|| SzConfigError::MissingSection("CFG_SFCALL".to_string()))?;
         let id = helpers::get_next_id_with_min(sfcall_array, "SFCALL_ID", 1000)?;
-        let record = json!({
-            "SFCALL_ID": id,
-            "SFUNC_ID": sfunc_id,
-            "EXEC_ORDER": 1,
-            "FTYPE_ID": ftype_id,
-            "FELEM_ID": -1
-        });
+        let record = serde_json::to_value(&SfcallRow {
+            sfcall_id: id,
+            sfunc_id,
+            exec_order: Some(1),
+            ftype_id,
+            felem_id: -1,
+        })?;
         if let Some(array) = config["G2_CONFIG"]["CFG_SFCALL"].as_array_mut() {
             array.push(record);
         }
@@ -558,15 +562,15 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
             .as_array()
             .ok_or_else(|| SzConfigError::MissingSection("CFG_EFCALL".to_string()))?;
         let id = helpers::get_next_id_with_min(efcall_array, "EFCALL_ID", 1000)?;
-        let record = json!({
-            "EFCALL_ID": id,
-            "EFUNC_ID": efunc_id,
-            "EXEC_ORDER": 1,
-            "FTYPE_ID": ftype_id,
-            "FELEM_ID": -1,
-            "EFEAT_FTYPE_ID": -1,
-            "IS_VIRTUAL": "No"
-        });
+        let record = serde_json::to_value(&EfcallRow {
+            efcall_id: id,
+            efunc_id,
+            exec_order: 1,
+            ftype_id,
+            felem_id: -1,
+            efeat_ftype_id: -1,
+            is_virtual: "No".to_string(),
+        })?;
         if let Some(array) = config["G2_CONFIG"]["CFG_EFCALL"].as_array_mut() {
             array.push(record);
         }
@@ -581,11 +585,12 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
             .as_array()
             .ok_or_else(|| SzConfigError::MissingSection("CFG_CFCALL".to_string()))?;
         let id = helpers::get_next_id_with_min(cfcall_array, "CFCALL_ID", 1000)?;
-        let record = json!({
-            "CFCALL_ID": id,
-            "CFUNC_ID": cfunc_id,
-            "FTYPE_ID": ftype_id
-        });
+        // CFG_CFCALL is exactly CFCALL_ID, FTYPE_ID, CFUNC_ID (no EXEC_ORDER column).
+        let record = serde_json::to_value(&CfcallRow {
+            cfcall_id: id,
+            cfunc_id,
+            ftype_id,
+        })?;
         if let Some(array) = config["G2_CONFIG"]["CFG_CFCALL"].as_array_mut() {
             array.push(record);
         }
@@ -699,13 +704,12 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
         } else {
             // Create new element
             let new_id = helpers::get_next_id_with_min(felem_array, "FELEM_ID", 1000)?;
-            let new_element = json!({
-                "FELEM_ID": new_id,
-                "FELEM_CODE": element_code.clone(),
-                "FELEM_DESC": element_code.clone(),
-                "DATA_TYPE": "string",
-                "TOKENIZE": "No"
-            });
+            let new_element = serde_json::to_value(&FelemRow {
+                felem_id: new_id,
+                felem_code: element_code.clone(),
+                felem_desc: element_code.clone(),
+                data_type: "string".to_string(),
+            })?;
             if let Some(array) = config["G2_CONFIG"]["CFG_FELEM"].as_array_mut() {
                 array.push(new_element);
             }
@@ -714,13 +718,13 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
 
         // Add to EFBOM if expressed
         if efcall_id > 0 && expressed.eq_ignore_ascii_case("yes") {
-            let record = json!({
-                "EFCALL_ID": efcall_id,
-                "EXEC_ORDER": fbom_order,
-                "FTYPE_ID": ftype_id,
-                "FELEM_ID": felem_id,
-                "FELEM_REQ": "Yes"
-            });
+            let record = serde_json::to_value(&EfbomRow {
+                efcall_id,
+                exec_order: fbom_order,
+                ftype_id,
+                felem_id,
+                felem_req: "Yes".to_string(),
+            })?;
             if let Some(array) = config["G2_CONFIG"]["CFG_EFBOM"].as_array_mut() {
                 array.push(record);
             }
@@ -728,30 +732,26 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
 
         // Add to CFBOM if compared
         if cfcall_id > 0 && compared.eq_ignore_ascii_case("yes") {
-            let record = json!({
-                "CFCALL_ID": cfcall_id,
-                "EXEC_ORDER": fbom_order,
-                "FTYPE_ID": ftype_id,
-                "FELEM_ID": felem_id
-            });
+            let record = serde_json::to_value(&CfbomRow {
+                cfcall_id,
+                exec_order: fbom_order,
+                ftype_id,
+                felem_id,
+            })?;
             if let Some(array) = config["G2_CONFIG"]["CFG_CFBOM"].as_array_mut() {
                 array.push(record);
             }
         }
 
-        // Add to FBOM (always)
-        let mut fbom_record = json!({
-            "FTYPE_ID": ftype_id,
-            "FELEM_ID": felem_id,
-            "EXEC_ORDER": fbom_order,
-            "DISPLAY_LEVEL": display_level,
-            "DERIVED": elem_derived
-        });
-
-        fbom_record["DISPLAY_DELIM"] = match display_delim {
-            Some(delim) => json!(delim),
-            None => Value::Null,
-        };
+        // Add to FBOM (always). DISPLAY_DELIM is nullable (seed-then-null).
+        let fbom_record = serde_json::to_value(&FbomRow {
+            ftype_id,
+            felem_id,
+            exec_order: Some(fbom_order),
+            display_level: Some(display_level),
+            display_delim,
+            derived: Some(elem_derived),
+        })?;
 
         if let Some(array) = config["G2_CONFIG"]["CFG_FBOM"].as_array_mut() {
             array.push(fbom_record);
@@ -1014,6 +1014,8 @@ pub fn set_feature(config_json: &str, params: SetFeatureParams) -> Result<String
         .find(|f| f["FTYPE_ID"].as_i64() == Some(ftype_id))
         .ok_or_else(|| SzConfigError::NotFound("Feature not found".to_string()))?;
 
+    // In-place update of a complete existing CFG_FTYPE row; all keys preserved.
+    // Not routed through FtypeRow (which would require reconstructing every field).
     // Track if any changes made (for "No changes detected")
     let mut changes_made = false;
 
@@ -1451,28 +1453,16 @@ pub fn add_feature_comparison(
         )));
     }
 
-    // Build record
-    let mut record = json!({
-        "FTYPE_ID": ftype_id,
-        "FELEM_ID": felem_id,
-    });
-
-    record["EXEC_ORDER"] = match params.exec_order {
-        Some(order) => json!(order),
-        None => Value::Null,
-    };
-    record["DISPLAY_LEVEL"] = match params.display_level {
-        Some(level) => json!(level),
-        None => Value::Null,
-    };
-    record["DISPLAY_DELIM"] = match params.display_delim {
-        Some(delim) => json!(delim),
-        None => Value::Null,
-    };
-    record["DERIVED"] = match params.derived {
-        Some(der) => json!(der),
-        None => Value::Null,
-    };
+    // Build record via FbomRow so every CFG_FBOM key is present; unset optional
+    // fields serialize as null (seed-then-null preserved).
+    let record = serde_json::to_value(&FbomRow {
+        ftype_id,
+        felem_id,
+        exec_order: params.exec_order,
+        display_level: params.display_level,
+        display_delim: params.display_delim.map(str::to_string),
+        derived: params.derived.map(str::to_string),
+    })?;
 
     helpers::add_to_config_array(config_json, "CFG_FBOM", record)
 }
@@ -1648,24 +1638,22 @@ pub fn add_feature_distinct_call_element(
 
     let ftype_id = helpers::lookup_feature_id(config_json, feature_code)?;
     let dfunc_id = helpers::lookup_dfunc_id(config_json, distinct_func_code)?;
-    let felem_id = if let Some(code) = params.element_code {
-        helpers::lookup_element_id(config_json, code)?
-    } else {
-        -1
-    };
+    // Validate the element code if supplied (a DFCALL identifies a feature/function
+    // pair; per the authoritative schema its row carries no FELEM_ID or EXEC_ORDER).
+    if let Some(code) = params.element_code {
+        helpers::lookup_element_id(config_json, code)?;
+    }
 
     let config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    // Check if already exists
+    // Check if already exists (identity is FTYPE_ID + DFUNC_ID)
     let dfcall_array = config["G2_CONFIG"]["CFG_DFCALL"]
         .as_array()
         .ok_or_else(|| SzConfigError::MissingSection("CFG_DFCALL".to_string()))?;
 
     if dfcall_array.iter().any(|item| {
-        item["FTYPE_ID"].as_i64() == Some(ftype_id)
-            && item["DFUNC_ID"].as_i64() == Some(dfunc_id)
-            && item["FELEM_ID"].as_i64() == Some(felem_id)
+        item["FTYPE_ID"].as_i64() == Some(ftype_id) && item["DFUNC_ID"].as_i64() == Some(dfunc_id)
     }) {
         return Err(SzConfigError::AlreadyExists(format!(
             "Feature distinct call element: {:?}+{:?}",
@@ -1676,18 +1664,13 @@ pub fn add_feature_distinct_call_element(
     // Get next DFCALL_ID
     let dfcall_id = helpers::get_next_id_with_min(dfcall_array, "DFCALL_ID", 1000)?;
 
-    // Build record
-    let mut record = json!({
-        "DFCALL_ID": dfcall_id,
-        "FTYPE_ID": ftype_id,
-        "DFUNC_ID": dfunc_id,
-        "FELEM_ID": felem_id,
-    });
-
-    record["EXEC_ORDER"] = match params.exec_order {
-        Some(order) => json!(order),
-        None => Value::Null,
-    };
+    // Build record via DfcallRow. CFG_DFCALL is exactly DFCALL_ID, FTYPE_ID,
+    // DFUNC_ID per the authoritative Senzing v4 schema.
+    let record = serde_json::to_value(&DfcallRow {
+        dfcall_id,
+        ftype_id,
+        dfunc_id,
+    })?;
 
     helpers::add_to_config_array(config_json, "CFG_DFCALL", record)
 }
@@ -1761,6 +1744,8 @@ pub fn update_feature_version(config_json: &str, version: &str) -> Result<String
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
+    // In-place update of a single scalar field (not a CFG_* section row builder);
+    // all other keys preserved. Left as-is per spec.
     // Navigate to COMPATIBILITY_VERSION
     let compat_version = config["G2_CONFIG"]["CONFIG_BASE_VERSION"]["COMPATIBILITY_VERSION"]
         .as_object_mut()
@@ -1769,4 +1754,224 @@ pub fn update_feature_version(config_json: &str, version: &str) -> Result<String
     compat_version.insert("FEATURE_VERSION".to_string(), json!(version));
 
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FTYPE_KEYS: [&str; 14] = [
+        "FTYPE_ID",
+        "FTYPE_CODE",
+        "FTYPE_DESC",
+        "FCLASS_ID",
+        "FTYPE_FREQ",
+        "FTYPE_EXCL",
+        "FTYPE_STAB",
+        "ANONYMIZE",
+        "DERIVED",
+        "USED_FOR_CAND",
+        "SHOW_IN_MATCH_KEY",
+        "PERSIST_HISTORY",
+        "VERSION",
+        "RTYPE_ID",
+    ];
+    const FBOM_KEYS: [&str; 6] = [
+        "FTYPE_ID",
+        "FELEM_ID",
+        "EXEC_ORDER",
+        "DISPLAY_LEVEL",
+        "DISPLAY_DELIM",
+        "DERIVED",
+    ];
+    const FELEM_KEYS: [&str; 4] = ["FELEM_ID", "FELEM_CODE", "FELEM_DESC", "DATA_TYPE"];
+
+    fn assert_all_keys(obj: &Value, keys: &[&str]) {
+        let map = obj.as_object().unwrap();
+        for key in keys {
+            assert!(map.contains_key(*key), "{key} key must be present");
+        }
+    }
+
+    /// add_feature must write a complete CFG_FTYPE row, a complete CFG_FELEM row
+    /// for the newly-created element, and a complete CFG_FBOM row.
+    #[test]
+    fn test_add_feature_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [],
+            "CFG_FCLASS": [{"FCLASS_ID": 1, "FCLASS_CODE": "OTHER"}],
+            "CFG_FELEM": [],
+            "CFG_FBOM": []
+        }}"#;
+
+        let elements = json!([{"element": "MYELEM"}]);
+        let params = AddFeatureParams {
+            feature: "MYFEAT",
+            element_list: &elements,
+            ..Default::default()
+        };
+        let modified = add_feature(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &value["G2_CONFIG"];
+
+        let ftype = &g2["CFG_FTYPE"][0];
+        assert_all_keys(ftype, &FTYPE_KEYS);
+        assert_eq!(ftype["FTYPE_CODE"], json!("MYFEAT"));
+        assert_eq!(ftype["FTYPE_FREQ"], json!("FM")); // default behavior
+        assert_eq!(ftype["PERSIST_HISTORY"], json!("Yes")); // default history
+        assert_eq!(ftype["VERSION"], json!(1));
+        assert_eq!(ftype["RTYPE_ID"], json!(0));
+
+        // A new element was created for MYELEM.
+        let felem = &g2["CFG_FELEM"][0];
+        assert_all_keys(felem, &FELEM_KEYS);
+        assert_eq!(felem["FELEM_CODE"], json!("MYELEM"));
+        assert_eq!(felem["DATA_TYPE"], json!("string"));
+        // CFG_FELEM has no TOKENIZE column in the Senzing v4 schema.
+        assert!(
+            !felem.as_object().unwrap().contains_key("TOKENIZE"),
+            "CFG_FELEM must not carry a TOKENIZE key"
+        );
+
+        // FBOM row: DISPLAY_DELIM present as null (not supplied).
+        let fbom = &g2["CFG_FBOM"][0];
+        assert_all_keys(fbom, &FBOM_KEYS);
+        assert_eq!(fbom["DISPLAY_DELIM"], Value::Null);
+        assert_eq!(fbom["EXEC_ORDER"], json!(1));
+        assert_eq!(fbom["DISPLAY_LEVEL"], json!(1));
+        assert_eq!(fbom["DERIVED"], json!("No"));
+    }
+
+    /// add_feature with standardize/expression/comparison functions must write
+    /// complete CFG_SFCALL, CFG_EFCALL, CFG_CFCALL, CFG_EFBOM and CFG_CFBOM rows.
+    /// CFG_CFCALL has no EXEC_ORDER column in the Senzing v4 schema.
+    #[test]
+    fn test_add_feature_calls_emit_all_keys() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [],
+            "CFG_FCLASS": [{"FCLASS_ID": 1, "FCLASS_CODE": "OTHER"}],
+            "CFG_FELEM": [],
+            "CFG_FBOM": [],
+            "CFG_SFCALL": [],
+            "CFG_EFCALL": [],
+            "CFG_CFCALL": [],
+            "CFG_EFBOM": [],
+            "CFG_CFBOM": [],
+            "CFG_SFUNC": [{"SFUNC_ID": 1, "SFUNC_CODE": "MYSTD"}],
+            "CFG_EFUNC": [{"EFUNC_ID": 1, "EFUNC_CODE": "MYEXP"}],
+            "CFG_CFUNC": [{"CFUNC_ID": 1, "CFUNC_CODE": "MYCMP"}]
+        }}"#;
+
+        let elements = json!([{"element": "MYELEM", "expressed": "Yes", "compared": "Yes"}]);
+        let params = AddFeatureParams {
+            feature: "MYFEAT",
+            element_list: &elements,
+            standardize: Some("MYSTD"),
+            expression: Some("MYEXP"),
+            comparison: Some("MYCMP"),
+            ..Default::default()
+        };
+        let modified = add_feature(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &value["G2_CONFIG"];
+
+        assert_all_keys(
+            &g2["CFG_SFCALL"][0],
+            &[
+                "SFCALL_ID",
+                "SFUNC_ID",
+                "EXEC_ORDER",
+                "FTYPE_ID",
+                "FELEM_ID",
+            ],
+        );
+        assert_all_keys(
+            &g2["CFG_EFCALL"][0],
+            &[
+                "EFCALL_ID",
+                "EFUNC_ID",
+                "EXEC_ORDER",
+                "FTYPE_ID",
+                "FELEM_ID",
+                "EFEAT_FTYPE_ID",
+                "IS_VIRTUAL",
+            ],
+        );
+
+        // CFG_CFCALL has no EXEC_ORDER column in the schema.
+        let cfcall = &g2["CFG_CFCALL"][0];
+        assert_all_keys(cfcall, &["CFCALL_ID", "CFUNC_ID", "FTYPE_ID"]);
+        assert!(
+            !cfcall.as_object().unwrap().contains_key("EXEC_ORDER"),
+            "CFG_CFCALL must NOT carry EXEC_ORDER"
+        );
+
+        assert_all_keys(
+            &g2["CFG_EFBOM"][0],
+            &[
+                "EFCALL_ID",
+                "EXEC_ORDER",
+                "FTYPE_ID",
+                "FELEM_ID",
+                "FELEM_REQ",
+            ],
+        );
+        assert_all_keys(
+            &g2["CFG_CFBOM"][0],
+            &["CFCALL_ID", "EXEC_ORDER", "FTYPE_ID", "FELEM_ID"],
+        );
+    }
+
+    /// add_feature_comparison must write a complete CFG_FBOM row with all keys
+    /// present as null when the optional params are not supplied.
+    #[test]
+    fn test_add_feature_comparison_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "PERSON"}],
+            "CFG_FELEM": [{"FELEM_ID": 5, "FELEM_CODE": "MYELEM"}],
+            "CFG_FBOM": []
+        }}"#;
+
+        let params = AddFeatureComparisonParams::new("PERSON", "MYELEM");
+        let modified = add_feature_comparison(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let fbom = &value["G2_CONFIG"]["CFG_FBOM"][0];
+
+        assert_all_keys(fbom, &FBOM_KEYS);
+        assert_eq!(fbom["FTYPE_ID"], json!(1));
+        assert_eq!(fbom["FELEM_ID"], json!(5));
+        // Optionals not supplied -> present as null.
+        assert_eq!(fbom["EXEC_ORDER"], Value::Null);
+        assert_eq!(fbom["DISPLAY_LEVEL"], Value::Null);
+        assert_eq!(fbom["DISPLAY_DELIM"], Value::Null);
+        assert_eq!(fbom["DERIVED"], Value::Null);
+    }
+
+    /// add_feature_distinct_call_element must write a CFG_DFCALL row with exactly
+    /// the three authoritative columns: DFCALL_ID, FTYPE_ID, DFUNC_ID. FELEM_ID
+    /// and EXEC_ORDER belong to CFG_DFBOM, not the DFCALL header row.
+    #[test]
+    fn test_add_feature_distinct_call_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "PERSON"}],
+            "CFG_DFUNC": [{"DFUNC_ID": 2, "DFUNC_CODE": "MYDIST"}],
+            "CFG_DFCALL": []
+        }}"#;
+
+        let params = AddFeatureDistinctCallElementParams::new("PERSON", "MYDIST");
+        let modified = add_feature_distinct_call_element(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dfcall = &value["G2_CONFIG"]["CFG_DFCALL"][0];
+
+        assert_all_keys(dfcall, &["DFCALL_ID", "FTYPE_ID", "DFUNC_ID"]);
+        assert_eq!(
+            dfcall.as_object().unwrap().len(),
+            3,
+            "DFCALL is exactly 3 columns"
+        );
+        assert_eq!(dfcall["FTYPE_ID"], json!(1));
+        assert_eq!(dfcall["DFUNC_ID"], json!(2));
+        assert!(!dfcall.as_object().unwrap().contains_key("FELEM_ID"));
+        assert!(!dfcall.as_object().unwrap().contains_key("EXEC_ORDER"));
+    }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5943,10 +5943,6 @@ pub extern "C" fn SzConfigTool_addElement(
             .get("dataType")
             .and_then(|v| v.as_str())
             .or_else(|| element_config.get("DATA_TYPE").and_then(|v| v.as_str())),
-        tokenized: element_config
-            .get("tokenized")
-            .and_then(|v| v.as_str())
-            .or_else(|| element_config.get("TOKENIZED").and_then(|v| v.as_str())),
     };
 
     handle_result!(crate::elements::add_element(config, params))
@@ -6090,10 +6086,6 @@ pub extern "C" fn SzConfigTool_setElement(
             .get("dataType")
             .and_then(|v| v.as_str())
             .or_else(|| updates_config.get("DATA_TYPE").and_then(|v| v.as_str())),
-        tokenized: updates_config
-            .get("tokenized")
-            .and_then(|v| v.as_str())
-            .or_else(|| updates_config.get("TOKENIZED").and_then(|v| v.as_str())),
     };
 
     handle_result!(crate::elements::set_element(config, params))
@@ -7956,6 +7948,7 @@ pub extern "C" fn SzConfigTool_addDistinctFunction(
             connect_str: connect,
             description: desc_opt,
             language: lang_opt,
+            anon_support: None,
         },
     ) {
         Ok((modified_config, _record)) => match CString::new(modified_config) {
@@ -8307,6 +8300,7 @@ pub extern "C" fn SzConfigTool_setDistinctFunction(
             connect_str: connect_opt,
             description: desc_opt,
             language: lang_opt,
+            anon_support: None,
         },
     ) {
         Ok((modified_config, _record)) => match CString::new(modified_config) {

--- a/src/fragments.rs
+++ b/src/fragments.rs
@@ -5,7 +5,28 @@
 
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+/// Complete CFG_ERFRAG row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted (optional fields serialize as JSON `null`). The Senzing engine's
+/// config loader requires every key to be present, so partial rows must never
+/// be written.
+#[derive(Debug, Clone, Serialize)]
+struct ErfragRow {
+    #[serde(rename = "ERFRAG_ID")]
+    erfrag_id: i64,
+    #[serde(rename = "ERFRAG_CODE")]
+    erfrag_code: String,
+    #[serde(rename = "ERFRAG_DESC")]
+    erfrag_desc: Option<String>,
+    #[serde(rename = "ERFRAG_SOURCE")]
+    erfrag_source: Option<String>,
+    #[serde(rename = "ERFRAG_DEPENDS")]
+    erfrag_depends: Option<String>,
+}
 
 /// Validates a fragment source XPath expression and computes dependencies
 ///
@@ -210,23 +231,20 @@ pub fn add_fragment(config_json: &str, fragment_config: &Value) -> Result<(Strin
         ));
     };
 
-    // Create new item with provided config plus ID and computed dependencies
-    let mut new_item = fragment_config.clone();
-    if let Some(obj) = new_item.as_object_mut() {
-        obj.insert("ERFRAG_ID".to_string(), json!(next_id));
-        obj.insert("ERFRAG_CODE".to_string(), json!(code.to_uppercase()));
-        obj.insert("ERFRAG_DESC".to_string(), json!(code.to_uppercase()));
-
-        // Set ERFRAG_DEPENDS to comma-separated list or null
-        if dependency_list.is_empty() {
-            obj.insert("ERFRAG_DEPENDS".to_string(), Value::Null);
+    // Build a complete row via ErfragRow so every CFG_ERFRAG key is present
+    // (optional fields serialize as null).
+    let row = ErfragRow {
+        erfrag_id: next_id,
+        erfrag_code: code_upper.clone(),
+        erfrag_desc: Some(code_upper.clone()),
+        erfrag_source: Some(source.to_string()),
+        erfrag_depends: if dependency_list.is_empty() {
+            None
         } else {
-            obj.insert(
-                "ERFRAG_DEPENDS".to_string(),
-                json!(dependency_list.join(",")),
-            );
-        }
-    }
+            Some(dependency_list.join(","))
+        },
+    };
+    let new_item = serde_json::to_value(&row)?;
 
     // Add to config
     let modified_json = helpers::add_to_config_array(config_json, "CFG_ERFRAG", new_item)?;
@@ -385,9 +403,20 @@ pub fn set_fragment(
 ) -> Result<String> {
     let code = fragment_code.to_uppercase();
 
-    // Validate and compute dependencies if SOURCE is being updated
-    let mut updated_item = fragment_config.clone();
-    if let Some(new_source) = fragment_config
+    // Fetch the existing row so fields not part of the update (ERFRAG_ID,
+    // ERFRAG_DESC, and — when SOURCE is unchanged — ERFRAG_SOURCE/ERFRAG_DEPENDS)
+    // are carried forward rather than dropped by the full-row replace.
+    let existing = helpers::find_in_config_array(config_json, "CFG_ERFRAG", "ERFRAG_CODE", &code)?
+        .ok_or_else(|| SzConfigError::NotFound(format!("Fragment not found: {code}")))?;
+
+    let erfrag_id = existing
+        .get("ERFRAG_ID")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    // If SOURCE is being updated, validate it and recompute ERFRAG_DEPENDS;
+    // otherwise keep the existing SOURCE and DEPENDS.
+    let (erfrag_source, erfrag_depends) = if let Some(new_source) = fragment_config
         .get("ERFRAG_SOURCE")
         .and_then(|v| v.as_str())
     {
@@ -395,24 +424,31 @@ pub fn set_fragment(
         if !error_message.is_empty() {
             return Err(SzConfigError::InvalidInput(error_message));
         }
+        let depends = if dependency_list.is_empty() {
+            None
+        } else {
+            Some(dependency_list.join(","))
+        };
+        (Some(new_source.to_string()), depends)
+    } else {
+        (
+            helpers::field_as_string(&existing, "ERFRAG_SOURCE"),
+            helpers::field_as_string(&existing, "ERFRAG_DEPENDS"),
+        )
+    };
 
-        // Update ERFRAG_DEPENDS in the update
-        if let Some(obj) = updated_item.as_object_mut() {
-            if dependency_list.is_empty() {
-                obj.insert("ERFRAG_DEPENDS".to_string(), Value::Null);
-            } else {
-                obj.insert(
-                    "ERFRAG_DEPENDS".to_string(),
-                    json!(dependency_list.join(",")),
-                );
-            }
-        }
-    }
+    // ERFRAG_DESC from the update if supplied, else preserve existing.
+    let erfrag_desc = helpers::field_as_string(fragment_config, "ERFRAG_DESC")
+        .or_else(|| helpers::field_as_string(&existing, "ERFRAG_DESC"));
 
-    // Ensure the code field matches
-    if let Some(obj) = updated_item.as_object_mut() {
-        obj.insert("ERFRAG_CODE".to_string(), json!(code.clone()));
-    }
+    let row = ErfragRow {
+        erfrag_id,
+        erfrag_code: code.clone(),
+        erfrag_desc,
+        erfrag_source,
+        erfrag_depends,
+    };
+    let updated_item = serde_json::to_value(&row)?;
 
     // Update the item in the config
     helpers::update_in_config_array(
@@ -422,4 +458,80 @@ pub fn set_fragment(
         &code,
         updated_item,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ERFRAG_KEYS: [&str; 5] = [
+        "ERFRAG_ID",
+        "ERFRAG_CODE",
+        "ERFRAG_DESC",
+        "ERFRAG_SOURCE",
+        "ERFRAG_DEPENDS",
+    ];
+
+    fn assert_all_keys(rule: &Value) {
+        let obj = rule.as_object().unwrap();
+        for key in ERFRAG_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+    }
+
+    #[test]
+    fn test_add_fragment_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": []}}"#;
+        let frag_config = json!({"ERFRAG_CODE": "custom_frag", "ERFRAG_SOURCE": "NAME+DOB"});
+
+        let (modified, _id) = add_fragment(config, &frag_config).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
+
+        assert_all_keys(frag);
+        assert_eq!(frag["ERFRAG_CODE"], json!("CUSTOM_FRAG"));
+        assert_eq!(frag["ERFRAG_SOURCE"], json!("NAME+DOB"));
+        // No FRAGMENT[...] references -> no dependencies -> null (present).
+        assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null);
+    }
+
+    /// Regression: updating one field must not drop the row's other keys.
+    /// Previously set_fragment replaced the whole row with the partial update,
+    /// discarding ERFRAG_ID / ERFRAG_DESC and leaving the engine loader with an
+    /// incomplete CFG_ERFRAG row.
+    #[test]
+    fn test_set_fragment_preserves_unupdated_fields() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+            {"ERFRAG_ID": 7, "ERFRAG_CODE": "TEST", "ERFRAG_DESC": "TEST",
+             "ERFRAG_SOURCE": "NAME+DOB", "ERFRAG_DEPENDS": null}
+        ]}}"#;
+
+        // Update only the description; SOURCE is not part of the update.
+        let update = json!({"ERFRAG_DESC": "Updated desc"});
+        let modified = set_fragment(config, "TEST", &update).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
+
+        assert_all_keys(frag);
+        assert_eq!(frag["ERFRAG_ID"], json!(7)); // preserved, not dropped
+        assert_eq!(frag["ERFRAG_DESC"], json!("Updated desc"));
+        assert_eq!(frag["ERFRAG_SOURCE"], json!("NAME+DOB")); // preserved
+        assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null); // preserved (present)
+    }
+
+    #[test]
+    fn test_set_fragment_all_keys_present_on_source_update() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+            {"ERFRAG_ID": 1, "ERFRAG_CODE": "TEST"}
+        ]}}"#;
+
+        let update = json!({"ERFRAG_SOURCE": "NAME+DOB"});
+        let modified = set_fragment(config, "TEST", &update).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
+
+        assert_all_keys(frag);
+        assert_eq!(frag["ERFRAG_ID"], json!(1));
+        assert_eq!(frag["ERFRAG_SOURCE"], json!("NAME+DOB"));
+    }
 }

--- a/src/functions/comparison.rs
+++ b/src/functions/comparison.rs
@@ -1,13 +1,41 @@
 //! Comparison function operations for Senzing configuration
 //!
 //! This module provides functions for managing comparison functions (CFG_CFUNC)
-//! and comparison function return codes (CFG_CFRTN) in the Senzing configuration JSON.
+//! in the Senzing configuration JSON. CFG_CFRTN (comparison function return
+//! codes / score rows) is owned by `thresholds.rs`.
 
 use crate::error::SzConfigError;
 use crate::helpers::{
     add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
 };
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_CFUNC row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted (optional fields serialize as JSON `null`). The Senzing engine's
+/// config loader requires every key to be present, so partial rows must never
+/// be written.
+#[derive(Debug, Clone, Serialize)]
+struct CfuncRow {
+    #[serde(rename = "CFUNC_ID")]
+    cfunc_id: i64,
+    #[serde(rename = "CFUNC_CODE")]
+    cfunc_code: String,
+    #[serde(rename = "CONNECT_STR")]
+    connect_str: String,
+    #[serde(rename = "ANON_SUPPORT")]
+    anon_support: String,
+    #[serde(rename = "CFUNC_DESC")]
+    cfunc_desc: Option<String>,
+    #[serde(rename = "LANGUAGE")]
+    language: Option<String>,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -94,23 +122,17 @@ pub fn add_comparison_function(
         serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
     let cfunc_id = get_next_id(&config_data, "G2_CONFIG.CFG_CFUNC", "CFUNC_ID", 1)?;
 
-    // Create new function record
-    let mut new_record = json!({
-        "CFUNC_ID": cfunc_id,
-        "CFUNC_CODE": cfunc_code,
-        "CONNECT_STR": params.connect_str,
-        "ANON_SUPPORT": anon_support,
-    });
-
-    // Add optional fields (always present, null when not specified)
-    new_record["CFUNC_DESC"] = match params.description {
-        Some(desc) => json!(desc),
-        None => Value::Null,
+    // Build a complete row via CfuncRow so every CFG_CFUNC key is present
+    // (optional fields serialize as null) regardless of what the caller passed.
+    let row = CfuncRow {
+        cfunc_id,
+        cfunc_code,
+        connect_str: params.connect_str.to_string(),
+        anon_support: anon_support.to_string(),
+        cfunc_desc: params.description.map(str::to_string),
+        language: params.language.map(str::to_string),
     };
-    new_record["LANGUAGE"] = match params.language {
-        Some(lang) => json!(lang),
-        None => Value::Null,
-    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_CFUNC
     let modified_json = add_to_config_array(config_json, "CFG_CFUNC", new_record.clone())?;
@@ -232,6 +254,7 @@ pub fn set_comparison_function(
         SzConfigError::not_found(format!("Comparison function not found: {cfunc_code}"))
     })?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
         if let Some(conn) = params.connect_str {
@@ -253,78 +276,6 @@ pub fn set_comparison_function(
     let modified_json = add_to_config_array(&temp_json, "CFG_CFUNC", function.clone())?;
 
     Ok((modified_json, function))
-}
-
-/// Add a comparison function return code
-///
-/// # Arguments
-/// * `config_json` - The configuration JSON string
-/// * `cfunc_code` - Function code (will be uppercased)
-/// * `cfrtn_code` - Return code (will be uppercased)
-/// * `cfrtn_desc` - Optional description
-///
-/// # Returns
-/// Result with modified JSON string and the new return code record
-///
-/// # Errors
-/// Returns error if function not found, return code exists, or JSON is invalid
-pub fn add_comparison_func_return_code(
-    config_json: &str,
-    cfunc_code: &str,
-    cfrtn_code: &str,
-    cfrtn_desc: Option<&str>,
-) -> Result<(String, Value), SzConfigError> {
-    let cfunc_code = cfunc_code.to_uppercase();
-    let cfrtn_code = cfrtn_code.to_uppercase();
-
-    // Find the function
-    let config_data: Value =
-        serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
-
-    let cfunc = find_in_config_array(config_json, "CFG_CFUNC", "CFUNC_CODE", &cfunc_code)?
-        .ok_or_else(|| {
-            SzConfigError::not_found(format!("Comparison function not found: {cfunc_code}"))
-        })?;
-
-    let cfunc_id = cfunc
-        .get("CFUNC_ID")
-        .and_then(|v| v.as_i64())
-        .ok_or_else(|| SzConfigError::validation("CFUNC_ID not found"))?;
-
-    // Check if return code already exists for this function
-    if let Some(g2_config) = config_data.get("G2_CONFIG")
-        && let Some(array) = g2_config.get("CFG_CFRTN")
-        && let Some(items) = array.as_array()
-        && items.iter().any(|item| {
-            item.get("CFUNC_ID").and_then(|v| v.as_i64()) == Some(cfunc_id)
-                && item.get("CFRTN_CODE").and_then(|v| v.as_str()) == Some(&cfrtn_code)
-        })
-    {
-        return Err(SzConfigError::validation(format!(
-            "Return code {cfrtn_code} already exists for function {cfunc_code}"
-        )));
-    }
-
-    // Get next CFRTN_ID
-    let cfrtn_id = get_next_id(&config_data, "G2_CONFIG.CFG_CFRTN", "CFRTN_ID", 1)?;
-
-    // Create new return code record
-    let mut new_record = json!({
-        "CFRTN_ID": cfrtn_id,
-        "CFUNC_ID": cfunc_id,
-        "CFRTN_CODE": cfrtn_code,
-    });
-
-    // Add optional description (always present, null when not specified)
-    new_record["CFRTN_DESC"] = match cfrtn_desc {
-        Some(desc) => json!(desc),
-        None => Value::Null,
-    };
-
-    // Add to CFG_CFRTN
-    let modified_json = add_to_config_array(config_json, "CFG_CFRTN", new_record.clone())?;
-
-    Ok((modified_json, new_record))
 }
 
 #[cfg(test)]
@@ -375,5 +326,44 @@ mod tests {
         let items = result.unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["function"], "CMP_NAME");
+    }
+
+    /// add_comparison_function must write a complete CFG_CFUNC row even when the
+    /// caller omits optionals — they become null, never dropped. ANON_SUPPORT
+    /// defaults to "No".
+    #[test]
+    fn test_add_comparison_function_emits_all_keys() {
+        let config = get_test_config();
+        let (modified, record) = add_comparison_function(
+            &config,
+            "custom_cmp",
+            AddComparisonFunctionParams {
+                connect_str: "g2CustomCmp",
+                description: None,
+                language: None,
+                anon_support: None,
+            },
+        )
+        .unwrap();
+
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let arr = value["G2_CONFIG"]["CFG_CFUNC"].as_array().unwrap();
+        let obj = arr.last().unwrap().as_object().unwrap();
+        for key in [
+            "CFUNC_ID",
+            "CFUNC_CODE",
+            "CONNECT_STR",
+            "ANON_SUPPORT",
+            "CFUNC_DESC",
+            "LANGUAGE",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(obj["CFUNC_CODE"], json!("CUSTOM_CMP"));
+        assert_eq!(obj["CONNECT_STR"], json!("g2CustomCmp"));
+        assert_eq!(obj["ANON_SUPPORT"], json!("No"));
+        assert_eq!(obj["CFUNC_DESC"], Value::Null);
+        assert_eq!(obj["LANGUAGE"], Value::Null);
+        assert_eq!(record["ANON_SUPPORT"], json!("No"));
     }
 }

--- a/src/functions/distinct.rs
+++ b/src/functions/distinct.rs
@@ -7,7 +7,34 @@ use crate::error::SzConfigError;
 use crate::helpers::{
     add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
 };
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_DFUNC row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted (optional fields serialize as JSON `null`). The Senzing engine's
+/// config loader requires every key to be present, so partial rows must never
+/// be written.
+#[derive(Debug, Clone, Serialize)]
+struct DfuncRow {
+    #[serde(rename = "DFUNC_ID")]
+    dfunc_id: i64,
+    #[serde(rename = "DFUNC_CODE")]
+    dfunc_code: String,
+    #[serde(rename = "DFUNC_DESC")]
+    dfunc_desc: Option<String>,
+    #[serde(rename = "CONNECT_STR")]
+    connect_str: String,
+    #[serde(rename = "ANON_SUPPORT")]
+    anon_support: String,
+    #[serde(rename = "LANGUAGE")]
+    language: Option<String>,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -19,6 +46,7 @@ pub struct AddDistinctFunctionParams<'a> {
     pub connect_str: &'a str,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
+    pub anon_support: Option<&'a str>,
 }
 
 impl<'a> TryFrom<&'a Value> for AddDistinctFunctionParams<'a> {
@@ -32,6 +60,7 @@ impl<'a> TryFrom<&'a Value> for AddDistinctFunctionParams<'a> {
                 .ok_or_else(|| SzConfigError::MissingField("connectStr".to_string()))?,
             description: json.get("description").and_then(|v| v.as_str()),
             language: json.get("language").and_then(|v| v.as_str()),
+            anon_support: json.get("anonSupport").and_then(|v| v.as_str()),
         })
     }
 }
@@ -42,6 +71,7 @@ pub struct SetDistinctFunctionParams<'a> {
     pub connect_str: Option<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
+    pub anon_support: Option<&'a str>,
 }
 
 /// Add a new distinct function
@@ -77,27 +107,39 @@ pub fn add_distinct_function(
         ));
     }
 
+    // Validate ANON_SUPPORT domain (["Yes", "No"], default "No"), mirroring
+    // add_comparison_function.
+    let anon_support = if let Some(val) = params.anon_support {
+        let val_upper = val.to_uppercase();
+        match val_upper.as_str() {
+            "YES" => "Yes",
+            "NO" => "No",
+            _ => {
+                return Err(SzConfigError::validation(format!(
+                    "Invalid ANON_SUPPORT value '{val}'. Must be 'Yes' or 'No'"
+                )));
+            }
+        }
+    } else {
+        "No"
+    };
+
     // Get next DFUNC_ID
     let config_data: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
     let dfunc_id = get_next_id(&config_data, "G2_CONFIG.CFG_DFUNC", "DFUNC_ID", 1)?;
 
-    // Create new function record
-    let mut new_record = json!({
-        "DFUNC_ID": dfunc_id,
-        "DFUNC_CODE": dfunc_code,
-        "CONNECT_STR": params.connect_str,
-    });
-
-    // Add optional fields (always present, null when not specified)
-    new_record["DFUNC_DESC"] = match params.description {
-        Some(desc) => json!(desc),
-        None => Value::Null,
+    // Build a complete row via DfuncRow so every CFG_DFUNC key is present
+    // (optional fields serialize as null) regardless of what the caller passed.
+    let row = DfuncRow {
+        dfunc_id,
+        dfunc_code,
+        dfunc_desc: params.description.map(str::to_string),
+        connect_str: params.connect_str.to_string(),
+        anon_support: anon_support.to_string(),
+        language: params.language.map(str::to_string),
     };
-    new_record["LANGUAGE"] = match params.language {
-        Some(lang) => json!(lang),
-        None => Value::Null,
-    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_DFUNC
     let modified_json = add_to_config_array(config_json, "CFG_DFUNC", new_record.clone())?;
@@ -216,6 +258,7 @@ pub fn set_distinct_function(
         SzConfigError::not_found(format!("Distinct function not found: {dfunc_code}"))
     })?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
         if let Some(conn) = params.connect_str {
@@ -226,6 +269,9 @@ pub fn set_distinct_function(
         }
         if let Some(lang) = params.language {
             obj.insert("LANGUAGE".to_string(), json!(lang));
+        }
+        if let Some(anon) = params.anon_support {
+            obj.insert("ANON_SUPPORT".to_string(), json!(anon));
         }
     }
 
@@ -266,12 +312,14 @@ mod tests {
                 connect_str: "g2CustomDist",
                 description: Some("Custom distinct"),
                 language: Some("en"),
+                anon_support: Some("Yes"),
             },
         );
         assert!(result.is_ok());
         let (modified, record) = result.unwrap();
         assert!(modified.contains("CUSTOM_DIST"));
         assert_eq!(record["DFUNC_CODE"], "CUSTOM_DIST");
+        assert_eq!(record["ANON_SUPPORT"], "Yes");
     }
 
     #[test]
@@ -282,5 +330,45 @@ mod tests {
         let items = result.unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["function"], "DIST_NAME");
+    }
+
+    /// add_distinct_function must write a complete CFG_DFUNC row even when the
+    /// caller omits optionals — they become null, never dropped. ANON_SUPPORT
+    /// defaults to "No".
+    #[test]
+    fn test_add_distinct_function_emits_all_keys() {
+        let config = get_test_config();
+        let (modified, record) = add_distinct_function(
+            &config,
+            "custom_dist",
+            AddDistinctFunctionParams {
+                connect_str: "g2CustomDist",
+                description: None,
+                language: None,
+                anon_support: None,
+            },
+        )
+        .unwrap();
+
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let arr = value["G2_CONFIG"]["CFG_DFUNC"].as_array().unwrap();
+        let obj = arr.last().unwrap().as_object().unwrap();
+        for key in [
+            "DFUNC_ID",
+            "DFUNC_CODE",
+            "DFUNC_DESC",
+            "CONNECT_STR",
+            "ANON_SUPPORT",
+            "LANGUAGE",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(obj["DFUNC_CODE"], json!("CUSTOM_DIST"));
+        assert_eq!(obj["CONNECT_STR"], json!("g2CustomDist"));
+        assert_eq!(obj["ANON_SUPPORT"], json!("No"));
+        assert_eq!(obj["DFUNC_DESC"], Value::Null);
+        assert_eq!(obj["LANGUAGE"], Value::Null);
+        assert_eq!(record["DFUNC_DESC"], Value::Null);
+        assert_eq!(record["ANON_SUPPORT"], json!("No"));
     }
 }

--- a/src/functions/expression.rs
+++ b/src/functions/expression.rs
@@ -7,7 +7,32 @@ use crate::error::SzConfigError;
 use crate::helpers::{
     add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
 };
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_EFUNC row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted (optional fields serialize as JSON `null`). The Senzing engine's
+/// config loader requires every key to be present, so partial rows must never
+/// be written.
+#[derive(Debug, Clone, Serialize)]
+struct EfuncRow {
+    #[serde(rename = "EFUNC_ID")]
+    efunc_id: i64,
+    #[serde(rename = "EFUNC_CODE")]
+    efunc_code: String,
+    #[serde(rename = "CONNECT_STR")]
+    connect_str: String,
+    #[serde(rename = "EFUNC_DESC")]
+    efunc_desc: Option<String>,
+    #[serde(rename = "LANGUAGE")]
+    language: Option<String>,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -75,22 +100,16 @@ pub fn add_expression_function(
         serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
     let efunc_id = get_next_id(&config_data, "G2_CONFIG.CFG_EFUNC", "EFUNC_ID", 1)?;
 
-    // Create new function record
-    let mut new_record = json!({
-        "EFUNC_ID": efunc_id,
-        "EFUNC_CODE": efunc_code,
-        "CONNECT_STR": params.connect_str,
-    });
-
-    // Add optional fields (always present, null when not specified)
-    new_record["EFUNC_DESC"] = match params.description {
-        Some(desc) => json!(desc),
-        None => Value::Null,
+    // Build a complete row via EfuncRow so every CFG_EFUNC key is present
+    // (optional fields serialize as null) regardless of what the caller passed.
+    let row = EfuncRow {
+        efunc_id,
+        efunc_code,
+        connect_str: params.connect_str.to_string(),
+        efunc_desc: params.description.map(str::to_string),
+        language: params.language.map(str::to_string),
     };
-    new_record["LANGUAGE"] = match params.language {
-        Some(lang) => json!(lang),
-        None => Value::Null,
-    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_EFUNC
     let modified_json = add_to_config_array(config_json, "CFG_EFUNC", new_record.clone())?;
@@ -211,6 +230,7 @@ pub fn set_expression_function(
         SzConfigError::not_found(format!("Expression function not found: {efunc_code}"))
     })?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
         if let Some(conn) = params.connect_str {
@@ -277,5 +297,41 @@ mod tests {
         let items = result.unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["function"], "EXPR_FEAT");
+    }
+
+    /// add_expression_function must write a complete CFG_EFUNC row even when the
+    /// caller omits optionals — they become null, never dropped.
+    #[test]
+    fn test_add_expression_function_emits_all_keys() {
+        let config = get_test_config();
+        let (modified, record) = add_expression_function(
+            &config,
+            "custom_expr",
+            AddExpressionFunctionParams {
+                connect_str: "g2CustomExpr",
+                description: None,
+                language: None,
+            },
+        )
+        .unwrap();
+
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let arr = value["G2_CONFIG"]["CFG_EFUNC"].as_array().unwrap();
+        let obj = arr.last().unwrap().as_object().unwrap();
+        for key in [
+            "EFUNC_ID",
+            "EFUNC_CODE",
+            "CONNECT_STR",
+            "EFUNC_DESC",
+            "LANGUAGE",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(obj["EFUNC_CODE"], json!("CUSTOM_EXPR"));
+        assert_eq!(obj["CONNECT_STR"], json!("g2CustomExpr"));
+        assert_eq!(obj["EFUNC_DESC"], Value::Null);
+        assert_eq!(obj["LANGUAGE"], Value::Null);
+        // Returned record mirrors the written row.
+        assert_eq!(record["EFUNC_DESC"], Value::Null);
     }
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -4,7 +4,7 @@
 //! Senzing configuration JSON, including:
 //! - Standardize functions (CFG_SFUNC)
 //! - Expression functions (CFG_EFUNC)
-//! - Comparison functions (CFG_CFUNC) and return codes (CFG_CFRTN)
+//! - Comparison functions (CFG_CFUNC)
 //! - Distinct functions (CFG_DFUNC)
 //! - Matching functions (CFG_RTYPE - placeholder)
 //! - Scoring functions (CFG_RTYPE - placeholder)
@@ -32,8 +32,8 @@ pub use expression::{
 };
 
 pub use comparison::{
-    add_comparison_func_return_code, add_comparison_function, delete_comparison_function,
-    get_comparison_function, list_comparison_functions, set_comparison_function,
+    add_comparison_function, delete_comparison_function, get_comparison_function,
+    list_comparison_functions, set_comparison_function,
 };
 
 pub use distinct::{

--- a/src/functions/standardize.rs
+++ b/src/functions/standardize.rs
@@ -7,7 +7,32 @@ use crate::error::SzConfigError;
 use crate::helpers::{
     add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
 };
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_SFUNC row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted (optional fields serialize as JSON `null`). The Senzing engine's
+/// config loader requires every key to be present, so partial rows must never
+/// be written.
+#[derive(Debug, Clone, Serialize)]
+struct SfuncRow {
+    #[serde(rename = "SFUNC_ID")]
+    sfunc_id: i64,
+    #[serde(rename = "SFUNC_CODE")]
+    sfunc_code: String,
+    #[serde(rename = "CONNECT_STR")]
+    connect_str: String,
+    #[serde(rename = "SFUNC_DESC")]
+    sfunc_desc: Option<String>,
+    #[serde(rename = "LANGUAGE")]
+    language: Option<String>,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -75,22 +100,16 @@ pub fn add_standardize_function(
         serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
     let sfunc_id = get_next_id(&config_data, "G2_CONFIG.CFG_SFUNC", "SFUNC_ID", 1)?;
 
-    // Create new function record
-    let mut new_record = json!({
-        "SFUNC_ID": sfunc_id,
-        "SFUNC_CODE": sfunc_code,
-        "CONNECT_STR": params.connect_str,
-    });
-
-    // Add optional fields (always present, null when not specified)
-    new_record["SFUNC_DESC"] = match params.description {
-        Some(desc) => json!(desc),
-        None => Value::Null,
+    // Build a complete row via SfuncRow so every CFG_SFUNC key is present
+    // (optional fields serialize as null) regardless of what the caller passed.
+    let row = SfuncRow {
+        sfunc_id,
+        sfunc_code,
+        connect_str: params.connect_str.to_string(),
+        sfunc_desc: params.description.map(str::to_string),
+        language: params.language.map(str::to_string),
     };
-    new_record["LANGUAGE"] = match params.language {
-        Some(lang) => json!(lang),
-        None => Value::Null,
-    };
+    let new_record = serde_json::to_value(&row)?;
 
     // Add to CFG_SFUNC
     let modified_json = add_to_config_array(config_json, "CFG_SFUNC", new_record.clone())?;
@@ -211,6 +230,7 @@ pub fn set_standardize_function(
         SzConfigError::not_found(format!("Standardize function not found: {sfunc_code}"))
     })?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
         if let Some(conn) = params.connect_str {
@@ -295,5 +315,40 @@ mod tests {
         assert!(result.is_ok());
         let (modified, _) = result.unwrap();
         assert!(!modified.contains("PARSE_NAME"));
+    }
+
+    /// add_standardize_function must write a complete CFG_SFUNC row even when the
+    /// caller omits optionals — they become null, never dropped.
+    #[test]
+    fn test_add_standardize_function_emits_all_keys() {
+        let config = get_test_config();
+        let (modified, record) = add_standardize_function(
+            &config,
+            "custom_parse",
+            AddStandardizeFunctionParams {
+                connect_str: "g2CustomParse",
+                description: None,
+                language: None,
+            },
+        )
+        .unwrap();
+
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let arr = value["G2_CONFIG"]["CFG_SFUNC"].as_array().unwrap();
+        let obj = arr.last().unwrap().as_object().unwrap();
+        for key in [
+            "SFUNC_ID",
+            "SFUNC_CODE",
+            "CONNECT_STR",
+            "SFUNC_DESC",
+            "LANGUAGE",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(obj["SFUNC_CODE"], json!("CUSTOM_PARSE"));
+        assert_eq!(obj["CONNECT_STR"], json!("g2CustomParse"));
+        assert_eq!(obj["SFUNC_DESC"], Value::Null);
+        assert_eq!(obj["LANGUAGE"], Value::Null);
+        assert_eq!(record["SFUNC_DESC"], Value::Null);
     }
 }

--- a/src/generic_plans.rs
+++ b/src/generic_plans.rs
@@ -5,7 +5,28 @@
 
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_GPLAN row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted. The Senzing engine's config loader requires every key to be
+/// present, so partial rows must never be written. All three CFG_GPLAN fields
+/// are always populated by the builders, so none are optional.
+#[derive(Debug, Clone, Serialize)]
+struct GplanRow {
+    #[serde(rename = "GPLAN_ID")]
+    gplan_id: i64,
+    #[serde(rename = "GPLAN_CODE")]
+    gplan_code: String,
+    #[serde(rename = "GPLAN_DESC")]
+    gplan_desc: String,
+}
 
 /// Clone a generic plan with all its thresholds
 ///
@@ -75,12 +96,13 @@ pub fn clone_generic_plan(
 
     let new_gplan_id = max_gplan_id + 1;
 
-    // Create new plan
-    let new_plan = json!({
-        "GPLAN_ID": new_gplan_id,
-        "GPLAN_CODE": new_code,
-        "GPLAN_DESC": new_desc
-    });
+    // Build a complete row via GplanRow so every CFG_GPLAN key is present.
+    let row = GplanRow {
+        gplan_id: new_gplan_id,
+        gplan_code: new_code.clone(),
+        gplan_desc: new_desc.to_string(),
+    };
+    let new_plan = serde_json::to_value(&row)?;
 
     let mut modified_json = helpers::add_to_config_array(config_json, "CFG_GPLAN", new_plan)?;
 
@@ -265,6 +287,11 @@ pub fn set_generic_plan(
             .get("GPLAN_ID")
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
+        // In-place update of a complete existing row; all keys preserved.
+        // Clones the full existing record and overwrites only GPLAN_DESC, so no
+        // key is dropped. Left as-is rather than routed through GplanRow to stay
+        // behavior-identical (a struct with a fixed field set could drop any
+        // extra key an existing record happens to carry).
         let mut updated = existing.clone();
         if let Some(obj) = updated.as_object_mut() {
             obj.insert("GPLAN_DESC".to_string(), json!(gplan_desc));
@@ -293,13 +320,75 @@ pub fn set_generic_plan(
             .unwrap_or(0);
 
         let new_id = max_id + 1;
-        let new_plan = json!({
-            "GPLAN_ID": new_id,
-            "GPLAN_CODE": code,
-            "GPLAN_DESC": gplan_desc
-        });
+        // Build a complete row via GplanRow so every CFG_GPLAN key is present.
+        let row = GplanRow {
+            gplan_id: new_id,
+            gplan_code: code.clone(),
+            gplan_desc: gplan_desc.to_string(),
+        };
+        let new_plan = serde_json::to_value(&row)?;
 
         let modified = helpers::add_to_config_array(config_json, "CFG_GPLAN", new_plan)?;
         Ok((modified, new_id, true))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GPLAN_KEYS: [&str; 3] = ["GPLAN_ID", "GPLAN_CODE", "GPLAN_DESC"];
+
+    fn assert_all_keys(plan: &Value) {
+        let obj = plan.as_object().unwrap();
+        for key in GPLAN_KEYS {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+    }
+
+    #[test]
+    fn test_clone_generic_plan_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST", "GPLAN_DESC": "Ingest"}], "CFG_GENERIC_THRESHOLD": []}}"#;
+        let (modified, _id) = clone_generic_plan(config, "INGEST", "CUSTOM", None).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let plans = value["G2_CONFIG"]["CFG_GPLAN"].as_array().unwrap();
+        let new_plan = plans
+            .iter()
+            .find(|p| p["GPLAN_CODE"].as_str() == Some("CUSTOM"))
+            .unwrap();
+
+        assert_all_keys(new_plan);
+        assert_eq!(new_plan["GPLAN_CODE"], json!("CUSTOM"));
+        // Description defaults to the (uppercased) new code when None supplied.
+        assert_eq!(new_plan["GPLAN_DESC"], json!("CUSTOM"));
+    }
+
+    #[test]
+    fn test_set_generic_plan_create_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_GPLAN": []}}"#;
+        let (modified, _id, was_created) =
+            set_generic_plan(config, "CUSTOM", "Custom Plan").unwrap();
+        assert!(was_created);
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let plan = &value["G2_CONFIG"]["CFG_GPLAN"][0];
+
+        assert_all_keys(plan);
+        assert_eq!(plan["GPLAN_CODE"], json!("CUSTOM"));
+        assert_eq!(plan["GPLAN_DESC"], json!("Custom Plan"));
+    }
+
+    #[test]
+    fn test_set_generic_plan_update_preserves_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_GPLAN": [{"GPLAN_ID": 3, "GPLAN_CODE": "CUSTOM", "GPLAN_DESC": "Old"}]}}"#;
+        let (modified, plan_id, was_created) =
+            set_generic_plan(config, "CUSTOM", "New Desc").unwrap();
+        assert!(!was_created);
+        assert_eq!(plan_id, 3);
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let plan = &value["G2_CONFIG"]["CFG_GPLAN"][0];
+
+        assert_all_keys(plan);
+        assert_eq!(plan["GPLAN_ID"], json!(3));
+        assert_eq!(plan["GPLAN_DESC"], json!("New Desc"));
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,15 @@
 use crate::error::{Result, SzConfigError};
 use serde_json::Value;
 
+/// Extract a string field from a config row as an owned `Option<String>`.
+///
+/// Returns `None` when the key is absent or its value is not a JSON string
+/// (including explicit `null`). Used by row builders to carry an existing
+/// field value forward when an update does not supply a new one.
+pub(crate) fn field_as_string(item: &Value, key: &str) -> Option<String> {
+    item.get(key).and_then(|v| v.as_str()).map(String::from)
+}
+
 /// Get the next available ID for a config array
 ///
 /// Finds the maximum value of the specified ID field and returns max + 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@
 pub mod error;
 pub mod helpers;
 
+// Shared crate-internal row structs (one per CFG_* section).
+pub(crate) mod config_rows;
+
 // Core entity modules
 pub mod attributes;
 pub mod behavior_overrides;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -5,7 +5,66 @@
 
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_ERRULE row.
+///
+/// This struct is the single source of truth for the on-disk shape of a rule.
+/// It derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted — optional fields serialize as JSON `null` rather than being dropped.
+/// The Senzing engine's config loader requires every key to be present (a
+/// missing key yields SENZ9117), so partial rows must never be written.
+#[derive(Debug, Clone, Serialize)]
+struct ErruleRow {
+    #[serde(rename = "ERRULE_ID")]
+    errule_id: i64,
+    #[serde(rename = "ERRULE_CODE")]
+    errule_code: String,
+    #[serde(rename = "RESOLVE")]
+    resolve: String,
+    #[serde(rename = "RELATE")]
+    relate: String,
+    #[serde(rename = "RTYPE_ID")]
+    rtype_id: i64,
+    #[serde(rename = "QUAL_ERFRAG_CODE")]
+    qual_erfrag_code: Option<String>,
+    #[serde(rename = "DISQ_ERFRAG_CODE")]
+    disq_erfrag_code: Option<String>,
+    #[serde(rename = "ERRULE_TIER")]
+    errule_tier: Option<i64>,
+}
+
+impl ErruleRow {
+    /// Build a complete row from a caller-provided JSON object plus a resolved
+    /// id and code. Missing scalar fields fall back to Senzing defaults and
+    /// missing optional fields become `None` (serialized as `null`), so the
+    /// resulting row always carries every CFG_ERRULE key.
+    fn from_config(id: i64, code: String, cfg: &Value) -> Self {
+        Self {
+            errule_id: id,
+            errule_code: code,
+            resolve: cfg
+                .get("RESOLVE")
+                .and_then(|v| v.as_str())
+                .unwrap_or("No")
+                .to_string(),
+            relate: cfg
+                .get("RELATE")
+                .and_then(|v| v.as_str())
+                .unwrap_or("No")
+                .to_string(),
+            rtype_id: cfg.get("RTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(1),
+            qual_erfrag_code: helpers::field_as_string(cfg, "QUAL_ERFRAG_CODE"),
+            disq_erfrag_code: helpers::field_as_string(cfg, "DISQ_ERFRAG_CODE"),
+            errule_tier: cfg.get("ERRULE_TIER").and_then(|v| v.as_i64()),
+        }
+    }
+}
 
 // ============================================================================
 // Parameter Structs
@@ -111,12 +170,10 @@ pub fn add_rule(config_json: &str, id: i64, rule_config: &Value) -> Result<(Stri
         ));
     }
 
-    // Create new item with provided config plus ID
-    let mut new_item = rule_config.clone();
-    if let Some(obj) = new_item.as_object_mut() {
-        obj.insert("ERRULE_ID".to_string(), json!(id));
-        obj.insert("ERRULE_CODE".to_string(), json!(code.to_uppercase()));
-    }
+    // Build a complete row via ErruleRow so every CFG_ERRULE key is present
+    // (optional fields serialize as null) regardless of what the caller passed.
+    let row = ErruleRow::from_config(id, code.to_uppercase(), rule_config);
+    let new_item = serde_json::to_value(&row)?;
 
     // Add to config
     let modified_json = helpers::add_to_config_array(config_json, "CFG_ERRULE", new_item)?;
@@ -381,33 +438,29 @@ pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
-    // Build update object from params with validated values
-    let mut updated_item = json!({
-        "ERRULE_ID": errule_id,
-        "ERRULE_CODE": code.clone()
-    });
-
-    if let Some(obj) = updated_item.as_object_mut() {
-        if params.resolve.is_some() {
-            obj.insert("RESOLVE".to_string(), json!(final_resolve));
-        }
-        if params.relate.is_some() {
-            obj.insert("RELATE".to_string(), json!(final_relate));
-        }
-        // Insert RTYPE_ID if explicitly provided OR if resolve was updated (auto-correction may have occurred)
-        if params.rtype_id.is_some() || params.resolve.is_some() {
-            obj.insert("RTYPE_ID".to_string(), json!(final_rtype_id));
-        }
-        if let Some(frag) = params.fragment {
-            obj.insert("QUAL_ERFRAG_CODE".to_string(), json!(frag.to_uppercase()));
-        }
-        if let Some(disq) = params.disqualifier {
-            obj.insert("DISQ_ERFRAG_CODE".to_string(), json!(disq.to_uppercase()));
-        }
-        if let Some(tier) = params.tier {
-            obj.insert("ERRULE_TIER".to_string(), json!(tier));
-        }
-    }
+    // Build the complete row. Optional fields not supplied in `params` fall back
+    // to the existing value (which may itself be null). Because ErruleRow always
+    // serializes every key (None -> null), the resulting object can never be
+    // missing a key the engine config loader requires.
+    let row = ErruleRow {
+        errule_id,
+        errule_code: code.clone(),
+        resolve: final_resolve.to_string(),
+        relate: final_relate.to_string(),
+        rtype_id: final_rtype_id,
+        qual_erfrag_code: params
+            .fragment
+            .map(str::to_uppercase)
+            .or_else(|| helpers::field_as_string(&existing_rule, "QUAL_ERFRAG_CODE")),
+        disq_erfrag_code: params
+            .disqualifier
+            .map(str::to_uppercase)
+            .or_else(|| helpers::field_as_string(&existing_rule, "DISQ_ERFRAG_CODE")),
+        errule_tier: params
+            .tier
+            .or_else(|| existing_rule.get("ERRULE_TIER").and_then(|v| v.as_i64())),
+    };
+    let updated_item = serde_json::to_value(&row)?;
 
     // Update the item in the config
     helpers::update_in_config_array(
@@ -417,4 +470,133 @@ pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
         &code,
         updated_item,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: updating a rule must preserve all existing keys, including
+    /// null-valued ones like DISQ_ERFRAG_CODE. The engine config loader rejects
+    /// a CFG_ERRULE row missing that key (SENZ9117), so set_rule must never drop
+    /// it when the disqualifier is not part of the update.
+    #[test]
+    fn test_set_rule_preserves_null_disqualifier() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERRULE": [
+            {"ERRULE_ID": 100, "ERRULE_CODE": "SAME_A1", "RESOLVE": "Yes",
+             "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "SAME_A1",
+             "DISQ_ERFRAG_CODE": null, "ERRULE_TIER": 10}
+        ], "CFG_ERFRAG": []}}"#;
+
+        let params = SetRuleParams {
+            code: "SAME_A1",
+            resolve: Some("No"),
+            relate: None,
+            rtype_id: None,
+            fragment: None,
+            disqualifier: None,
+            tier: None,
+        };
+
+        let modified = set_rule(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let rule = &value["G2_CONFIG"]["CFG_ERRULE"][0];
+        let obj = rule.as_object().unwrap();
+
+        // Every CFG_ERRULE key must always be present, even when null.
+        for key in [
+            "ERRULE_ID",
+            "ERRULE_CODE",
+            "RESOLVE",
+            "RELATE",
+            "RTYPE_ID",
+            "QUAL_ERFRAG_CODE",
+            "DISQ_ERFRAG_CODE",
+            "ERRULE_TIER",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+
+        // The updated field applied; unprovided fields preserved (incl. null).
+        assert_eq!(rule["RESOLVE"], json!("No"));
+        assert_eq!(rule["DISQ_ERFRAG_CODE"], Value::Null);
+        assert_eq!(rule["RELATE"], json!("No"));
+        assert_eq!(rule["QUAL_ERFRAG_CODE"], json!("SAME_A1"));
+        assert_eq!(rule["ERRULE_TIER"], json!(10));
+    }
+
+    /// A brand-new-style update that provides no optional fields at all must
+    /// still emit every key (as null where nothing exists), so the engine
+    /// config loader never sees a missing CFG_ERRULE key.
+    #[test]
+    fn test_set_rule_emits_all_keys_when_optionals_absent() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERRULE": [
+            {"ERRULE_ID": 42, "ERRULE_CODE": "MINIMAL", "RESOLVE": "No"}
+        ], "CFG_ERFRAG": []}}"#;
+
+        let params = SetRuleParams {
+            code: "MINIMAL",
+            resolve: Some("Yes"),
+            relate: None,
+            rtype_id: None,
+            fragment: None,
+            disqualifier: None,
+            tier: None,
+        };
+
+        let modified = set_rule(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let obj = value["G2_CONFIG"]["CFG_ERRULE"][0].as_object().unwrap();
+
+        for key in [
+            "ERRULE_ID",
+            "ERRULE_CODE",
+            "RESOLVE",
+            "RELATE",
+            "RTYPE_ID",
+            "QUAL_ERFRAG_CODE",
+            "DISQ_ERFRAG_CODE",
+            "ERRULE_TIER",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        // Nothing existed for these optionals, so they surface as null.
+        assert_eq!(obj["QUAL_ERFRAG_CODE"], Value::Null);
+        assert_eq!(obj["DISQ_ERFRAG_CODE"], Value::Null);
+        assert_eq!(obj["ERRULE_TIER"], Value::Null);
+    }
+
+    /// add_rule must write a complete row even when the caller supplies only a
+    /// subset of fields — the omitted optionals become null, never dropped.
+    #[test]
+    fn test_add_rule_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERRULE": []}}"#;
+        let rule_config = json!({
+            "ERRULE_CODE": "custom_rule",
+            "RESOLVE": "Yes",
+            "RELATE": "No",
+            "RTYPE_ID": 1
+        });
+
+        let (modified, _id) = add_rule(config, 0, &rule_config).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let obj = value["G2_CONFIG"]["CFG_ERRULE"][0].as_object().unwrap();
+
+        for key in [
+            "ERRULE_ID",
+            "ERRULE_CODE",
+            "RESOLVE",
+            "RELATE",
+            "RTYPE_ID",
+            "QUAL_ERFRAG_CODE",
+            "DISQ_ERFRAG_CODE",
+            "ERRULE_TIER",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(obj["ERRULE_CODE"], json!("CUSTOM_RULE"));
+        assert_eq!(obj["QUAL_ERFRAG_CODE"], Value::Null);
+        assert_eq!(obj["DISQ_ERFRAG_CODE"], Value::Null);
+        assert_eq!(obj["ERRULE_TIER"], Value::Null);
+    }
 }

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -1,6 +1,64 @@
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+// ============================================================================
+// Row Structs
+// ============================================================================
+
+/// Complete CFG_CFRTN (comparison threshold) row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted — the seed-then-null fields (EXEC_ORDER and the score fields)
+/// serialize as JSON `null` when absent rather than being dropped. The Senzing
+/// engine's config loader requires every key to be present, so partial rows
+/// must never be written.
+#[derive(Debug, Clone, Serialize)]
+struct CfrtnRow {
+    #[serde(rename = "CFRTN_ID")]
+    cfrtn_id: i64,
+    #[serde(rename = "CFUNC_ID")]
+    cfunc_id: i64,
+    #[serde(rename = "FTYPE_ID")]
+    ftype_id: i64,
+    #[serde(rename = "CFUNC_RTNVAL")]
+    cfunc_rtnval: String,
+    #[serde(rename = "EXEC_ORDER")]
+    exec_order: Option<i64>,
+    #[serde(rename = "SAME_SCORE")]
+    same_score: Option<i64>,
+    #[serde(rename = "CLOSE_SCORE")]
+    close_score: Option<i64>,
+    #[serde(rename = "LIKELY_SCORE")]
+    likely_score: Option<i64>,
+    #[serde(rename = "PLAUSIBLE_SCORE")]
+    plausible_score: Option<i64>,
+    #[serde(rename = "UN_LIKELY_SCORE")]
+    un_likely_score: Option<i64>,
+}
+
+/// Complete CFG_GENERIC_THRESHOLD row.
+///
+/// Derives `Serialize` with no `skip_serializing_if`, so every key is always
+/// emitted. All fields are always populated by the builder, so none are
+/// optional. The Senzing engine's config loader requires every key to be
+/// present, so partial rows must never be written.
+#[derive(Debug, Clone, Serialize)]
+struct GenericThresholdRow {
+    #[serde(rename = "GPLAN_ID")]
+    gplan_id: i64,
+    #[serde(rename = "BEHAVIOR")]
+    behavior: String,
+    #[serde(rename = "FTYPE_ID")]
+    ftype_id: i64,
+    #[serde(rename = "CANDIDATE_CAP")]
+    candidate_cap: i64,
+    #[serde(rename = "SCORING_CAP")]
+    scoring_cap: i64,
+    #[serde(rename = "SEND_TO_REDO")]
+    send_to_redo: String,
+}
 
 // ============================================================================
 // Parameter Structs
@@ -249,38 +307,21 @@ pub fn add_comparison_threshold(
     // Get next ID
     let cfrtn_id = helpers::get_next_id_from_array(cfrtn_array, "CFRTN_ID")?;
 
-    // Build record
-    let mut record = json!({
-        "CFRTN_ID": cfrtn_id,
-        "CFUNC_ID": cfunc_id,
-        "FTYPE_ID": ftype_id,
-        "CFUNC_RTNVAL": rtnval_upper,
-    });
-
-    record["EXEC_ORDER"] = match params.exec_order {
-        Some(order) => json!(order),
-        None => Value::Null,
+    // Build a complete row via CfrtnRow so every CFG_CFRTN key is present
+    // (unset seed-then-null fields serialize as null).
+    let row = CfrtnRow {
+        cfrtn_id,
+        cfunc_id,
+        ftype_id,
+        cfunc_rtnval: rtnval_upper,
+        exec_order: params.exec_order,
+        same_score: params.same_score,
+        close_score: params.close_score,
+        likely_score: params.likely_score,
+        plausible_score: params.plausible_score,
+        un_likely_score: params.un_likely_score,
     };
-    record["SAME_SCORE"] = match params.same_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["CLOSE_SCORE"] = match params.close_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["LIKELY_SCORE"] = match params.likely_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["PLAUSIBLE_SCORE"] = match params.plausible_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["UN_LIKELY_SCORE"] = match params.un_likely_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
+    let record = serde_json::to_value(&row)?;
 
     helpers::add_to_config_array(config_json, "CFG_CFRTN", record)
 }
@@ -323,38 +364,21 @@ pub(crate) fn add_comparison_threshold_by_id(
     // Get next ID
     let cfrtn_id = crate::helpers::get_next_id_from_array(cfrtn_array, "CFRTN_ID")?;
 
-    // Build record
-    let mut record = json!({
-        "CFRTN_ID": cfrtn_id,
-        "CFUNC_ID": cfunc_id,
-        "FTYPE_ID": ftype,
-        "CFUNC_RTNVAL": rtnval_upper,
-    });
-
-    record["EXEC_ORDER"] = match exec_order {
-        Some(order) => json!(order),
-        None => Value::Null,
+    // Build a complete row via CfrtnRow so every CFG_CFRTN key is present
+    // (unset seed-then-null fields serialize as null).
+    let row = CfrtnRow {
+        cfrtn_id,
+        cfunc_id,
+        ftype_id: ftype,
+        cfunc_rtnval: rtnval_upper,
+        exec_order,
+        same_score,
+        close_score,
+        likely_score,
+        plausible_score,
+        un_likely_score,
     };
-    record["SAME_SCORE"] = match same_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["CLOSE_SCORE"] = match close_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["LIKELY_SCORE"] = match likely_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["PLAUSIBLE_SCORE"] = match plausible_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
-    record["UN_LIKELY_SCORE"] = match un_likely_score {
-        Some(score) => json!(score),
-        None => Value::Null,
-    };
+    let record = serde_json::to_value(&row)?;
 
     crate::helpers::add_to_config_array(config_json, "CFG_CFRTN", record)
 }
@@ -381,6 +405,7 @@ pub(crate) fn set_comparison_threshold_by_id(
         .find(|item| item["CFRTN_ID"].as_i64() == Some(cfrtn_id))
         .ok_or_else(|| SzConfigError::NotFound(format!("Comparison threshold ID: {cfrtn_id}")))?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields from params
     if let Some(dest_obj) = cfrtn.as_object_mut() {
         if let Some(score) = same_score {
@@ -544,6 +569,7 @@ pub fn set_comparison_threshold(
             ))
         })?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields from params
     if let Some(dest_obj) = cfrtn.as_object_mut() {
         if let Some(order) = params.exec_order {
@@ -752,15 +778,17 @@ pub fn add_generic_threshold(
         )));
     }
 
-    // Create new threshold record
-    let new_threshold = json!({
-        "GPLAN_ID": gplan_id,
-        "BEHAVIOR": behavior_upper,
-        "FTYPE_ID": ftype_id,
-        "CANDIDATE_CAP": candidate_cap,
-        "SCORING_CAP": scoring_cap,
-        "SEND_TO_REDO": redo_upper
-    });
+    // Build a complete row via GenericThresholdRow so every
+    // CFG_GENERIC_THRESHOLD key is present.
+    let row = GenericThresholdRow {
+        gplan_id,
+        behavior: behavior_upper,
+        ftype_id,
+        candidate_cap,
+        scoring_cap,
+        send_to_redo: redo_upper,
+    };
+    let new_threshold = serde_json::to_value(&row)?;
 
     if let Some(threshold_array) = config["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"].as_array_mut() {
         threshold_array.push(new_threshold);
@@ -878,6 +906,7 @@ pub fn set_generic_threshold(
             ))
         })?;
 
+    // In-place update of a complete existing row; all keys preserved.
     // Update fields from params
     if let Some(dest_obj) = gthresh.as_object_mut() {
         if let Some(feature_code) = params.feature {
@@ -993,4 +1022,113 @@ pub fn set_threshold(_config_json: &str, _params: SetThresholdParams) -> Result<
     Err(SzConfigError::InvalidInput(
         "set_threshold not yet implemented".to_string(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CFRTN_KEYS: [&str; 10] = [
+        "CFRTN_ID",
+        "CFUNC_ID",
+        "FTYPE_ID",
+        "CFUNC_RTNVAL",
+        "EXEC_ORDER",
+        "SAME_SCORE",
+        "CLOSE_SCORE",
+        "LIKELY_SCORE",
+        "PLAUSIBLE_SCORE",
+        "UN_LIKELY_SCORE",
+    ];
+
+    const GENERIC_THRESHOLD_KEYS: [&str; 6] = [
+        "GPLAN_ID",
+        "BEHAVIOR",
+        "FTYPE_ID",
+        "CANDIDATE_CAP",
+        "SCORING_CAP",
+        "SEND_TO_REDO",
+    ];
+
+    fn assert_all_keys(row: &Value, keys: &[&str]) {
+        let obj = row.as_object().unwrap();
+        for key in keys {
+            assert!(obj.contains_key(*key), "{key} key must be present");
+        }
+    }
+
+    #[test]
+    fn test_add_comparison_threshold_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_CFRTN": [],
+            "CFG_CFUNC": [{"CFUNC_ID": 5, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}]
+        }}"#;
+
+        // Only the required fields supplied; the seed-then-null fields must
+        // surface as null, never dropped.
+        let params = AddComparisonThresholdParams::new("GNR_COMP", "NAME", "FULL_SCORE");
+        let modified = add_comparison_threshold(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let row = &value["G2_CONFIG"]["CFG_CFRTN"][0];
+
+        assert_all_keys(row, &CFRTN_KEYS);
+        assert_eq!(row["CFUNC_ID"], json!(5));
+        assert_eq!(row["FTYPE_ID"], json!(3));
+        assert_eq!(row["CFUNC_RTNVAL"], json!("FULL_SCORE"));
+        assert_eq!(row["EXEC_ORDER"], Value::Null);
+        assert_eq!(row["SAME_SCORE"], Value::Null);
+        assert_eq!(row["UN_LIKELY_SCORE"], Value::Null);
+    }
+
+    #[test]
+    fn test_add_comparison_threshold_by_id_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {"CFG_CFRTN": []}}"#;
+
+        let modified = add_comparison_threshold_by_id(
+            config,
+            5,
+            Some(3),
+            "full_score",
+            Some(1),
+            Some(100),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let row = &value["G2_CONFIG"]["CFG_CFRTN"][0];
+
+        assert_all_keys(row, &CFRTN_KEYS);
+        assert_eq!(row["CFUNC_RTNVAL"], json!("FULL_SCORE")); // uppercased
+        assert_eq!(row["EXEC_ORDER"], json!(1));
+        assert_eq!(row["SAME_SCORE"], json!(100));
+        assert_eq!(row["CLOSE_SCORE"], Value::Null);
+        assert_eq!(row["PLAUSIBLE_SCORE"], Value::Null);
+    }
+
+    #[test]
+    fn test_add_generic_threshold_emits_all_keys() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+            "CFG_GENERIC_THRESHOLD": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}]
+        }}"#;
+
+        let params = AddGenericThresholdParams::new("INGEST", "NAME", 20, 10, "No");
+        let modified = add_generic_threshold(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let row = &value["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"][0];
+
+        assert_all_keys(row, &GENERIC_THRESHOLD_KEYS);
+        assert_eq!(row["GPLAN_ID"], json!(1));
+        assert_eq!(row["BEHAVIOR"], json!("NAME"));
+        // feature defaults to "ALL" -> ftype_id 0.
+        assert_eq!(row["FTYPE_ID"], json!(0));
+        assert_eq!(row["CANDIDATE_CAP"], json!(10));
+        assert_eq!(row["SCORING_CAP"], json!(20));
+        assert_eq!(row["SEND_TO_REDO"], json!("NO"));
+    }
 }

--- a/tests/fixtures/g2config_template.json
+++ b/tests/fixtures/g2config_template.json
@@ -1,0 +1,10176 @@
+{
+    "G2_CONFIG": {
+        "CFG_ATTR": [
+            {
+                "ATTR_ID": 1001,
+                "ATTR_CODE": "DATA_SOURCE",
+                "ATTR_CLASS": "OBSERVATION",
+                "FTYPE_CODE": null,
+                "FELEM_CODE": null,
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1003,
+                "ATTR_CODE": "RECORD_ID",
+                "ATTR_CLASS": "OBSERVATION",
+                "FTYPE_CODE": null,
+                "FELEM_CODE": null,
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1007,
+                "ATTR_CODE": "DSRC_ACTION",
+                "ATTR_CLASS": "OBSERVATION",
+                "FTYPE_CODE": null,
+                "FELEM_CODE": null,
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1101,
+                "ATTR_CODE": "NAME_TYPE",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "USAGE_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1102,
+                "ATTR_CODE": "NAME_FULL",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "FULL_NAME",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1103,
+                "ATTR_CODE": "NAME_ORG",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "ORG_NAME",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1104,
+                "ATTR_CODE": "NAME_LAST",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "SUR_NAME",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1105,
+                "ATTR_CODE": "NAME_FIRST",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "GIVEN_NAME",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1106,
+                "ATTR_CODE": "NAME_MIDDLE",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "MIDDLE_NAME",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1107,
+                "ATTR_CODE": "NAME_PREFIX",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "NAME_PREFIX",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1108,
+                "ATTR_CODE": "NAME_SUFFIX",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "NAME_SUFFIX",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1109,
+                "ATTR_CODE": "NAME_GEN",
+                "ATTR_CLASS": "NAME",
+                "FTYPE_CODE": "NAME",
+                "FELEM_CODE": "NAME_GEN",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1210,
+                "ATTR_CODE": "GENDER",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "GENDER",
+                "FELEM_CODE": "GENDER",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1221,
+                "ATTR_CODE": "DATE_OF_BIRTH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOB",
+                "FELEM_CODE": "DATE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1222,
+                "ATTR_CODE": "DOB_YEAR",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOB",
+                "FELEM_CODE": "DATE_YEAR",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1223,
+                "ATTR_CODE": "DOB_MONTH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOB",
+                "FELEM_CODE": "DATE_MONTH",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1224,
+                "ATTR_CODE": "DOB_DAY",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOB",
+                "FELEM_CODE": "DATE_DAY",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1225,
+                "ATTR_CODE": "DOB_HASH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOB",
+                "FELEM_CODE": "DATE_HASH",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1231,
+                "ATTR_CODE": "NATIONALITY",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "NATIONALITY",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1241,
+                "ATTR_CODE": "CITIZENSHIP",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "CITIZENSHIP",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1261,
+                "ATTR_CODE": "DATE_OF_DEATH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOD",
+                "FELEM_CODE": "DATE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1262,
+                "ATTR_CODE": "DOD_YEAR",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOD",
+                "FELEM_CODE": "DATE_YEAR",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1263,
+                "ATTR_CODE": "DOD_MONTH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOD",
+                "FELEM_CODE": "DATE_MONTH",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1264,
+                "ATTR_CODE": "DOD_DAY",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOD",
+                "FELEM_CODE": "DATE_DAY",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1265,
+                "ATTR_CODE": "DOD_HASH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "DOD",
+                "FELEM_CODE": "DATE_HASH",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1311,
+                "ATTR_CODE": "ACCOUNT_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "ACCT_NUM",
+                "FELEM_CODE": "ACCT_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1312,
+                "ATTR_CODE": "ACCOUNT_DOMAIN",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "ACCT_NUM",
+                "FELEM_CODE": "ACCT_DOMAIN",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1321,
+                "ATTR_CODE": "PASSPORT_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "PASSPORT",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1322,
+                "ATTR_CODE": "PASSPORT_COUNTRY",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "PASSPORT",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1323,
+                "ATTR_CODE": "PASSPORT_ISSUE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "PASSPORT",
+                "FELEM_CODE": "ISSUE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1324,
+                "ATTR_CODE": "PASSPORT_EXPIRE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "PASSPORT",
+                "FELEM_CODE": "EXPIRE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1325,
+                "ATTR_CODE": "PASSPORT_NUMSTD",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "PASSPORT",
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1331,
+                "ATTR_CODE": "DRIVERS_LICENSE_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "DRLIC",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1332,
+                "ATTR_CODE": "DRIVERS_LICENSE_STATE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "DRLIC",
+                "FELEM_CODE": "STATE",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1333,
+                "ATTR_CODE": "DRIVERS_LICENSE_ISSUE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "DRLIC",
+                "FELEM_CODE": "ISSUE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1334,
+                "ATTR_CODE": "DRIVERS_LICENSE_EXPIRE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "DRLIC",
+                "FELEM_CODE": "EXPIRE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1335,
+                "ATTR_CODE": "DRLIC_NUMSTD",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "DRLIC",
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1341,
+                "ATTR_CODE": "SSN_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SSN",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1342,
+                "ATTR_CODE": "SSN_NUMSTD",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SSN",
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1350,
+                "ATTR_CODE": "NATIONAL_ID_TYPE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FELEM_CODE": "ID_TYPE",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1351,
+                "ATTR_CODE": "NATIONAL_ID_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1352,
+                "ATTR_CODE": "NATIONAL_ID_COUNTRY",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1353,
+                "ATTR_CODE": "NATIONAL_ID_ISSUE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FELEM_CODE": "ISSUE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1354,
+                "ATTR_CODE": "NATIONAL_ID_EXPIRE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FELEM_CODE": "EXPIRE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1355,
+                "ATTR_CODE": "NATIONAL_ID_NUM_STD",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1361,
+                "ATTR_CODE": "TAX_ID_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TAX_ID",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1362,
+                "ATTR_CODE": "TAX_ID_COUNTRY",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TAX_ID",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1363,
+                "ATTR_CODE": "TAX_ID_ISSUE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TAX_ID",
+                "FELEM_CODE": "ISSUE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1364,
+                "ATTR_CODE": "TAX_ID_EXPIRE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TAX_ID",
+                "FELEM_CODE": "EXPIRE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1365,
+                "ATTR_CODE": "TAX_ID_NUM_STD",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TAX_ID",
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1371,
+                "ATTR_CODE": "OTHER_ID_TYPE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "OTHER_ID",
+                "FELEM_CODE": "ID_TYPE",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1372,
+                "ATTR_CODE": "OTHER_ID_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "OTHER_ID",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1373,
+                "ATTR_CODE": "OTHER_ID_COUNTRY",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "OTHER_ID",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1374,
+                "ATTR_CODE": "OTHER_ID_ISSUE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "OTHER_ID",
+                "FELEM_CODE": "ISSUE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1375,
+                "ATTR_CODE": "OTHER_ID_EXPIRE_DT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "OTHER_ID",
+                "FELEM_CODE": "EXPIRE_DATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1376,
+                "ATTR_CODE": "OTHER_ID_NUM_STD",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "OTHER_ID",
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1381,
+                "ATTR_CODE": "TRUSTED_ID_TYPE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TRUSTED_ID",
+                "FELEM_CODE": "ID_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1382,
+                "ATTR_CODE": "TRUSTED_ID_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TRUSTED_ID",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1501,
+                "ATTR_CODE": "WEBSITE_ADDRESS",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "WEBSITE",
+                "FELEM_CODE": "ADDR",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1511,
+                "ATTR_CODE": "EMAIL_ADDRESS",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "EMAIL",
+                "FELEM_CODE": "ADDR",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1512,
+                "ATTR_CODE": "EMAIL_TYPE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "EMAIL",
+                "FELEM_CODE": "USAGE_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1521,
+                "ATTR_CODE": "SOCIAL_NETWORK",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "LOGIN_ID",
+                "FELEM_CODE": "LOGIN_DOMAIN",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1522,
+                "ATTR_CODE": "SOCIAL_HANDLE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "LOGIN_ID",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1601,
+                "ATTR_CODE": "ADDR_FULL",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR_FULL",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1602,
+                "ATTR_CODE": "ADDR_LINE1",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR1",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1603,
+                "ATTR_CODE": "ADDR_LINE2",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR2",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1604,
+                "ATTR_CODE": "ADDR_LINE3",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR3",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1605,
+                "ATTR_CODE": "ADDR_LINE4",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR4",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1606,
+                "ATTR_CODE": "ADDR_LINE5",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR5",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1607,
+                "ATTR_CODE": "ADDR_LINE6",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "ADDR6",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1608,
+                "ATTR_CODE": "ADDR_CITY",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "CITY",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1609,
+                "ATTR_CODE": "ADDR_STATE",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "STATE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1610,
+                "ATTR_CODE": "ADDR_POSTAL_CODE",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "POSTAL_CODE",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1611,
+                "ATTR_CODE": "ADDR_COUNTRY",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1612,
+                "ATTR_CODE": "ADDR_STR_NUM",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "STR_NUM",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1613,
+                "ATTR_CODE": "ADDR_STR_NAME",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "STR_NAME",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1614,
+                "ATTR_CODE": "ADDR_UNIT_TYPE",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "UNIT_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1615,
+                "ATTR_CODE": "ADDR_UNIT_NUM",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "UNIT_NUM",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1618,
+                "ATTR_CODE": "ADDR_STR_NAME_STD",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "STR_NAME_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1619,
+                "ATTR_CODE": "ADDR_CITY_STD",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "CITY_STD",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1620,
+                "ATTR_CODE": "ADDR_POSTAL_5",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "POSTAL_5",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1623,
+                "ATTR_CODE": "ADDR_TYPE",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "ADDRESS",
+                "FELEM_CODE": "USAGE_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1701,
+                "ATTR_CODE": "PHONE_AREACODE",
+                "ATTR_CLASS": "PHONE",
+                "FTYPE_CODE": "PHONE",
+                "FELEM_CODE": "PHONE_AREA_CODE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1702,
+                "ATTR_CODE": "PHONE_NUMBER",
+                "ATTR_CLASS": "PHONE",
+                "FTYPE_CODE": "PHONE",
+                "FELEM_CODE": "PHONE_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1703,
+                "ATTR_CODE": "PHONE_EXT",
+                "ATTR_CLASS": "PHONE",
+                "FTYPE_CODE": "PHONE",
+                "FELEM_CODE": "PHONE_EXT",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1704,
+                "ATTR_CODE": "PHONE_LAST_10",
+                "ATTR_CLASS": "PHONE",
+                "FTYPE_CODE": "PHONE",
+                "FELEM_CODE": "PHONE_LAST_10",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1705,
+                "ATTR_CODE": "PHONE_LAST_5",
+                "ATTR_CLASS": "PHONE",
+                "FTYPE_CODE": "PHONE",
+                "FELEM_CODE": "PHONE_LAST_5",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 1706,
+                "ATTR_CODE": "PHONE_TYPE",
+                "ATTR_CLASS": "PHONE",
+                "FTYPE_CODE": "PHONE",
+                "FELEM_CODE": "USAGE_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1801,
+                "ATTR_CODE": "RELATIONSHIP_TYPE",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_LINK",
+                "FELEM_CODE": "REL_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1802,
+                "ATTR_CODE": "RELATIONSHIP_ROLE",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_LINK",
+                "FELEM_CODE": "USAGE_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1803,
+                "ATTR_CODE": "RELATIONSHIP_KEY",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_LINK",
+                "FELEM_CODE": "REL_KEY",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1901,
+                "ATTR_CODE": "GEO_LATLONG",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "GEO_LOC",
+                "FELEM_CODE": "LATLONG",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1902,
+                "ATTR_CODE": "GEO_LATITUDE",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "GEO_LOC",
+                "FELEM_CODE": "LATITUDE",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1903,
+                "ATTR_CODE": "GEO_LONGITUDE",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "GEO_LOC",
+                "FELEM_CODE": "LONGITUDE",
+                "FELEM_REQ": "Any",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 1904,
+                "ATTR_CODE": "GEO_PRECISION",
+                "ATTR_CLASS": "ADDRESS",
+                "FTYPE_CODE": "GEO_LOC",
+                "FELEM_CODE": "GEO_PRECISION",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2001,
+                "ATTR_CODE": "GROUP_ASSOCIATION_TYPE",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "GROUP_ASSOCIATION",
+                "FELEM_CODE": "TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": "(org)",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2002,
+                "ATTR_CODE": "GROUP_ASSOCIATION_ORG_NAME",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "GROUP_ASSOCIATION",
+                "FELEM_CODE": "ORG_NAME",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2101,
+                "ATTR_CODE": "VEHICLE_LICENSE_PLATE_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "VEH_LIC_PLATE",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2102,
+                "ATTR_CODE": "VEHICLE_LICENSE_PLATE_STATE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "VEH_LIC_PLATE",
+                "FELEM_CODE": "STATE",
+                "FELEM_REQ": "Desired",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2201,
+                "ATTR_CODE": "VEHICLE_VIN_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "VEH_VIN",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2301,
+                "ATTR_CODE": "EMPLOYER_TYPE",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "EMPLOYER",
+                "FELEM_CODE": "TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": "EMPLOYER",
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 2302,
+                "ATTR_CODE": "EMPLOYER",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "EMPLOYER",
+                "FELEM_CODE": "ORG_NAME",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2303,
+                "ATTR_CODE": "LINKEDIN",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "LINKEDIN",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2304,
+                "ATTR_CODE": "FACEBOOK",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "FACEBOOK",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2305,
+                "ATTR_CODE": "TWITTER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TWITTER",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2306,
+                "ATTR_CODE": "SKYPE",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SKYPE",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2307,
+                "ATTR_CODE": "ZOOMROOM",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "ZOOMROOM",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2308,
+                "ATTR_CODE": "INSTAGRAM",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "INSTAGRAM",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2309,
+                "ATTR_CODE": "WHATSAPP",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "WHATSAPP",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2310,
+                "ATTR_CODE": "SIGNAL",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SIGNAL",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2311,
+                "ATTR_CODE": "TELEGRAM",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TELEGRAM",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2312,
+                "ATTR_CODE": "TANGO",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "TANGO",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2313,
+                "ATTR_CODE": "VIBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "VIBER",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2314,
+                "ATTR_CODE": "WECHAT",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "WECHAT",
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": "None",
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2401,
+                "ATTR_CODE": "RECORD_TYPE",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "RECORD_TYPE",
+                "FELEM_CODE": "TYPE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2421,
+                "ATTR_CODE": "PLACE_OF_BIRTH",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "PLACE_OF_BIRTH",
+                "FELEM_CODE": "PLACE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2431,
+                "ATTR_CODE": "REGISTRATION_DATE",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "REGISTRATION_DATE",
+                "FELEM_CODE": "DATE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2432,
+                "ATTR_CODE": "REGISTRATION_COUNTRY",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "REGISTRATION_COUNTRY",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2441,
+                "ATTR_CODE": "GROUP_ASSN_ID_TYPE",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "GROUP_ASSN_ID",
+                "FELEM_CODE": "ID_TYPE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2442,
+                "ATTR_CODE": "GROUP_ASSN_ID_NUMBER",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "GROUP_ASSN_ID",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2501,
+                "ATTR_CODE": "DUNS_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "DUNS_NUMBER",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2511,
+                "ATTR_CODE": "NPI_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "NPI_NUMBER",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2521,
+                "ATTR_CODE": "LEI_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "LEI_NUMBER",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2701,
+                "ATTR_CODE": "COUNTRY_OF_ASSOCIATION",
+                "ATTR_CLASS": "ATTRIBUTE",
+                "FTYPE_CODE": "COUNTRY_OF_ASSOCIATION",
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2710,
+                "ATTR_CODE": "MOBILE_AD_ID",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "MOBILE_AD_ID",
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2801,
+                "ATTR_CODE": "REL_ANCHOR_DOMAIN",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_ANCHOR",
+                "FELEM_CODE": "KEY_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2802,
+                "ATTR_CODE": "REL_ANCHOR_KEY",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_ANCHOR",
+                "FELEM_CODE": "KEY_VALUE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2811,
+                "ATTR_CODE": "REL_POINTER_DOMAIN",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_POINTER",
+                "FELEM_CODE": "KEY_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2812,
+                "ATTR_CODE": "REL_POINTER_KEY",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_POINTER",
+                "FELEM_CODE": "KEY_VALUE",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2813,
+                "ATTR_CODE": "REL_POINTER_ROLE",
+                "ATTR_CLASS": "RELATIONSHIP",
+                "FTYPE_CODE": "REL_POINTER",
+                "FELEM_CODE": "USAGE_TYPE",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2814,
+                "ATTR_CODE": "PLACEKEY",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "PLACEKEY",
+                "FELEM_CODE": "PLACEKEY",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2815,
+                "ATTR_CODE": "SEMANTIC_EMBEDDING",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SEMANTIC_VALUE",
+                "FELEM_CODE": "EMBEDDING",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2816,
+                "ATTR_CODE": "SEMANTIC_ALGORITHM",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SEMANTIC_VALUE",
+                "FELEM_CODE": "ALGORITHM",
+                "FELEM_REQ": "No",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "Yes"
+            },
+            {
+                "ATTR_ID": 2817,
+                "ATTR_CODE": "SEMANTIC_LABEL",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "SEMANTIC_VALUE",
+                "FELEM_CODE": "LABEL",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            },
+            {
+                "ATTR_ID": 2818,
+                "ATTR_CODE": "CREDITCARD_NUMBER",
+                "ATTR_CLASS": "IDENTIFIER",
+                "FTYPE_CODE": "CREDITCARD",
+                "FELEM_CODE": "CREDITCARD_NUM",
+                "FELEM_REQ": "Yes",
+                "DEFAULT_VALUE": null,
+                "INTERNAL": "No"
+            }
+        ],
+        "CFG_CFBOM": [
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 5
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 7,
+                "EXEC_ORDER": 6
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 8,
+                "EXEC_ORDER": 7
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 9,
+                "EXEC_ORDER": 8
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 9
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 10
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 11
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 81,
+                "EXEC_ORDER": 12
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 83,
+                "EXEC_ORDER": 13
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 84,
+                "EXEC_ORDER": 14
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 86,
+                "EXEC_ORDER": 15
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 87,
+                "EXEC_ORDER": 16
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 89,
+                "EXEC_ORDER": 17
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 91,
+                "EXEC_ORDER": 18
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 92,
+                "EXEC_ORDER": 19
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 93,
+                "EXEC_ORDER": 20
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 94,
+                "EXEC_ORDER": 21
+            },
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 96,
+                "EXEC_ORDER": 22
+            },
+            {
+                "CFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 4,
+                "FTYPE_ID": 4,
+                "FELEM_ID": 13,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 22,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 23,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 24,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 25,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 5
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 27,
+                "EXEC_ORDER": 6
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 7
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 29,
+                "EXEC_ORDER": 8
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 30,
+                "EXEC_ORDER": 9
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 31,
+                "EXEC_ORDER": 10
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 32,
+                "EXEC_ORDER": 11
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 100,
+                "EXEC_ORDER": 12
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 108,
+                "EXEC_ORDER": 13
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 72,
+                "EXEC_ORDER": 14
+            },
+            {
+                "CFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 33,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 60,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 61,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 109,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 7,
+                "FTYPE_ID": 7,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 13,
+                "FTYPE_ID": 13,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 13,
+                "FTYPE_ID": 13,
+                "FELEM_ID": 57,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 14,
+                "FTYPE_ID": 14,
+                "FELEM_ID": 35,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 14,
+                "FTYPE_ID": 14,
+                "FELEM_ID": 119,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 14,
+                "FTYPE_ID": 14,
+                "FELEM_ID": 120,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 14,
+                "FTYPE_ID": 14,
+                "FELEM_ID": 121,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 15,
+                "FTYPE_ID": 15,
+                "FELEM_ID": 35,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 15,
+                "FTYPE_ID": 15,
+                "FELEM_ID": 120,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 15,
+                "FTYPE_ID": 15,
+                "FELEM_ID": 121,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 16,
+                "FTYPE_ID": 16,
+                "FELEM_ID": 40,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 16,
+                "FTYPE_ID": 16,
+                "FELEM_ID": 58,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 18,
+                "FTYPE_ID": 36,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 19,
+                "FTYPE_ID": 37,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 19,
+                "FTYPE_ID": 37,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 34,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 34,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 35,
+                "FTYPE_ID": 52,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 35,
+                "FTYPE_ID": 52,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 35,
+                "FTYPE_ID": 52,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 36,
+                "FTYPE_ID": 53,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 36,
+                "FTYPE_ID": 53,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 37,
+                "FTYPE_ID": 54,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 38,
+                "FTYPE_ID": 55,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 39,
+                "FTYPE_ID": 56,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 39,
+                "FTYPE_ID": 56,
+                "FELEM_ID": 99,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 40,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 51,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 40,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 52,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 41,
+                "FTYPE_ID": 57,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 41,
+                "FTYPE_ID": 57,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 42,
+                "FTYPE_ID": 59,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 42,
+                "FTYPE_ID": 59,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 43,
+                "FTYPE_ID": 60,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 44,
+                "FTYPE_ID": 61,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 45,
+                "FTYPE_ID": 62,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 46,
+                "FTYPE_ID": 63,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 47,
+                "FTYPE_ID": 64,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 48,
+                "FTYPE_ID": 65,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 49,
+                "FTYPE_ID": 66,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 50,
+                "FTYPE_ID": 67,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 51,
+                "FTYPE_ID": 68,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 52,
+                "FTYPE_ID": 69,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 53,
+                "FTYPE_ID": 70,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 54,
+                "FTYPE_ID": 71,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 55,
+                "FTYPE_ID": 72,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 57,
+                "FTYPE_ID": 74,
+                "FELEM_ID": 116,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 58,
+                "FTYPE_ID": 75,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 58,
+                "FTYPE_ID": 75,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 58,
+                "FTYPE_ID": 75,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3
+            },
+            {
+                "CFCALL_ID": 58,
+                "FTYPE_ID": 75,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4
+            },
+            {
+                "CFCALL_ID": 59,
+                "FTYPE_ID": 76,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 60,
+                "FTYPE_ID": 77,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 60,
+                "FTYPE_ID": 77,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 61,
+                "FTYPE_ID": 78,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 62,
+                "FTYPE_ID": 79,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 63,
+                "FTYPE_ID": 80,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 64,
+                "FTYPE_ID": 86,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 65,
+                "FTYPE_ID": 87,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 66,
+                "FTYPE_ID": 93,
+                "FELEM_ID": 124,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 67,
+                "FTYPE_ID": 99,
+                "FELEM_ID": 127,
+                "EXEC_ORDER": 1
+            },
+            {
+                "CFCALL_ID": 67,
+                "FTYPE_ID": 99,
+                "FELEM_ID": 128,
+                "EXEC_ORDER": 2
+            },
+            {
+                "CFCALL_ID": 68,
+                "FTYPE_ID": 101,
+                "FELEM_ID": 130,
+                "EXEC_ORDER": 1
+            }
+        ],
+        "CFG_CFCALL": [
+            {
+                "CFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "CFUNC_ID": 2
+            },
+            {
+                "CFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "CFUNC_ID": 5
+            },
+            {
+                "CFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "CFUNC_ID": 5
+            },
+            {
+                "CFCALL_ID": 4,
+                "FTYPE_ID": 4,
+                "CFUNC_ID": 11
+            },
+            {
+                "CFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "CFUNC_ID": 4
+            },
+            {
+                "CFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "CFUNC_ID": 7
+            },
+            {
+                "CFCALL_ID": 7,
+                "FTYPE_ID": 7,
+                "CFUNC_ID": 8
+            },
+            {
+                "CFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 13,
+                "FTYPE_ID": 13,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 14,
+                "FTYPE_ID": 14,
+                "CFUNC_ID": 13
+            },
+            {
+                "CFCALL_ID": 15,
+                "FTYPE_ID": 15,
+                "CFUNC_ID": 17
+            },
+            {
+                "CFCALL_ID": 16,
+                "FTYPE_ID": 16,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 18,
+                "FTYPE_ID": 36,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 19,
+                "FTYPE_ID": 37,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 34,
+                "FTYPE_ID": 11,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 35,
+                "FTYPE_ID": 52,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 36,
+                "FTYPE_ID": 53,
+                "CFUNC_ID": 9
+            },
+            {
+                "CFCALL_ID": 37,
+                "FTYPE_ID": 54,
+                "CFUNC_ID": 1
+            },
+            {
+                "CFCALL_ID": 38,
+                "FTYPE_ID": 55,
+                "CFUNC_ID": 1
+            },
+            {
+                "CFCALL_ID": 39,
+                "FTYPE_ID": 56,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 40,
+                "FTYPE_ID": 24,
+                "CFUNC_ID": 10
+            },
+            {
+                "CFCALL_ID": 41,
+                "FTYPE_ID": 57,
+                "CFUNC_ID": 12
+            },
+            {
+                "CFCALL_ID": 42,
+                "FTYPE_ID": 59,
+                "CFUNC_ID": 12
+            },
+            {
+                "CFCALL_ID": 43,
+                "FTYPE_ID": 60,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 44,
+                "FTYPE_ID": 61,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 45,
+                "FTYPE_ID": 62,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 46,
+                "FTYPE_ID": 63,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 47,
+                "FTYPE_ID": 64,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 48,
+                "FTYPE_ID": 65,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 49,
+                "FTYPE_ID": 66,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 50,
+                "FTYPE_ID": 67,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 51,
+                "FTYPE_ID": 68,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 52,
+                "FTYPE_ID": 69,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 53,
+                "FTYPE_ID": 70,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 54,
+                "FTYPE_ID": 71,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 55,
+                "FTYPE_ID": 72,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 57,
+                "FTYPE_ID": 74,
+                "CFUNC_ID": 1
+            },
+            {
+                "CFCALL_ID": 58,
+                "FTYPE_ID": 75,
+                "CFUNC_ID": 5
+            },
+            {
+                "CFCALL_ID": 59,
+                "FTYPE_ID": 76,
+                "CFUNC_ID": 1
+            },
+            {
+                "CFCALL_ID": 60,
+                "FTYPE_ID": 77,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 61,
+                "FTYPE_ID": 78,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 62,
+                "FTYPE_ID": 79,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 63,
+                "FTYPE_ID": 80,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 64,
+                "FTYPE_ID": 86,
+                "CFUNC_ID": 1
+            },
+            {
+                "CFCALL_ID": 65,
+                "FTYPE_ID": 87,
+                "CFUNC_ID": 3
+            },
+            {
+                "CFCALL_ID": 66,
+                "FTYPE_ID": 93,
+                "CFUNC_ID": 14
+            },
+            {
+                "CFCALL_ID": 67,
+                "FTYPE_ID": 99,
+                "CFUNC_ID": 15
+            },
+            {
+                "CFCALL_ID": 68,
+                "FTYPE_ID": 101,
+                "CFUNC_ID": 16
+            }
+        ],
+        "CFG_CFRTN": [
+            {
+                "CFRTN_ID": 1,
+                "CFUNC_ID": 1,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 2,
+                "CFUNC_ID": 2,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "GNR_FN",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 99,
+                "CLOSE_SCORE": 88,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 3,
+                "CFUNC_ID": 2,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "GNR_SN",
+                "EXEC_ORDER": 2,
+                "SAME_SCORE": 99,
+                "CLOSE_SCORE": 88,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 4,
+                "CFUNC_ID": 2,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "GNR_GN",
+                "EXEC_ORDER": 3,
+                "SAME_SCORE": 99,
+                "CLOSE_SCORE": 88,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 5,
+                "CFUNC_ID": 3,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 6,
+                "CFUNC_ID": 2,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "GENERATION_MATCH",
+                "EXEC_ORDER": 4,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 9,
+                "CFUNC_ID": 5,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 92,
+                "LIKELY_SCORE": 90,
+                "PLAUSIBLE_SCORE": 85,
+                "UN_LIKELY_SCORE": 80
+            },
+            {
+                "CFRTN_ID": 10,
+                "CFUNC_ID": 7,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 98,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 11,
+                "CFUNC_ID": 8,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 12,
+                "CFUNC_ID": 9,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 85,
+                "PLAUSIBLE_SCORE": 80,
+                "UN_LIKELY_SCORE": 70
+            },
+            {
+                "CFRTN_ID": 13,
+                "CFUNC_ID": 4,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 97,
+                "CLOSE_SCORE": 85,
+                "LIKELY_SCORE": 70,
+                "PLAUSIBLE_SCORE": 65,
+                "UN_LIKELY_SCORE": 50
+            },
+            {
+                "CFRTN_ID": 14,
+                "CFUNC_ID": 2,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "GNR_ON",
+                "EXEC_ORDER": 5,
+                "SAME_SCORE": 99,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 15,
+                "CFUNC_ID": 10,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 16,
+                "CFUNC_ID": 11,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 17,
+                "CFUNC_ID": 12,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 18,
+                "CFUNC_ID": 13,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 19,
+                "CFUNC_ID": 14,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 24,
+                "CFUNC_ID": 9,
+                "FTYPE_ID": 12,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 95,
+                "LIKELY_SCORE": 95,
+                "PLAUSIBLE_SCORE": 95,
+                "UN_LIKELY_SCORE": 95
+            },
+            {
+                "CFRTN_ID": 25,
+                "CFUNC_ID": 9,
+                "FTYPE_ID": 52,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 95,
+                "LIKELY_SCORE": 95,
+                "PLAUSIBLE_SCORE": 95,
+                "UN_LIKELY_SCORE": 95
+            },
+            {
+                "CFRTN_ID": 26,
+                "CFUNC_ID": 9,
+                "FTYPE_ID": 11,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 95,
+                "LIKELY_SCORE": 95,
+                "PLAUSIBLE_SCORE": 95,
+                "UN_LIKELY_SCORE": 95
+            },
+            {
+                "CFRTN_ID": 27,
+                "CFUNC_ID": 9,
+                "FTYPE_ID": 53,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 100,
+                "LIKELY_SCORE": 100,
+                "PLAUSIBLE_SCORE": 100,
+                "UN_LIKELY_SCORE": 100
+            },
+            {
+                "CFRTN_ID": 28,
+                "CFUNC_ID": 15,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 90,
+                "CLOSE_SCORE": 80,
+                "LIKELY_SCORE": 50,
+                "PLAUSIBLE_SCORE": 30,
+                "UN_LIKELY_SCORE": 20
+            },
+            {
+                "CFRTN_ID": 29,
+                "CFUNC_ID": 16,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            },
+            {
+                "CFRTN_ID": 30,
+                "CFUNC_ID": 17,
+                "FTYPE_ID": 0,
+                "CFUNC_RTNVAL": "FULL_SCORE",
+                "EXEC_ORDER": 1,
+                "SAME_SCORE": 100,
+                "CLOSE_SCORE": 90,
+                "LIKELY_SCORE": 80,
+                "PLAUSIBLE_SCORE": 70,
+                "UN_LIKELY_SCORE": 60
+            }
+        ],
+        "CFG_CFUNC": [
+            {
+                "CFUNC_ID": 1,
+                "CFUNC_CODE": "STR_COMP",
+                "CFUNC_DESC": "String comparison",
+                "CONNECT_STR": "g2StringComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 2,
+                "CFUNC_CODE": "GNR_COMP",
+                "CFUNC_DESC": "GNR name comparison",
+                "CONNECT_STR": "g2GNRNameComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 3,
+                "CFUNC_CODE": "EXACT_COMP",
+                "CFUNC_DESC": "Exact match comp",
+                "CONNECT_STR": "g2ExactMatchComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 4,
+                "CFUNC_CODE": "ADDR_COMP",
+                "CFUNC_DESC": "Address comparison",
+                "CONNECT_STR": "g2AddressComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 5,
+                "CFUNC_CODE": "DOB_COMP",
+                "CFUNC_DESC": "DOB comparison",
+                "CONNECT_STR": "g2DateComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 7,
+                "CFUNC_CODE": "PHONE_COMP",
+                "CFUNC_DESC": "Phone comparison",
+                "CONNECT_STR": "g2PhoneComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 8,
+                "CFUNC_CODE": "SSN_COMP",
+                "CFUNC_DESC": "SSN comp",
+                "CONNECT_STR": "g2SSNComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 9,
+                "CFUNC_CODE": "ID_COMP",
+                "CFUNC_DESC": "ID Comparison",
+                "CONNECT_STR": "g2DLComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 10,
+                "CFUNC_CODE": "GEOLOC_COMP",
+                "CFUNC_DESC": "GEOLOC Comparison",
+                "CONNECT_STR": "g2GEOLOCComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 11,
+                "CFUNC_CODE": "EXACT_DOMAIN_COMP",
+                "CFUNC_DESC": "Exact domain match comp",
+                "CONNECT_STR": "g2ExactDomainMatchComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 12,
+                "CFUNC_CODE": "GROUP_ASSOCIATION_COMP",
+                "CFUNC_DESC": "Group Association comparison",
+                "CONNECT_STR": "g2GroupAssociationComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 13,
+                "CFUNC_CODE": "EMAIL_COMP",
+                "CFUNC_DESC": "Email comp",
+                "CONNECT_STR": "g2EmailComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 14,
+                "CFUNC_CODE": "PLACEKEY_COMP",
+                "CFUNC_DESC": "Placekey comp",
+                "CONNECT_STR": "g2PlacekeyComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 15,
+                "CFUNC_CODE": "SEMANTIC_SIMILARITY_COMP",
+                "CFUNC_DESC": "Semantic Similarity comp",
+                "CONNECT_STR": "g2SemanticSimilarityComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 16,
+                "CFUNC_CODE": "CREDITCARD_COMP",
+                "CFUNC_DESC": "Credit card comp",
+                "CONNECT_STR": "g2CreditCardComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "CFUNC_ID": 17,
+                "CFUNC_CODE": "WEBSITE_COMP",
+                "CFUNC_DESC": "Website comp",
+                "CONNECT_STR": "g2WebsiteComp",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            }
+        ],
+        "CFG_DFBOM": [
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 7,
+                "EXEC_ORDER": 6
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 8,
+                "EXEC_ORDER": 7
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 9,
+                "EXEC_ORDER": 8
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 10
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 11
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 12
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 13
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 14
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 81,
+                "EXEC_ORDER": 15
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 83,
+                "EXEC_ORDER": 16
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 84,
+                "EXEC_ORDER": 17
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 86,
+                "EXEC_ORDER": 18
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 87,
+                "EXEC_ORDER": 19
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 89,
+                "EXEC_ORDER": 20
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 91,
+                "EXEC_ORDER": 21
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 92,
+                "EXEC_ORDER": 22
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 93,
+                "EXEC_ORDER": 23
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 94,
+                "EXEC_ORDER": 24
+            },
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 96,
+                "EXEC_ORDER": 25
+            },
+            {
+                "DFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 100,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 22,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 23,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 24,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 25,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 6
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 27,
+                "EXEC_ORDER": 7
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 8
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 29,
+                "EXEC_ORDER": 9
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 30,
+                "EXEC_ORDER": 10
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 31,
+                "EXEC_ORDER": 11
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 32,
+                "EXEC_ORDER": 12
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 72,
+                "EXEC_ORDER": 13
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 14
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 108,
+                "EXEC_ORDER": 15
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 16
+            },
+            {
+                "DFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 109,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 33,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 34,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 60,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 61,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 6
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 6
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 6
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 7
+            },
+            {
+                "DFCALL_ID": 13,
+                "FTYPE_ID": 13,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 13,
+                "FTYPE_ID": 13,
+                "FELEM_ID": 57,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 16,
+                "FTYPE_ID": 16,
+                "FELEM_ID": 40,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 16,
+                "FTYPE_ID": 16,
+                "FELEM_ID": 58,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 51,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 52,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 53,
+                "EXEC_ORDER": 3
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 75,
+                "EXEC_ORDER": 4
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 76,
+                "EXEC_ORDER": 5
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 104,
+                "EXEC_ORDER": 6
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 105,
+                "EXEC_ORDER": 7
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 106,
+                "EXEC_ORDER": 8
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 107,
+                "EXEC_ORDER": 9
+            },
+            {
+                "DFCALL_ID": 36,
+                "FTYPE_ID": 36,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 36,
+                "FTYPE_ID": 36,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 37,
+                "FTYPE_ID": 37,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1
+            },
+            {
+                "DFCALL_ID": 37,
+                "FTYPE_ID": 37,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2
+            },
+            {
+                "DFCALL_ID": 37,
+                "FTYPE_ID": 37,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3
+            }
+        ],
+        "CFG_DFCALL": [
+            {
+                "DFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "DFUNC_ID": 5
+            },
+            {
+                "DFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "DFUNC_ID": 4
+            },
+            {
+                "DFCALL_ID": 3,
+                "FTYPE_ID": 3,
+                "DFUNC_ID": 4
+            },
+            {
+                "DFCALL_ID": 5,
+                "FTYPE_ID": 5,
+                "DFUNC_ID": 6
+            },
+            {
+                "DFCALL_ID": 6,
+                "FTYPE_ID": 6,
+                "DFUNC_ID": 1
+            },
+            {
+                "DFCALL_ID": 9,
+                "FTYPE_ID": 9,
+                "DFUNC_ID": 3
+            },
+            {
+                "DFCALL_ID": 10,
+                "FTYPE_ID": 10,
+                "DFUNC_ID": 3
+            },
+            {
+                "DFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "DFUNC_ID": 3
+            },
+            {
+                "DFCALL_ID": 12,
+                "FTYPE_ID": 12,
+                "DFUNC_ID": 3
+            },
+            {
+                "DFCALL_ID": 13,
+                "FTYPE_ID": 13,
+                "DFUNC_ID": 1
+            },
+            {
+                "DFCALL_ID": 16,
+                "FTYPE_ID": 16,
+                "DFUNC_ID": 1
+            },
+            {
+                "DFCALL_ID": 24,
+                "FTYPE_ID": 24,
+                "DFUNC_ID": 1
+            },
+            {
+                "DFCALL_ID": 36,
+                "FTYPE_ID": 36,
+                "DFUNC_ID": 1
+            },
+            {
+                "DFCALL_ID": 37,
+                "FTYPE_ID": 37,
+                "DFUNC_ID": 1
+            }
+        ],
+        "CFG_DFUNC": [
+            {
+                "DFUNC_ID": 1,
+                "DFUNC_CODE": "FELEM_STRICT_SUBSET",
+                "DFUNC_DESC": "Strict subset of felems",
+                "CONNECT_STR": "g2StrictSubsetFelems",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "DFUNC_ID": 2,
+                "DFUNC_CODE": "TOKEN_STRICT_SUBSET",
+                "DFUNC_DESC": "Strict subset of tokens",
+                "CONNECT_STR": "g2StrictSubsetTokens",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "DFUNC_ID": 3,
+                "DFUNC_CODE": "FELEM_NORM_STRICT_SUBSET",
+                "DFUNC_DESC": "Strict subset of normalized felems",
+                "CONNECT_STR": "g2StrictSubsetNormalizedFelems",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "DFUNC_ID": 4,
+                "DFUNC_CODE": "PARTIAL_DATES",
+                "DFUNC_DESC": "Partial dates",
+                "CONNECT_STR": "g2PartialDates",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "DFUNC_ID": 5,
+                "DFUNC_CODE": "PARTIAL_NAMES",
+                "DFUNC_DESC": "Partial names",
+                "CONNECT_STR": "g2PartialNames",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            },
+            {
+                "DFUNC_ID": 6,
+                "DFUNC_CODE": "PARTIAL_ADDRESSES",
+                "DFUNC_DESC": "Partial addresses",
+                "CONNECT_STR": "g2PartialAddresses",
+                "ANON_SUPPORT": "Yes",
+                "LANGUAGE": null
+            }
+        ],
+        "CFG_DSRC_INTEREST": [],
+        "CFG_DSRC": [
+            {
+                "DSRC_ID": 1,
+                "DSRC_CODE": "TEST",
+                "DSRC_DESC": "Test",
+                "RETENTION_LEVEL": "Remember"
+            },
+            {
+                "DSRC_ID": 2,
+                "DSRC_CODE": "SEARCH",
+                "DSRC_DESC": "Search",
+                "RETENTION_LEVEL": "Forget"
+            }
+        ],
+        "CFG_EFBOM": [
+            {
+                "EFCALL_ID": 1,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 60,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 2,
+                "FTYPE_ID": 9,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 3,
+                "FTYPE_ID": 10,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 4,
+                "FTYPE_ID": 12,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 5,
+                "FTYPE_ID": 13,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 8,
+                "FTYPE_ID": 37,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 29,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 72,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 31,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 32,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 73,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 74,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 100,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 108,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 10,
+                "FTYPE_ID": 7,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 10,
+                "FTYPE_ID": -1,
+                "FELEM_ID": 71,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 12,
+                "FTYPE_ID": 52,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 51,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 52,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 53,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 75,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 76,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 104,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 105,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 106,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": 107,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 14,
+                "FTYPE_ID": 16,
+                "FELEM_ID": 40,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 15,
+                "FTYPE_ID": 53,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 16,
+                "FTYPE_ID": 7,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 29,
+                "FTYPE_ID": 78,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 30,
+                "FTYPE_ID": 79,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 31,
+                "FTYPE_ID": 80,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 32,
+                "FTYPE_ID": 87,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 34,
+                "FTYPE_ID": 14,
+                "FELEM_ID": 121,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 19,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 12,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 93,
+                "FTYPE_ID": 93,
+                "FELEM_ID": 124,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": -1,
+                "FELEM_ID": 71,
+                "EXEC_ORDER": 12,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": -1,
+                "FELEM_ID": 112,
+                "EXEC_ORDER": 13,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": -1,
+                "FELEM_ID": 113,
+                "EXEC_ORDER": 14,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 7,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 12,
+                "FELEM_REQ": "Yes"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 73,
+                "EXEC_ORDER": 12,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 5,
+                "FELEM_ID": 74,
+                "EXEC_ORDER": 13,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 86,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 14,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 77,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 12,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 57,
+                "FELEM_ID": 118,
+                "EXEC_ORDER": 13,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 59,
+                "FELEM_ID": 118,
+                "EXEC_ORDER": 14,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 2,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 3,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 4,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 5,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 6,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 7,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 8,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 9,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 10,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 11,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 6,
+                "FELEM_ID": 61,
+                "EXEC_ORDER": 12,
+                "FELEM_REQ": "No"
+            },
+            {
+                "EFCALL_ID": 99,
+                "FTYPE_ID": 101,
+                "FELEM_ID": 130,
+                "EXEC_ORDER": 1,
+                "FELEM_REQ": "Yes"
+            }
+        ],
+        "CFG_EFCALL": [
+            {
+                "EFCALL_ID": 1,
+                "FTYPE_ID": 6,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 4,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 2,
+                "FTYPE_ID": 9,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 3,
+                "FTYPE_ID": 10,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 4,
+                "FTYPE_ID": 12,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 5,
+                "FTYPE_ID": 13,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 1,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 7,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 2,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 8,
+                "FTYPE_ID": 37,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 9,
+                "FTYPE_ID": 5,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 3,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 10,
+                "FTYPE_ID": 7,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 1,
+                "EXEC_ORDER": 2,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 12,
+                "FTYPE_ID": 52,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 13,
+                "FTYPE_ID": 24,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 6,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 14,
+                "FTYPE_ID": 16,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 15,
+                "FTYPE_ID": 53,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 16,
+                "FTYPE_ID": 7,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 29,
+                "FTYPE_ID": 78,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 30,
+                "FTYPE_ID": 79,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 31,
+                "FTYPE_ID": 80,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 32,
+                "FTYPE_ID": 87,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 5,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": -1,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 34,
+                "FTYPE_ID": 14,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 7,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": 88,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 92,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 92,
+                "EFEAT_FTYPE_ID": 92,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 93,
+                "FTYPE_ID": 93,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 8,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": 19,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 94,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 94,
+                "EFEAT_FTYPE_ID": 94,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 95,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 95,
+                "EFEAT_FTYPE_ID": 95,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 96,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 96,
+                "EFEAT_FTYPE_ID": 96,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 97,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 97,
+                "EFEAT_FTYPE_ID": 97,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 98,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 2,
+                "EXEC_ORDER": 98,
+                "EFEAT_FTYPE_ID": 98,
+                "IS_VIRTUAL": "No"
+            },
+            {
+                "EFCALL_ID": 99,
+                "FTYPE_ID": 101,
+                "FELEM_ID": -1,
+                "EFUNC_ID": 9,
+                "EXEC_ORDER": 1,
+                "EFEAT_FTYPE_ID": 100,
+                "IS_VIRTUAL": "No"
+            }
+        ],
+        "CFG_EFUNC": [
+            {
+                "EFUNC_ID": 1,
+                "EFUNC_CODE": "EXPRESS_BOM",
+                "EFUNC_DESC": "General BOM Hasher",
+                "CONNECT_STR": "g2GenericHasher",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 2,
+                "EFUNC_CODE": "NAME_HASHER",
+                "EFUNC_DESC": "Name expression",
+                "CONNECT_STR": "g2NameHasher",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 3,
+                "EFUNC_CODE": "ADDR_HASHER",
+                "EFUNC_DESC": "Address expression",
+                "CONNECT_STR": "g2AddressHasher",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 4,
+                "EFUNC_CODE": "PHONE_HASHER",
+                "EFUNC_DESC": "Phone Hasher",
+                "CONNECT_STR": "g2PhoneHasher",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 5,
+                "EFUNC_CODE": "EXPRESS_ID",
+                "EFUNC_DESC": "General ID Hasher",
+                "CONNECT_STR": "g2IDHasher",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 6,
+                "EFUNC_CODE": "STB_HASHER",
+                "EFUNC_DESC": "General STB Hasher",
+                "CONNECT_STR": "g2STBHasher",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 7,
+                "EFUNC_CODE": "FEAT_BUILDER",
+                "EFUNC_DESC": "FeatureBuilder",
+                "CONNECT_STR": "g2FeatBuilder",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 8,
+                "EFUNC_CODE": "PLACEKEY_EFEAT",
+                "EFUNC_DESC": "Plackey EFeat Creater",
+                "CONNECT_STR": "g2PlacekeyECreator",
+                "LANGUAGE": null
+            },
+            {
+                "EFUNC_ID": 9,
+                "EFUNC_CODE": "CREDITCARD_EFEAT",
+                "EFUNC_DESC": "Credit card EFeat Creator",
+                "CONNECT_STR": "g2CreditCardECreator",
+                "LANGUAGE": null
+            }
+        ],
+        "CFG_ERFRAG": [
+            {
+                "ERFRAG_ID": 11,
+                "ERFRAG_CODE": "SAME_NAME",
+                "ERFRAG_DESC": "SAME_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./GNR_SAME_NAME>0]",
+                "ERFRAG_DEPENDS": "301"
+            },
+            {
+                "ERFRAG_ID": 12,
+                "ERFRAG_CODE": "CLOSE_NAME",
+                "ERFRAG_DESC": "CLOSE_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./GNR_CLOSE_NAME>0]",
+                "ERFRAG_DEPENDS": "302"
+            },
+            {
+                "ERFRAG_ID": 13,
+                "ERFRAG_CODE": "LIKELY_NAME",
+                "ERFRAG_DESC": "LIKELY_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./GNR_LIKELY_NAME>0]",
+                "ERFRAG_DEPENDS": "303"
+            },
+            {
+                "ERFRAG_ID": 14,
+                "ERFRAG_CODE": "PART_NAME",
+                "ERFRAG_DESC": "PART_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./GNR_PART_NAME>0]",
+                "ERFRAG_DEPENDS": "304"
+            },
+            {
+                "ERFRAG_ID": 15,
+                "ERFRAG_CODE": "SUR_NAME",
+                "ERFRAG_DESC": "SUR_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./GNR_SUR_NAME>0]",
+                "ERFRAG_DEPENDS": "305"
+            },
+            {
+                "ERFRAG_ID": 16,
+                "ERFRAG_CODE": "DIFF_NAME",
+                "ERFRAG_DESC": "DIFF_NAME",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/NAME[sum(./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 17,
+                "ERFRAG_CODE": "NO_NAME",
+                "ERFRAG_DESC": "NO_NAME",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/NAME[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 18,
+                "ERFRAG_CODE": "ORG_NAME",
+                "ERFRAG_DESC": "ORG_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./GNR_ORG_NAME>0]",
+                "ERFRAG_DEPENDS": "306"
+            },
+            {
+                "ERFRAG_ID": 19,
+                "ERFRAG_CODE": "PART_NO_NAME",
+                "ERFRAG_DESC": "PART_NO_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./PART_NAME>0 or ./NO_NAME>0]",
+                "ERFRAG_DEPENDS": "14,17"
+            },
+            {
+                "ERFRAG_ID": 20,
+                "ERFRAG_CODE": "MULT_F1",
+                "ERFRAG_DESC": "MULT_F1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1[./SAME > 1]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 21,
+                "ERFRAG_CODE": "SAME_F1",
+                "ERFRAG_DESC": "SAME_F1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 22,
+                "ERFRAG_CODE": "CLOSE_F1",
+                "ERFRAG_DESC": "CLOSE_F1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 23,
+                "ERFRAG_CODE": "CLOSE_F1E",
+                "ERFRAG_DESC": "CLOSE_F1E",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1E[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 24,
+                "ERFRAG_CODE": "CLOSE_F1ES",
+                "ERFRAG_DESC": "CLOSE_F1ES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1ES[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 25,
+                "ERFRAG_CODE": "DIFF_F1",
+                "ERFRAG_DESC": "DIFF_F1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1[sum(./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 26,
+                "ERFRAG_CODE": "NO_F1",
+                "ERFRAG_DESC": "NO_F1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 27,
+                "ERFRAG_CODE": "SAME_F1E",
+                "ERFRAG_DESC": "SAME_F1E",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/F1E[sum(./SAME) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 30,
+                "ERFRAG_CODE": "MULT_FF",
+                "ERFRAG_DESC": "MULT_FF",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FF[sum(./SAME | ./CLOSE) > 1]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 31,
+                "ERFRAG_CODE": "SAME_FF",
+                "ERFRAG_DESC": "SAME_FF",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FF[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 32,
+                "ERFRAG_CODE": "CLOSE_FF",
+                "ERFRAG_DESC": "CLOSE_FF",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FF[sum(./SAME | ./CLOSE) > 0] | ./SUMMARY/BEHAVIOR/FFE[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 33,
+                "ERFRAG_CODE": "SAME_FFE",
+                "ERFRAG_DESC": "SAME_FFE",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FFE[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 34,
+                "ERFRAG_CODE": "CLOSE_FFES",
+                "ERFRAG_DESC": "CLOSE_FFES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FFES[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 35,
+                "ERFRAG_CODE": "DIFF_FF",
+                "ERFRAG_DESC": "DIFF_FF",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FF[sum(./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 36,
+                "ERFRAG_CODE": "NO_FF",
+                "ERFRAG_DESC": "NO_FF",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FF[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 37,
+                "ERFRAG_CODE": "CLOSE_FFE",
+                "ERFRAG_DESC": "CLOSE_FFE",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FFE[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 38,
+                "ERFRAG_CODE": "DIFF_FFE",
+                "ERFRAG_DESC": "DIFF_FFE",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FFE[sum(./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 39,
+                "ERFRAG_CODE": "LIKELY_FFE",
+                "ERFRAG_DESC": "LIKELY_FFE",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FFE[sum(./SAME | ./CLOSE | ./LIKELY) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 40,
+                "ERFRAG_CODE": "SAME_FME",
+                "ERFRAG_DESC": "SAME_FME",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FME[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 41,
+                "ERFRAG_CODE": "SAME_FMES",
+                "ERFRAG_DESC": "SAME_FMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FMES[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 42,
+                "ERFRAG_CODE": "CLOSE_FMES",
+                "ERFRAG_DESC": "CLOSE_FMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FMES[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 43,
+                "ERFRAG_CODE": "CLOSE_FME",
+                "ERFRAG_DESC": "CLOSE_FME",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FME[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 45,
+                "ERFRAG_CODE": "DIFF_FMES",
+                "ERFRAG_DESC": "DIFF_FMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FMES[sum(./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 46,
+                "ERFRAG_CODE": "NO_FMES",
+                "ERFRAG_DESC": "NO_FMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FMES[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 47,
+                "ERFRAG_CODE": "SAME_FVMES",
+                "ERFRAG_DESC": "SAME_FVMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FVMES[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 48,
+                "ERFRAG_CODE": "CLOSE_FVMES",
+                "ERFRAG_DESC": "CLOSE_FVMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FVMES[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 49,
+                "ERFRAG_CODE": "DIFF_FVMES",
+                "ERFRAG_DESC": "DIFF_FVMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FVMES[sum(./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 50,
+                "ERFRAG_CODE": "NO_FVMES",
+                "ERFRAG_DESC": "NO_FVMES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/FVMES[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 51,
+                "ERFRAG_CODE": "SAME_EXCL",
+                "ERFRAG_DESC": "SAME_EXCL",
+                "ERFRAG_SOURCE": "./FRAGMENT[sum(./SAME_FFE | ./SAME_F1E | ./SAME_A1E | ./SAME_FME) > 0]",
+                "ERFRAG_DEPENDS": "27,33,40,205"
+            },
+            {
+                "ERFRAG_ID": 52,
+                "ERFRAG_CODE": "CLOSE_EXCL",
+                "ERFRAG_DESC": "CLOSE_EXCL",
+                "ERFRAG_SOURCE": "./FRAGMENT[sum(./CLOSE_FFE | ./CLOSE_F1E | ./CLOSE_A1E | ./CLOSE_FME) > 0]",
+                "ERFRAG_DEPENDS": "23,37,43,202"
+            },
+            {
+                "ERFRAG_ID": 55,
+                "ERFRAG_CODE": "DIFF_EXCL",
+                "ERFRAG_DESC": "DIFF_EXCL",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/EXCLUSIVE[sum(./UNLIKELY | ./NO_CHANCE) > 0] | ./FRAGMENT[./NAME_GEN_MISMATCH>0]",
+                "ERFRAG_DEPENDS": "75"
+            },
+            {
+                "ERFRAG_ID": 56,
+                "ERFRAG_CODE": "NO_EXCL",
+                "ERFRAG_DESC": "NO_EXCL",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/EXCLUSIVE[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 60,
+                "ERFRAG_CODE": "MULT_STAB",
+                "ERFRAG_DESC": "MULT_STAB",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/STABLE[sum(./SAME | ./CLOSE) > 1]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 61,
+                "ERFRAG_CODE": "SAME_STAB",
+                "ERFRAG_DESC": "SAME_STAB",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/STABLE[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 62,
+                "ERFRAG_CODE": "CLOSE_STAB",
+                "ERFRAG_DESC": "CLOSE_STAB",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/STABLE[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 63,
+                "ERFRAG_CODE": "DIFF_GEN",
+                "ERFRAG_DESC": "DIFF_GEN",
+                "ERFRAG_SOURCE": "./SCORES/NAME[./GENERATION_MATCH = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 64,
+                "ERFRAG_CODE": "SAME_GEN",
+                "ERFRAG_DESC": "SAME_GEN",
+                "ERFRAG_SOURCE": "./SCORES/NAME[./GENERATION_MATCH >= 90]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 65,
+                "ERFRAG_CODE": "DIFF_STAB",
+                "ERFRAG_DESC": "DIFF_STAB",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/STABLE[sum(./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0] | ./FRAGMENT[./NAME_GEN_MISMATCH>0]",
+                "ERFRAG_DEPENDS": "75"
+            },
+            {
+                "ERFRAG_ID": 66,
+                "ERFRAG_CODE": "NO_STAB",
+                "ERFRAG_DESC": "NO_STAB",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/STABLE[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 67,
+                "ERFRAG_CODE": "LIKELY_STAB",
+                "ERFRAG_DESC": "LIKELY_STAB",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/STABLE[sum(./SAME | ./CLOSE | ./LIKELY) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 71,
+                "ERFRAG_CODE": "NO_NAME_CONF",
+                "ERFRAG_DESC": "NO_NAME_CONF",
+                "ERFRAG_SOURCE": "./FRAGMENT[./NO_NAME=1 and sum(./DIFF_EXCL)=0]",
+                "ERFRAG_DEPENDS": "17,55"
+            },
+            {
+                "ERFRAG_ID": 72,
+                "ERFRAG_CODE": "NAME_CONFL",
+                "ERFRAG_DESC": "NAME_CONFL",
+                "ERFRAG_SOURCE": "./FRAGMENT[./NO_NAME=0 or sum(./DIFF_EXCL)>0]",
+                "ERFRAG_DEPENDS": "17,55"
+            },
+            {
+                "ERFRAG_ID": 75,
+                "ERFRAG_CODE": "NAME_GEN_MISMATCH",
+                "ERFRAG_DESC": "DIFF_NAME_GEN",
+                "ERFRAG_SOURCE": "./FRAGMENT[./DIFF_GEN>0 and sum(./SAME_GEN)=0]",
+                "ERFRAG_DEPENDS": "63,64"
+            },
+            {
+                "ERFRAG_ID": 109,
+                "ERFRAG_CODE": "SF1_SNAME_CFF_CSTAB",
+                "ERFRAG_DESC": "SAME_F1+SAME_NAME+CLOSE_FF+CLOSE_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./SAME_NAME>0 and ./CLOSE_FF>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "21,11,32,62"
+            },
+            {
+                "ERFRAG_ID": 110,
+                "ERFRAG_CODE": "SF1_PNAME_CFF_CSTAB",
+                "ERFRAG_DESC": "SAME_F1+PART_NO_NAME+CLOSE_FF+CLOSE_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./PART_NO_NAME>0 and ./CLOSE_FF>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "21,19,32,62"
+            },
+            {
+                "ERFRAG_ID": 111,
+                "ERFRAG_CODE": "SF1_PNAME_CFF_DSTAB",
+                "ERFRAG_DESC": "SAME_F1+PART_NO_NAME+CLOSE_FF+DIFF_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./PART_NO_NAME>0 and ./CLOSE_FF>0 and ./DIFF_STAB>0]",
+                "ERFRAG_DEPENDS": "21,19,32,65"
+            },
+            {
+                "ERFRAG_ID": 112,
+                "ERFRAG_CODE": "SF1_PNAME_CFF",
+                "ERFRAG_DESC": "SAME_F1+PART_NO_NAME+CLOSE_FF",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./PART_NO_NAME>0 and ./CLOSE_FF>0]",
+                "ERFRAG_DEPENDS": "21,19,32"
+            },
+            {
+                "ERFRAG_ID": 113,
+                "ERFRAG_CODE": "CF1_PNAME_CFF_CSTAB",
+                "ERFRAG_DESC": "CLOSE_F1+PART_NO_NAME+CLOSE_FF+CLOSE_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_F1>0 and ./PART_NO_NAME>0 and ./CLOSE_FF>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "22,19,32,62"
+            },
+            {
+                "ERFRAG_ID": 114,
+                "ERFRAG_CODE": "CF1_CNAME_CSTAB",
+                "ERFRAG_DESC": "CLOSE_F1+CLOSE_NAME+CLOSE_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_F1>0 and ./CLOSE_NAME>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "22,12,62"
+            },
+            {
+                "ERFRAG_ID": 115,
+                "ERFRAG_CODE": "CF1_PNAME_MSTAB",
+                "ERFRAG_DESC": "CLOSE_F1+PART_NO_NAME+MULT_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_F1>0 and ./PART_NO_NAME>0 and ./MULT_STAB>0]",
+                "ERFRAG_DEPENDS": "22,19,60"
+            },
+            {
+                "ERFRAG_ID": 117,
+                "ERFRAG_CODE": "SF1_NCONF",
+                "ERFRAG_DESC": "SAME_F1+NO_NAME_CONF",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./NO_NAME_CONF>0]",
+                "ERFRAG_DEPENDS": "21,71"
+            },
+            {
+                "ERFRAG_ID": 120,
+                "ERFRAG_CODE": "SF1_PNAME_CSTAB",
+                "ERFRAG_DESC": "SAME_F1+PART_NO_NAME+CLOSE_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./PART_NO_NAME>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "21,19,62"
+            },
+            {
+                "ERFRAG_ID": 133,
+                "ERFRAG_CODE": "SF1_CNAME",
+                "ERFRAG_DESC": "SAME_F1+CLOSE_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./CLOSE_NAME>0]",
+                "ERFRAG_DEPENDS": "21,12"
+            },
+            {
+                "ERFRAG_ID": 134,
+                "ERFRAG_CODE": "SF1E_CNAME",
+                "ERFRAG_DESC": "SAME_F1E+CLOSE_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1E>0 and ./CLOSE_NAME>0]",
+                "ERFRAG_DEPENDS": "27,12"
+            },
+            {
+                "ERFRAG_ID": 140,
+                "ERFRAG_CODE": "MSTAB_LNAME_SF1",
+                "ERFRAG_DESC": "MULT_STAB+LIKELY_NAME+SAME_F1",
+                "ERFRAG_SOURCE": "./FRAGMENT[./MULT_STAB>0 and ./LIKELY_NAME>0 and ./SAME_F1>0]",
+                "ERFRAG_DEPENDS": "60,13,21"
+            },
+            {
+                "ERFRAG_ID": 141,
+                "ERFRAG_CODE": "MSTAB_CNAME",
+                "ERFRAG_DESC": "MULT_STAB+CLOSE_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./MULT_STAB>0 and ./CLOSE_NAME>0]",
+                "ERFRAG_DEPENDS": "60,12"
+            },
+            {
+                "ERFRAG_ID": 150,
+                "ERFRAG_CODE": "MFF_LNAME_SF1",
+                "ERFRAG_DESC": "MULT_FF+LIKELY_NAME+SAME_F1",
+                "ERFRAG_SOURCE": "./FRAGMENT[./MULT_FF>0 and ./LIKELY_NAME>0 and ./SAME_F1>0]",
+                "ERFRAG_DEPENDS": "30,13,21"
+            },
+            {
+                "ERFRAG_ID": 151,
+                "ERFRAG_CODE": "MFF_LNAME_CEXCL",
+                "ERFRAG_DESC": "MULT_FF+LIKELY_NAME+CLOSE_EXCL",
+                "ERFRAG_SOURCE": "./FRAGMENT[./MULT_FF>0 and ./LIKELY_NAME>0 and ./CLOSE_EXCL>0]",
+                "ERFRAG_DEPENDS": "30,13,52"
+            },
+            {
+                "ERFRAG_ID": 152,
+                "ERFRAG_CODE": "MFF_CNAME",
+                "ERFRAG_DESC": "MULT_FF+CLOSE_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./MULT_FF>0 and ./CLOSE_NAME>0]",
+                "ERFRAG_DEPENDS": "30,12"
+            },
+            {
+                "ERFRAG_ID": 160,
+                "ERFRAG_CODE": "CNAME_CFF_CEXCL",
+                "ERFRAG_DESC": "CLOSE_NAME+CLOSE_FF+CLOSE_EXCL",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_NAME>0 and ./CLOSE_FF>0 and ./CLOSE_EXCL>0]",
+                "ERFRAG_DEPENDS": "12,32,52"
+            },
+            {
+                "ERFRAG_ID": 161,
+                "ERFRAG_CODE": "CNAME_CFF_DEXCL",
+                "ERFRAG_DESC": "CLOSE_NAME+CLOSE_FF+DIFF_EXCL",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_NAME>0 and ./CLOSE_FF>0 and ./DIFF_EXCL>0]",
+                "ERFRAG_DEPENDS": "12,32,55"
+            },
+            {
+                "ERFRAG_ID": 163,
+                "ERFRAG_CODE": "CNAME_CFF",
+                "ERFRAG_DESC": "CLOSE_NAME+CLOSE_FF",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_NAME>0 and ./CLOSE_FF>0]",
+                "ERFRAG_DEPENDS": "12,32"
+            },
+            {
+                "ERFRAG_ID": 164,
+                "ERFRAG_CODE": "CNAME_LFFE",
+                "ERFRAG_DESC": "CLOSE_NAME+LIKELY_FFE",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_NAME>0 and ./LIKELY_FFE>0]",
+                "ERFRAG_DEPENDS": "12,39"
+            },
+            {
+                "ERFRAG_ID": 170,
+                "ERFRAG_CODE": "CF1_CSTAB",
+                "ERFRAG_DESC": "CLOSE_F1+CSTAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_F1>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "22,62"
+            },
+            {
+                "ERFRAG_ID": 171,
+                "ERFRAG_CODE": "CF1_CNAME",
+                "ERFRAG_DESC": "CLOSE_F1+CLOSE_NAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_F1>0 and ./CLOSE_NAME>0]",
+                "ERFRAG_DEPENDS": "22,12"
+            },
+            {
+                "ERFRAG_ID": 172,
+                "ERFRAG_CODE": "SF1_MFF",
+                "ERFRAG_DESC": "SAME_F1+MULT_FF",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./MULT_FF>0]",
+                "ERFRAG_DEPENDS": "21,30"
+            },
+            {
+                "ERFRAG_ID": 174,
+                "ERFRAG_CODE": "SF1_CFF",
+                "ERFRAG_DESC": "SAME_F1+CLOSE_FF",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1>0 and ./CLOSE_FF>0]",
+                "ERFRAG_DEPENDS": "21,32"
+            },
+            {
+                "ERFRAG_ID": 180,
+                "ERFRAG_CODE": "SNAME_SSTAB",
+                "ERFRAG_DESC": "SAME_NAME+SAME_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_NAME>0 and ./SAME_STAB>0]",
+                "ERFRAG_DEPENDS": "11,61"
+            },
+            {
+                "ERFRAG_ID": 181,
+                "ERFRAG_CODE": "CNAME_CSTAB",
+                "ERFRAG_DESC": "CLOSE_NAME+CLOSE_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_NAME>0 and ./CLOSE_STAB>0]",
+                "ERFRAG_DEPENDS": "12,62"
+            },
+            {
+                "ERFRAG_ID": 183,
+                "ERFRAG_CODE": "LNAME_CFF_LSTAB",
+                "ERFRAG_DESC": "LIKELY_NAME+CLOSE_FF+LIKELY_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./LIKELY_NAME>0 and ./CLOSE_FF>0 and ./LIKELY_STAB>0]",
+                "ERFRAG_DEPENDS": "13,32,67"
+            },
+            {
+                "ERFRAG_ID": 185,
+                "ERFRAG_CODE": "SF1E_SFF_MSTAB",
+                "ERFRAG_DESC": "SAME_F1E+SAME_FF+MULT_STAB",
+                "ERFRAG_SOURCE": "./FRAGMENT[./SAME_F1E>0 and ./SAME_FF>0 and ./MULT_STAB>0]",
+                "ERFRAG_DEPENDS": "27,31,60"
+            },
+            {
+                "ERFRAG_ID": 190,
+                "ERFRAG_CODE": "CFF_SURNAME",
+                "ERFRAG_DESC": "CLOSE_FF+SURNAME",
+                "ERFRAG_SOURCE": "./FRAGMENT[./CLOSE_FF>0 and ./SUR_NAME>0]",
+                "ERFRAG_DEPENDS": "32,15"
+            },
+            {
+                "ERFRAG_ID": 201,
+                "ERFRAG_CODE": "SAME_A1",
+                "ERFRAG_DESC": "SAME_A1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/A1[./SAME > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 202,
+                "ERFRAG_CODE": "CLOSE_A1E",
+                "ERFRAG_DESC": "CLOSE_A1E",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/A1E[sum(./SAME | ./CLOSE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 203,
+                "ERFRAG_CODE": "DIFF_A1",
+                "ERFRAG_DESC": "DIFF_A1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/A1[sum(./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 204,
+                "ERFRAG_CODE": "NO_A1",
+                "ERFRAG_DESC": "NO_A1",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/A1[sum(./SAME | ./CLOSE | ./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) = 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 205,
+                "ERFRAG_CODE": "SAME_A1E",
+                "ERFRAG_DESC": "SAME_A1E",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/A1E[sum(./SAME) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 206,
+                "ERFRAG_CODE": "DIFF_A1ES",
+                "ERFRAG_DESC": "DIFF_A1ES",
+                "ERFRAG_SOURCE": "./SUMMARY/BEHAVIOR/A1ES[sum(./LIKELY | ./PLAUSIBLE | ./UNLIKELY | ./NO_CHANCE) > 0]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 207,
+                "ERFRAG_CODE": "DIFF_GEN_A1ES",
+                "ERFRAG_DESC": "DIFF_GEN_A1ES",
+                "ERFRAG_SOURCE": "./SCORES/NAME[./GENERATION_MATCH = 0] | ./FRAGMENT[./DIFF_A1ES>0] | ./FRAGMENT[./DIFF_RECTYPE>0]",
+                "ERFRAG_DEPENDS": "206,208"
+            },
+            {
+                "ERFRAG_ID": 208,
+                "ERFRAG_CODE": "DIFF_RECTYPE",
+                "ERFRAG_DESC": "DIFF_RECTYPE",
+                "ERFRAG_SOURCE": "./SCORES/RECORD_TYPE[./FULL_SCORE<85]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 301,
+                "ERFRAG_CODE": "GNR_SAME_NAME",
+                "ERFRAG_DESC": "GNR_SAME_NAME",
+                "ERFRAG_SOURCE": "./SCORES/NAME[(./GNR_FN>=95 and ./GNR_GN>=95 and ./GNR_SN>=95) or (./GNR_FN>=95 and ./GNR_GN<0 and ./GNR_SN<0)]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 302,
+                "ERFRAG_CODE": "GNR_CLOSE_NAME",
+                "ERFRAG_DESC": "GNR_CLOSE_NAME",
+                "ERFRAG_SOURCE": "./SCORES/NAME[(./GNR_FN>=88 and ./GNR_GN>=85 and ./GNR_SN>=88) or (./GNR_FN>=88 and ./GNR_GN<0 and ./GNR_SN<0) or ./GNR_ON>=85 or ./GNR_FN>=90]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 303,
+                "ERFRAG_CODE": "GNR_LIKELY_NAME",
+                "ERFRAG_DESC": "GNR_LIKELY_NAME",
+                "ERFRAG_SOURCE": "./SCORES/NAME[(./GNR_FN>=82 and ./GNR_GN>=80 and ./GNR_SN>=82) or (./GNR_FN>=82 and ./GNR_GN<0 and ./GNR_SN<0) or ./GNR_ON>=80 or ./GNR_FN>=85]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 304,
+                "ERFRAG_CODE": "GNR_PART_NAME",
+                "ERFRAG_DESC": "GNR_PART_NAME",
+                "ERFRAG_SOURCE": "./SCORES/NAME[./GNR_FN>=85 or ./GNR_GN>=92]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 305,
+                "ERFRAG_CODE": "GNR_SUR_NAME",
+                "ERFRAG_DESC": "GNR_SUR_NAME",
+                "ERFRAG_SOURCE": "./SCORES/NAME[./GNR_SN>=92]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 306,
+                "ERFRAG_CODE": "GNR_ORG_NAME",
+                "ERFRAG_DESC": "GNR_ORG_NAME",
+                "ERFRAG_SOURCE": "./SCORES/NAME[./GNR_ON>=85]",
+                "ERFRAG_DEPENDS": null
+            },
+            {
+                "ERFRAG_ID": 999,
+                "ERFRAG_CODE": "DISABLE",
+                "ERFRAG_DESC": "DISABLE",
+                "ERFRAG_SOURCE": "./FRAGMENT[./NO_NAME=666]",
+                "ERFRAG_DEPENDS": "17"
+            }
+        ],
+        "CFG_ERRULE": [
+            {
+                "ERRULE_ID": 100,
+                "ERRULE_CODE": "SAME_A1",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SAME_A1",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": 10
+            },
+            {
+                "ERRULE_ID": 108,
+                "ERRULE_CODE": "SF1_SNAME_CFF_CSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1_SNAME_CFF_CSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 18
+            },
+            {
+                "ERRULE_ID": 110,
+                "ERRULE_CODE": "SF1_PNAME_CFF_CSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1_PNAME_CFF_CSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 20
+            },
+            {
+                "ERRULE_ID": 111,
+                "ERRULE_CODE": "SF1_SNAME_CFF_CSTAB_DEXCL",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1_SNAME_CFF_CSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_GEN_A1ES",
+                "ERRULE_TIER": 20
+            },
+            {
+                "ERRULE_ID": 112,
+                "ERRULE_CODE": "SF1_PNAME_CFF_OLD",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "DISABLE",
+                "DISQ_ERFRAG_CODE": "",
+                "ERRULE_TIER": 20
+            },
+            {
+                "ERRULE_ID": 120,
+                "ERRULE_CODE": "SF1_PNAME_CSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1_PNAME_CSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 20
+            },
+            {
+                "ERRULE_ID": 122,
+                "ERRULE_CODE": "SF1_PNAME_CFF",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1_PNAME_CFF",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 25
+            },
+            {
+                "ERRULE_ID": 130,
+                "ERRULE_CODE": "SF1_CNAME",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1_CNAME",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 30
+            },
+            {
+                "ERRULE_ID": 131,
+                "ERRULE_CODE": "CF1_PNAME_CFF_CSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "CF1_PNAME_CFF_CSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 40
+            },
+            {
+                "ERRULE_ID": 132,
+                "ERRULE_CODE": "CF1_CNAME_CSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "CF1_CNAME_CSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 40
+            },
+            {
+                "ERRULE_ID": 133,
+                "ERRULE_CODE": "CF1_PNAME_MSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "CF1_PNAME_MSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 40
+            },
+            {
+                "ERRULE_ID": 140,
+                "ERRULE_CODE": "MSTAB_LNAME_SF1",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "MSTAB_LNAME_SF1",
+                "DISQ_ERFRAG_CODE": "DIFF_GEN_A1ES",
+                "ERRULE_TIER": 50
+            },
+            {
+                "ERRULE_ID": 141,
+                "ERRULE_CODE": "MSTAB_CNAME",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "MSTAB_CNAME",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 50
+            },
+            {
+                "ERRULE_ID": 150,
+                "ERRULE_CODE": "MFF_LNAME_SF1",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "MFF_LNAME_SF1",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 50
+            },
+            {
+                "ERRULE_ID": 151,
+                "ERRULE_CODE": "MFF_LNAME_CEXCL",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "MFF_LNAME_CEXCL",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 50
+            },
+            {
+                "ERRULE_ID": 152,
+                "ERRULE_CODE": "MFF_CNAME",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "MFF_CNAME",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 50
+            },
+            {
+                "ERRULE_ID": 160,
+                "ERRULE_CODE": "CNAME_CFF_CEXCL",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "CNAME_CFF_CEXCL",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 60
+            },
+            {
+                "ERRULE_ID": 162,
+                "ERRULE_CODE": "CNAME_CFF",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "CNAME_CFF",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 60
+            },
+            {
+                "ERRULE_ID": 163,
+                "ERRULE_CODE": "SF1E_SFF_MSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SF1E_SFF_MSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 60
+            },
+            {
+                "ERRULE_ID": 164,
+                "ERRULE_CODE": "CNAME_CFF_DEXCL",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "CNAME_CFF_DEXCL",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 165,
+                "ERRULE_CODE": "CNAME_LFFE",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "CNAME_LFFE",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 170,
+                "ERRULE_CODE": "SF1_NCONF",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SAME_F1",
+                "DISQ_ERFRAG_CODE": "NAME_CONFL",
+                "ERRULE_TIER": 60
+            },
+            {
+                "ERRULE_ID": 172,
+                "ERRULE_CODE": "CNAME_SF1E",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "SF1E_CNAME",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 174,
+                "ERRULE_CODE": "CNAME_SF1",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "SF1_CNAME",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 175,
+                "ERRULE_CODE": "SF1E",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "SAME_F1E",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 176,
+                "ERRULE_CODE": "SF1_OLD",
+                "RESOLVE": "No",
+                "RELATE": "No",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "DISABLE",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 180,
+                "ERRULE_CODE": "SNAME_SSTAB",
+                "RESOLVE": "Yes",
+                "RELATE": "No",
+                "RTYPE_ID": 1,
+                "QUAL_ERFRAG_CODE": "SNAME_SSTAB",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": 60
+            },
+            {
+                "ERRULE_ID": 183,
+                "ERRULE_CODE": "LNAME_CFF_LSTAB",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "LNAME_CFF_LSTAB",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 185,
+                "ERRULE_CODE": "CNAME_CSTAB",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "CNAME_CSTAB",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 190,
+                "ERRULE_CODE": "CNAME_CF1",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "CF1_CNAME",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 195,
+                "ERRULE_CODE": "SF1",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 3,
+                "QUAL_ERFRAG_CODE": "SAME_F1",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 197,
+                "ERRULE_CODE": "CF1",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 3,
+                "QUAL_ERFRAG_CODE": "CLOSE_F1",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 199,
+                "ERRULE_CODE": "CFF_SURNAME",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 3,
+                "QUAL_ERFRAG_CODE": "CFF_SURNAME",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 200,
+                "ERRULE_CODE": "MFF",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 3,
+                "QUAL_ERFRAG_CODE": "MULT_FF",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 202,
+                "ERRULE_CODE": "SFF",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 3,
+                "QUAL_ERFRAG_CODE": "SAME_FF",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 203,
+                "ERRULE_CODE": "SNAME",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "SAME_NAME",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 204,
+                "ERRULE_CODE": "CFF",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 3,
+                "QUAL_ERFRAG_CODE": "CLOSE_FF",
+                "DISQ_ERFRAG_CODE": null,
+                "ERRULE_TIER": null
+            },
+            {
+                "ERRULE_ID": 206,
+                "ERRULE_CODE": "CNAME",
+                "RESOLVE": "No",
+                "RELATE": "Yes",
+                "RTYPE_ID": 2,
+                "QUAL_ERFRAG_CODE": "CLOSE_NAME",
+                "DISQ_ERFRAG_CODE": "DIFF_EXCL",
+                "ERRULE_TIER": null
+            }
+        ],
+        "CFG_FBOM": [
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 4,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 5,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 6,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 7,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 8,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 9,
+                "EXEC_ORDER": 8,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 10,
+                "EXEC_ORDER": 9,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 10,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 12,
+                "EXEC_ORDER": 11,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 77,
+                "EXEC_ORDER": 12,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 78,
+                "EXEC_ORDER": 13,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 79,
+                "EXEC_ORDER": 14,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 81,
+                "EXEC_ORDER": 15,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 83,
+                "EXEC_ORDER": 16,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 84,
+                "EXEC_ORDER": 17,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 86,
+                "EXEC_ORDER": 18,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 87,
+                "EXEC_ORDER": 19,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 89,
+                "EXEC_ORDER": 20,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 91,
+                "EXEC_ORDER": 21,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 92,
+                "EXEC_ORDER": 22,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 93,
+                "EXEC_ORDER": 23,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 94,
+                "EXEC_ORDER": 24,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 96,
+                "EXEC_ORDER": 25,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 1,
+                "FELEM_ID": 118,
+                "EXEC_ORDER": 26,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 71,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 112,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FELEM_ID": 113,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 71,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 112,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FELEM_ID": 113,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 4,
+                "FELEM_ID": 13,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 100,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 22,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 23,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 24,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 101,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 102,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 103,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 25,
+                "EXEC_ORDER": 8,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 9,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 27,
+                "EXEC_ORDER": 10,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 11,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 29,
+                "EXEC_ORDER": 12,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 30,
+                "EXEC_ORDER": 13,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 31,
+                "EXEC_ORDER": 14,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 32,
+                "EXEC_ORDER": 15,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 65,
+                "EXEC_ORDER": 16,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 66,
+                "EXEC_ORDER": 17,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 72,
+                "EXEC_ORDER": 18,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 73,
+                "EXEC_ORDER": 19,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 74,
+                "EXEC_ORDER": 20,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 11,
+                "EXEC_ORDER": 21,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 108,
+                "EXEC_ORDER": 22,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 23,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 6,
+                "FELEM_ID": 109,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 6,
+                "FELEM_ID": 33,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 6,
+                "FELEM_ID": 34,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 6,
+                "FELEM_ID": 60,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 6,
+                "FELEM_ID": 61,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 7,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 7,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 7,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 9,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 9,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 9,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 9,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 9,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 13,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 13,
+                "FELEM_ID": 57,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 14,
+                "FELEM_ID": 35,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 14,
+                "FELEM_ID": 119,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 14,
+                "FELEM_ID": 120,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 14,
+                "FELEM_ID": 2,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 14,
+                "FELEM_ID": 121,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 15,
+                "FELEM_ID": 35,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 15,
+                "FELEM_ID": 120,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 15,
+                "FELEM_ID": 121,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 16,
+                "FELEM_ID": 40,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 16,
+                "FELEM_ID": 58,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 18,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 19,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 20,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 21,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 22,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 23,
+                "FELEM_ID": 55,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 23,
+                "FELEM_ID": 54,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 51,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 52,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 2,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 53,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 75,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 76,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 104,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 105,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 106,
+                "EXEC_ORDER": 8,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FELEM_ID": 107,
+                "EXEC_ORDER": 9,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 26,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 27,
+                "FELEM_ID": 46,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 28,
+                "FELEM_ID": 44,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 29,
+                "FELEM_ID": 99,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 36,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 36,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 37,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 37,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 37,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 97,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 98,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 53,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 53,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 53,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 54,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 54,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 55,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 55,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 56,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 56,
+                "FELEM_ID": 99,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 57,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 57,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 57,
+                "FELEM_ID": 118,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 58,
+                "FELEM_ID": 115,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 58,
+                "FELEM_ID": 110,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 58,
+                "FELEM_ID": 111,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 58,
+                "FELEM_ID": 114,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 59,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 59,
+                "FELEM_ID": 3,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 59,
+                "FELEM_ID": 118,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 60,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 61,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 62,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 63,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 64,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 65,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 66,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 67,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 68,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 69,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 70,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 71,
+                "FELEM_ID": 56,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 72,
+                "FELEM_ID": 18,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 74,
+                "FELEM_ID": 116,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 43,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 62,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 63,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 64,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 71,
+                "EXEC_ORDER": 5,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 112,
+                "EXEC_ORDER": 6,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FELEM_ID": 113,
+                "EXEC_ORDER": 7,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 76,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 76,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 77,
+                "FELEM_ID": 38,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 77,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 78,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 78,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 78,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 78,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 79,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 79,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 79,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 79,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 80,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 80,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 80,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 80,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 86,
+                "FELEM_ID": 28,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 86,
+                "FELEM_ID": 117,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 87,
+                "FELEM_ID": 37,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 87,
+                "FELEM_ID": 26,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 87,
+                "FELEM_ID": 69,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 87,
+                "FELEM_ID": 39,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 88,
+                "FELEM_ID": 121,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 89,
+                "FELEM_ID": 122,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 89,
+                "FELEM_ID": 123,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 90,
+                "FELEM_ID": 122,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 90,
+                "FELEM_ID": 123,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 91,
+                "FELEM_ID": 55,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 91,
+                "FELEM_ID": 120,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 91,
+                "FELEM_ID": 125,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 91,
+                "FELEM_ID": 126,
+                "EXEC_ORDER": 4,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 92,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 93,
+                "FELEM_ID": 124,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 94,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 95,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 96,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 97,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 98,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 99,
+                "FELEM_ID": 127,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "Yes"
+            },
+            {
+                "FTYPE_ID": 99,
+                "FELEM_ID": 128,
+                "EXEC_ORDER": 2,
+                "DISPLAY_LEVEL": 0,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 99,
+                "FELEM_ID": 129,
+                "EXEC_ORDER": 3,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 101,
+                "FELEM_ID": 130,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            },
+            {
+                "FTYPE_ID": 100,
+                "FELEM_ID": 36,
+                "EXEC_ORDER": 1,
+                "DISPLAY_LEVEL": 1,
+                "DISPLAY_DELIM": null,
+                "DERIVED": "No"
+            }
+        ],
+        "CFG_FBOVR": [
+            {
+                "FTYPE_ID": 5,
+                "UTYPE_CODE": "BUSINESS",
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No"
+            },
+            {
+                "FTYPE_ID": 6,
+                "UTYPE_CODE": "MOBILE",
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No"
+            },
+            {
+                "FTYPE_ID": 24,
+                "UTYPE_CODE": "BUSINESS",
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No"
+            },
+            {
+                "FTYPE_ID": 93,
+                "UTYPE_CODE": "BUSINESS",
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No"
+            }
+        ],
+        "CFG_FCLASS": [
+            {
+                "FCLASS_ID": 1,
+                "FCLASS_CODE": "NAME",
+                "FCLASS_DESC": "Name"
+            },
+            {
+                "FCLASS_ID": 2,
+                "FCLASS_CODE": "BIO_DATE",
+                "FCLASS_DESC": "Biographical date"
+            },
+            {
+                "FCLASS_ID": 3,
+                "FCLASS_CODE": "BIO_FEATURE",
+                "FCLASS_DESC": "Biographical feature"
+            },
+            {
+                "FCLASS_ID": 4,
+                "FCLASS_CODE": "POSTAL_ADDRESS",
+                "FCLASS_DESC": "Postal address"
+            },
+            {
+                "FCLASS_ID": 5,
+                "FCLASS_CODE": "PHONE",
+                "FCLASS_DESC": "Phone"
+            },
+            {
+                "FCLASS_ID": 6,
+                "FCLASS_CODE": "ELECTED_ID",
+                "FCLASS_DESC": "Elected ID"
+            },
+            {
+                "FCLASS_ID": 7,
+                "FCLASS_CODE": "ISSUED_ID",
+                "FCLASS_DESC": "Issued ID"
+            },
+            {
+                "FCLASS_ID": 8,
+                "FCLASS_CODE": "PARTIAL_ID",
+                "FCLASS_DESC": "Partial ID"
+            },
+            {
+                "FCLASS_ID": 9,
+                "FCLASS_CODE": "OTHER",
+                "FCLASS_DESC": "Other"
+            },
+            {
+                "FCLASS_ID": 10,
+                "FCLASS_CODE": "INTERNAL_USE",
+                "FCLASS_DESC": "Internal use only"
+            },
+            {
+                "FCLASS_ID": 11,
+                "FCLASS_CODE": "SPACE_TIME",
+                "FCLASS_DESC": "Space-time"
+            },
+            {
+                "FCLASS_ID": 12,
+                "FCLASS_CODE": "RELATIONSHIP",
+                "FCLASS_DESC": "Relationship"
+            }
+        ],
+        "CFG_FELEM": [
+            {
+                "FELEM_ID": 2,
+                "FELEM_CODE": "FULL_NAME",
+                "FELEM_DESC": "Full name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 3,
+                "FELEM_CODE": "ORG_NAME",
+                "FELEM_DESC": "Organization name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 4,
+                "FELEM_CODE": "SUR_NAME",
+                "FELEM_DESC": "Surname",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 5,
+                "FELEM_CODE": "GIVEN_NAME",
+                "FELEM_DESC": "Given name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 6,
+                "FELEM_CODE": "MIDDLE_NAME",
+                "FELEM_DESC": "Middle name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 7,
+                "FELEM_CODE": "NAME_PREFIX",
+                "FELEM_DESC": "Name prefix",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 8,
+                "FELEM_CODE": "NAME_SUFFIX",
+                "FELEM_DESC": "Name suffix",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 9,
+                "FELEM_CODE": "NAME_GEN",
+                "FELEM_DESC": "Name generation",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 10,
+                "FELEM_CODE": "CULTURE",
+                "FELEM_DESC": "Name culture",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 11,
+                "FELEM_CODE": "SCRIPT",
+                "FELEM_DESC": "Script type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 12,
+                "FELEM_CODE": "CATEGORY",
+                "FELEM_DESC": "Name category",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 13,
+                "FELEM_CODE": "GENDER",
+                "FELEM_DESC": "Gender",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 14,
+                "FELEM_CODE": "MAKE",
+                "FELEM_DESC": "Make",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 15,
+                "FELEM_CODE": "MODEL",
+                "FELEM_DESC": "Model",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 16,
+                "FELEM_CODE": "COLOR",
+                "FELEM_DESC": "Color",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 17,
+                "FELEM_CODE": "YEAR",
+                "FELEM_DESC": "Year",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 18,
+                "FELEM_CODE": "TYPE",
+                "FELEM_DESC": "Type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 19,
+                "FELEM_CODE": "OS",
+                "FELEM_DESC": "Operating system",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 22,
+                "FELEM_CODE": "ADDR1",
+                "FELEM_DESC": "Addr line 1",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 23,
+                "FELEM_CODE": "ADDR2",
+                "FELEM_DESC": "Addr line 2",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 24,
+                "FELEM_CODE": "ADDR3",
+                "FELEM_DESC": "Addr line 3",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 25,
+                "FELEM_CODE": "CITY",
+                "FELEM_DESC": "City",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 26,
+                "FELEM_CODE": "STATE",
+                "FELEM_DESC": "State",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 27,
+                "FELEM_CODE": "POSTAL_CODE",
+                "FELEM_DESC": "Postal code",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 28,
+                "FELEM_CODE": "COUNTRY",
+                "FELEM_DESC": "Country",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 29,
+                "FELEM_CODE": "STR_NUM",
+                "FELEM_DESC": "Street number",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 30,
+                "FELEM_CODE": "STR_NAME",
+                "FELEM_DESC": "Street name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 31,
+                "FELEM_CODE": "UNIT_TYPE",
+                "FELEM_DESC": "Unit type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 32,
+                "FELEM_CODE": "UNIT_NUM",
+                "FELEM_DESC": "Unit number",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 33,
+                "FELEM_CODE": "PHONE_NUM",
+                "FELEM_DESC": "Phone number",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 34,
+                "FELEM_CODE": "PHONE_EXT",
+                "FELEM_DESC": "Phone extension",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 35,
+                "FELEM_CODE": "ADDR",
+                "FELEM_DESC": "Address",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 36,
+                "FELEM_CODE": "EXPRESSION",
+                "FELEM_DESC": "Expression",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 37,
+                "FELEM_CODE": "ID_NUM",
+                "FELEM_DESC": "ID Number",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 38,
+                "FELEM_CODE": "ID_TYPE",
+                "FELEM_DESC": "ID type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 39,
+                "FELEM_CODE": "ID_LAST4",
+                "FELEM_DESC": "Last4 ID num",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 40,
+                "FELEM_CODE": "ACCT_NUM",
+                "FELEM_DESC": "Account number",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 41,
+                "FELEM_CODE": "DSRC_CODE",
+                "FELEM_DESC": "Data source code",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 42,
+                "FELEM_CODE": "ACCT_TYPE",
+                "FELEM_DESC": "Account type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 43,
+                "FELEM_CODE": "DATE",
+                "FELEM_DESC": "Date",
+                "DATA_TYPE": "date"
+            },
+            {
+                "FELEM_ID": 44,
+                "FELEM_CODE": "YESNO_FLAG",
+                "FELEM_DESC": "Yes/No flag",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 45,
+                "FELEM_CODE": "CALL_SIGN",
+                "FELEM_DESC": "Call sign",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 46,
+                "FELEM_CODE": "CODE",
+                "FELEM_DESC": "Code",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 47,
+                "FELEM_CODE": "PORT",
+                "FELEM_DESC": "Port",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 48,
+                "FELEM_CODE": "LENGTH",
+                "FELEM_DESC": "Length",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 49,
+                "FELEM_CODE": "BEAM",
+                "FELEM_DESC": "Beam",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 50,
+                "FELEM_CODE": "TONNAGE",
+                "FELEM_DESC": "Tonnage",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 51,
+                "FELEM_CODE": "LATITUDE",
+                "FELEM_DESC": "Latitude",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 52,
+                "FELEM_CODE": "LONGITUDE",
+                "FELEM_DESC": "Longitude",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 53,
+                "FELEM_CODE": "TIME",
+                "FELEM_DESC": "Time",
+                "DATA_TYPE": "datetime"
+            },
+            {
+                "FELEM_ID": 54,
+                "FELEM_CODE": "REL_KEY",
+                "FELEM_DESC": "Relationship key",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 55,
+                "FELEM_CODE": "REL_TYPE",
+                "FELEM_DESC": "Relationship type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 56,
+                "FELEM_CODE": "LOGIN_ID",
+                "FELEM_DESC": "Login ID",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 57,
+                "FELEM_CODE": "LOGIN_DOMAIN",
+                "FELEM_DESC": "Login domain",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 58,
+                "FELEM_CODE": "ACCT_DOMAIN",
+                "FELEM_DESC": "Account domain",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 59,
+                "FELEM_CODE": "AMOUNT",
+                "FELEM_DESC": "Amount",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 60,
+                "FELEM_CODE": "PHONE_LAST_10",
+                "FELEM_DESC": "Phone Last10",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 61,
+                "FELEM_CODE": "PHONE_LAST_5",
+                "FELEM_DESC": "Phone Last5",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 62,
+                "FELEM_CODE": "DATE_YEAR",
+                "FELEM_DESC": "Date Year",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 63,
+                "FELEM_CODE": "DATE_MONTH",
+                "FELEM_DESC": "Date Month",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 64,
+                "FELEM_CODE": "DATE_DAY",
+                "FELEM_DESC": "Date Day",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 65,
+                "FELEM_CODE": "STR_NAME_NORM",
+                "FELEM_DESC": "Normalized Street Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 66,
+                "FELEM_CODE": "CITY_NORM",
+                "FELEM_DESC": "Normalized City Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 69,
+                "FELEM_CODE": "ID_NUM_STD",
+                "FELEM_DESC": "Standardized ID number",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 71,
+                "FELEM_CODE": "DATE_HASH",
+                "FELEM_DESC": "Date Hash",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 72,
+                "FELEM_CODE": "STR_NAME_STD",
+                "FELEM_DESC": "Standardized Street Name Metaphone",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 73,
+                "FELEM_CODE": "CITY_STD",
+                "FELEM_DESC": "Standardized City Metaphone",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 74,
+                "FELEM_CODE": "POSTAL_5",
+                "FELEM_DESC": "Postal Code (first 5 digits)",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 75,
+                "FELEM_CODE": "GEO_PRECISION",
+                "FELEM_DESC": "In Meters",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 76,
+                "FELEM_CODE": "TIME_PRECISION",
+                "FELEM_DESC": "Timebox Precision",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 77,
+                "FELEM_CODE": "ALL_NM",
+                "FELEM_DESC": "All for NAME_KEY",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 78,
+                "FELEM_CODE": "ALL_META",
+                "FELEM_DESC": "Meta for NAME_KEY",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 79,
+                "FELEM_CODE": "NM_PAIR",
+                "FELEM_DESC": "Pairs for NAME_KEY",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 81,
+                "FELEM_CODE": "ORIG_GN",
+                "FELEM_DESC": "Original (standardised) Given Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 83,
+                "FELEM_CODE": "META_GN",
+                "FELEM_DESC": "Metaphoned Given Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 84,
+                "FELEM_CODE": "ORIG_SN",
+                "FELEM_DESC": "Original (standardised) Surname",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 86,
+                "FELEM_CODE": "META_SN",
+                "FELEM_DESC": "Metaphoned Surname",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 87,
+                "FELEM_CODE": "ORIG_ON",
+                "FELEM_DESC": "Original Organisation Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 89,
+                "FELEM_CODE": "META_ON",
+                "FELEM_DESC": "Metaphoned Organisation Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 91,
+                "FELEM_CODE": "STD_PRE",
+                "FELEM_DESC": "Standardized Name Prefixes",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 92,
+                "FELEM_CODE": "STD_SUF",
+                "FELEM_DESC": "Standardized Name Suffixes",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 93,
+                "FELEM_CODE": "STD_GEN",
+                "FELEM_DESC": "Standardized Name Generation",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 94,
+                "FELEM_CODE": "ORIG_FN",
+                "FELEM_DESC": "Original (standardised) Full Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 96,
+                "FELEM_CODE": "META_FN",
+                "FELEM_DESC": "Metaphoned Full Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 97,
+                "FELEM_CODE": "ISSUE_DATE",
+                "FELEM_DESC": "Issue date",
+                "DATA_TYPE": "date"
+            },
+            {
+                "FELEM_ID": 98,
+                "FELEM_CODE": "EXPIRE_DATE",
+                "FELEM_DESC": "Expiration date",
+                "DATA_TYPE": "date"
+            },
+            {
+                "FELEM_ID": 99,
+                "FELEM_CODE": "VALUE",
+                "FELEM_DESC": "Value",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 100,
+                "FELEM_CODE": "ADDR_FULL",
+                "FELEM_DESC": "Full address string",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 101,
+                "FELEM_CODE": "ADDR4",
+                "FELEM_DESC": "Address line 4",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 102,
+                "FELEM_CODE": "ADDR5",
+                "FELEM_DESC": "Address line 5",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 103,
+                "FELEM_CODE": "ADDR6",
+                "FELEM_DESC": "Address line 6",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 104,
+                "FELEM_CODE": "LATLONG",
+                "FELEM_DESC": "Latitude,Longitude as decimal numbers",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 105,
+                "FELEM_CODE": "STB6",
+                "FELEM_DESC": "STB 6 byte",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 106,
+                "FELEM_CODE": "STB7",
+                "FELEM_DESC": "STB 7 byte",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 107,
+                "FELEM_CODE": "STB8",
+                "FELEM_DESC": "STB 8 byte",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 108,
+                "FELEM_CODE": "LIBPOSTAL_PARSE",
+                "FELEM_DESC": "LibPostal address parse",
+                "DATA_TYPE": "json"
+            },
+            {
+                "FELEM_ID": 109,
+                "FELEM_CODE": "PHONE_AREA_CODE",
+                "FELEM_DESC": "Phone area code",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 110,
+                "FELEM_CODE": "AMBIGUOUS_FTYPE_ID",
+                "FELEM_DESC": "Feature Type ID",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 111,
+                "FELEM_CODE": "AMBIGUOUS_TIER",
+                "FELEM_DESC": "Ambiguous Tier",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 112,
+                "FELEM_CODE": "MMYY_HASH",
+                "FELEM_DESC": "Month and Year Hash",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 113,
+                "FELEM_CODE": "MMDD_HASH",
+                "FELEM_DESC": "Month and Day Hash",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 114,
+                "FELEM_CODE": "AMBIGUOUS_SUPRESSED_LIBFEAT",
+                "FELEM_DESC": "Ambiguous Suppressed Library Feature ID",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 115,
+                "FELEM_CODE": "AMBIGUOUS_TYPE",
+                "FELEM_DESC": "Ambiguous Type",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 116,
+                "FELEM_CODE": "PLACE",
+                "FELEM_DESC": "Place",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 117,
+                "FELEM_CODE": "COUNTRY_CODE",
+                "FELEM_DESC": "Country Code",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 118,
+                "FELEM_CODE": "TOKENIZED_NM",
+                "FELEM_DESC": "Tokenized Name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 119,
+                "FELEM_CODE": "USER_NAME",
+                "FELEM_DESC": "User name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 120,
+                "FELEM_CODE": "DOMAIN_NAME",
+                "FELEM_DESC": "Domain name",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 121,
+                "FELEM_CODE": "ADDR_STD",
+                "FELEM_DESC": "Standardized address",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 122,
+                "FELEM_CODE": "KEY_TYPE",
+                "FELEM_DESC": "Key type",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 123,
+                "FELEM_CODE": "KEY_VALUE",
+                "FELEM_DESC": "Key value",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 124,
+                "FELEM_CODE": "PLACEKEY",
+                "FELEM_DESC": "Safegraph Placekey",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 125,
+                "FELEM_CODE": "SUPRESSED_RELATIONSHIP_FTYPE_ID",
+                "FELEM_DESC": "Suppressed relationship feature type ID",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 126,
+                "FELEM_CODE": "SUPRESSED_RELATIONSHIP_CONNECTING_FTYPE_ID",
+                "FELEM_DESC": "Suppressed relationship connecting feature type ID",
+                "DATA_TYPE": "number"
+            },
+            {
+                "FELEM_ID": 127,
+                "FELEM_CODE": "EMBEDDING",
+                "FELEM_DESC": "Embeddings",
+                "DATA_TYPE": "embedding"
+            },
+            {
+                "FELEM_ID": 128,
+                "FELEM_CODE": "ALGORITHM",
+                "FELEM_DESC": "Algorithm",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 129,
+                "FELEM_CODE": "LABEL",
+                "FELEM_DESC": "Label",
+                "DATA_TYPE": "string"
+            },
+            {
+                "FELEM_ID": 130,
+                "FELEM_CODE": "CREDITCARD_NUM",
+                "FELEM_DESC": "Credit card number",
+                "DATA_TYPE": "string"
+            }
+        ],
+        "CFG_FTYPE": [
+            {
+                "FTYPE_ID": 1,
+                "FTYPE_CODE": "NAME",
+                "FTYPE_DESC": "Name",
+                "FCLASS_ID": 1,
+                "FTYPE_FREQ": "NAME",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 2,
+                "FTYPE_CODE": "DOB",
+                "FTYPE_DESC": "Date of birth",
+                "FCLASS_ID": 2,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 3,
+                "FTYPE_CODE": "DOD",
+                "FTYPE_DESC": "Date of death",
+                "FCLASS_ID": 2,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 4,
+                "FTYPE_CODE": "GENDER",
+                "FTYPE_DESC": "Gender",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Denial"
+            },
+            {
+                "FTYPE_ID": 5,
+                "FTYPE_CODE": "ADDRESS",
+                "FTYPE_DESC": "Address",
+                "FCLASS_ID": 4,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 4,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 6,
+                "FTYPE_CODE": "PHONE",
+                "FTYPE_DESC": "Phone",
+                "FCLASS_ID": 5,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 7,
+                "FTYPE_CODE": "SSN",
+                "FTYPE_DESC": "Social security number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 9,
+                "FTYPE_CODE": "DRLIC",
+                "FTYPE_DESC": "Drivers license",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 10,
+                "FTYPE_CODE": "PASSPORT",
+                "FTYPE_DESC": "Passport number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 11,
+                "FTYPE_CODE": "TAX_ID",
+                "FTYPE_DESC": "Tax ID",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 12,
+                "FTYPE_CODE": "NATIONAL_ID",
+                "FTYPE_DESC": "National ID number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 13,
+                "FTYPE_CODE": "LOGIN_ID",
+                "FTYPE_DESC": "Login ID",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 14,
+                "FTYPE_CODE": "EMAIL",
+                "FTYPE_DESC": "Email address",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 3,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 15,
+                "FTYPE_CODE": "WEBSITE",
+                "FTYPE_DESC": "Website address",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 16,
+                "FTYPE_CODE": "ACCT_NUM",
+                "FTYPE_DESC": "Account number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 18,
+                "FTYPE_CODE": "NAME_KEY",
+                "FTYPE_DESC": "Name key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "NAME",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 19,
+                "FTYPE_CODE": "ADDR_KEY",
+                "FTYPE_DESC": "Address key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 20,
+                "FTYPE_CODE": "ID_KEY",
+                "FTYPE_DESC": "ID Key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 21,
+                "FTYPE_CODE": "PHONE_KEY",
+                "FTYPE_DESC": "Phone Key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 22,
+                "FTYPE_CODE": "SEARCH_KEY",
+                "FTYPE_DESC": "Search key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 23,
+                "FTYPE_CODE": "REL_LINK",
+                "FTYPE_DESC": "Relation link",
+                "FCLASS_ID": 12,
+                "FTYPE_FREQ": "NONE",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 11,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 24,
+                "FTYPE_CODE": "GEO_LOC",
+                "FTYPE_DESC": "Geo location",
+                "FCLASS_ID": 11,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 26,
+                "FTYPE_CODE": "STB_KEY",
+                "FTYPE_DESC": "Space-time box",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Confirm"
+            },
+            {
+                "FTYPE_ID": 27,
+                "FTYPE_CODE": "INTERESTING_ENTITY",
+                "FTYPE_DESC": "Interesting entity",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "No",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 28,
+                "FTYPE_CODE": "CONFUSED_ENTITY",
+                "FTYPE_DESC": "Confused entity",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "No",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 29,
+                "FTYPE_CODE": "ORPHANED_ENTITY",
+                "FTYPE_DESC": "Orphaned entity",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "No",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 36,
+                "FTYPE_CODE": "VEH_VIN",
+                "FTYPE_DESC": "Vehicle ID number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 37,
+                "FTYPE_CODE": "VEH_LIC_PLATE",
+                "FTYPE_DESC": "Vehicle license plate",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 52,
+                "FTYPE_CODE": "OTHER_ID",
+                "FTYPE_DESC": "Other ID number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 53,
+                "FTYPE_CODE": "TRUSTED_ID",
+                "FTYPE_DESC": "Trusted ID",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "A1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 54,
+                "FTYPE_CODE": "CITIZENSHIP",
+                "FTYPE_DESC": "Country of citizenship",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 55,
+                "FTYPE_CODE": "NATIONALITY",
+                "FTYPE_DESC": "Nationality",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 56,
+                "FTYPE_CODE": "PHYSICAL_ATTRIBUTE",
+                "FTYPE_DESC": "Physical Attribute",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Denial"
+            },
+            {
+                "FTYPE_ID": 57,
+                "FTYPE_CODE": "GROUP_ASSOCIATION",
+                "FTYPE_DESC": "Group Association",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 58,
+                "FTYPE_CODE": "AMBIGUOUS_ENTITY",
+                "FTYPE_DESC": "Ambiguous entity",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "No",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 59,
+                "FTYPE_CODE": "EMPLOYER",
+                "FTYPE_DESC": "Employer",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 60,
+                "FTYPE_CODE": "LINKEDIN",
+                "FTYPE_DESC": "LinkedIn",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 61,
+                "FTYPE_CODE": "FACEBOOK",
+                "FTYPE_DESC": "Facebook",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 62,
+                "FTYPE_CODE": "TWITTER",
+                "FTYPE_DESC": "Twitter",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 63,
+                "FTYPE_CODE": "SKYPE",
+                "FTYPE_DESC": "Skype",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 64,
+                "FTYPE_CODE": "ZOOMROOM",
+                "FTYPE_DESC": "Zoom room",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 65,
+                "FTYPE_CODE": "INSTAGRAM",
+                "FTYPE_DESC": "Instagram",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 66,
+                "FTYPE_CODE": "WHATSAPP",
+                "FTYPE_DESC": "WhatsApp",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 67,
+                "FTYPE_CODE": "SIGNAL",
+                "FTYPE_DESC": "Signal",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 68,
+                "FTYPE_CODE": "TELEGRAM",
+                "FTYPE_DESC": "Telegram",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 69,
+                "FTYPE_CODE": "TANGO",
+                "FTYPE_DESC": "Tango",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 70,
+                "FTYPE_CODE": "VIBER",
+                "FTYPE_DESC": "Viber",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 71,
+                "FTYPE_CODE": "WECHAT",
+                "FTYPE_DESC": "WeChat",
+                "FCLASS_ID": 6,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 72,
+                "FTYPE_CODE": "RECORD_TYPE",
+                "FTYPE_DESC": "Record Type",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Denial"
+            },
+            {
+                "FTYPE_ID": 74,
+                "FTYPE_CODE": "PLACE_OF_BIRTH",
+                "FTYPE_DESC": "Place of Birth",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 75,
+                "FTYPE_CODE": "REGISTRATION_DATE",
+                "FTYPE_DESC": "Registration Date",
+                "FCLASS_ID": 2,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "Yes",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 76,
+                "FTYPE_CODE": "REGISTRATION_COUNTRY",
+                "FTYPE_DESC": "Registration Country",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 77,
+                "FTYPE_CODE": "GROUP_ASSN_ID",
+                "FTYPE_DESC": "Group Association ID",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 78,
+                "FTYPE_CODE": "DUNS_NUMBER",
+                "FTYPE_DESC": "DUNS Number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 79,
+                "FTYPE_CODE": "NPI_NUMBER",
+                "FTYPE_DESC": "NPI Number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 80,
+                "FTYPE_CODE": "LEI_NUMBER",
+                "FTYPE_DESC": "LEI Number",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "Yes",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 86,
+                "FTYPE_CODE": "COUNTRY_OF_ASSOCIATION",
+                "FTYPE_DESC": "Country of Association",
+                "FCLASS_ID": 3,
+                "FTYPE_FREQ": "FVM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Denial"
+            },
+            {
+                "FTYPE_ID": 87,
+                "FTYPE_CODE": "MOBILE_AD_ID",
+                "FTYPE_DESC": "Mobile Ad ID",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 2,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 88,
+                "FTYPE_CODE": "EMAIL_KEY",
+                "FTYPE_DESC": "Email Key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 89,
+                "FTYPE_CODE": "REL_ANCHOR",
+                "FTYPE_DESC": "Relation anchor",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "NONE",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 11,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 90,
+                "FTYPE_CODE": "REL_POINTER",
+                "FTYPE_DESC": "Relation pointer",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "NONE",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 11,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 91,
+                "FTYPE_CODE": "SUPPRESSED_RELATION_DOMAIN",
+                "FTYPE_DESC": "Suppressed relationship domain",
+                "FCLASS_ID": 9,
+                "FTYPE_FREQ": "FM",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "No",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 92,
+                "FTYPE_CODE": "NAMEADDR_KEY",
+                "FTYPE_DESC": "Name-Address key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 93,
+                "FTYPE_CODE": "PLACEKEY",
+                "FTYPE_DESC": "Placekey",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 94,
+                "FTYPE_CODE": "NAMEDATE_KEY",
+                "FTYPE_DESC": "Name-Date key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 95,
+                "FTYPE_CODE": "NAMEID_KEY",
+                "FTYPE_DESC": "Name-ID key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 96,
+                "FTYPE_CODE": "NAMEREGION_KEY",
+                "FTYPE_DESC": "Name-Region key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 97,
+                "FTYPE_CODE": "NAMEGROUP_KEY",
+                "FTYPE_DESC": "Name-Group key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 98,
+                "FTYPE_CODE": "NAMEPHONE_KEY",
+                "FTYPE_DESC": "Name-Phone key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            },
+            {
+                "FTYPE_ID": 99,
+                "FTYPE_CODE": "SEMANTIC_VALUE",
+                "FTYPE_DESC": "Semantic value",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "FF",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 101,
+                "FTYPE_CODE": "CREDITCARD",
+                "FTYPE_DESC": "Credit card",
+                "FCLASS_ID": 7,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "No",
+                "DERIVED": "No",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "Yes"
+            },
+            {
+                "FTYPE_ID": 100,
+                "FTYPE_CODE": "CREDITCARD_KEY",
+                "FTYPE_DESC": "Credit card key",
+                "FCLASS_ID": 10,
+                "FTYPE_FREQ": "F1",
+                "FTYPE_EXCL": "No",
+                "FTYPE_STAB": "No",
+                "PERSIST_HISTORY": "Yes",
+                "USED_FOR_CAND": "Yes",
+                "DERIVED": "Yes",
+                "RTYPE_ID": 0,
+                "ANONYMIZE": "No",
+                "VERSION": 1,
+                "SHOW_IN_MATCH_KEY": "No"
+            }
+        ],
+        "CFG_GENERIC_THRESHOLD": [
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "NAME",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "F1",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": 5,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "F1E",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": 50,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "F1ES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": 50,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FF",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": 30,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FF",
+                "FTYPE_ID": 5,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": 500,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FF",
+                "FTYPE_ID": 57,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": 500,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FF",
+                "FTYPE_ID": 59,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": 500,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FF",
+                "FTYPE_ID": 97,
+                "CANDIDATE_CAP": 500,
+                "SCORING_CAP": 500,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FFE",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": 500,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FFES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": 500,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FME",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FVM",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FVME",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FVMES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 5,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "Yes"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "NAME",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 100,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "F1",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "F1E",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "F1ES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 10,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FF",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 100,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FFE",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 100,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FFES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 100,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FME",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FVM",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FVME",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FVMES",
+                "FTYPE_ID": 0,
+                "CANDIDATE_CAP": 20,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 2,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 3,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 75,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 27,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 28,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 29,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 58,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 1,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 91,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 2,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 3,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FMES",
+                "FTYPE_ID": 75,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 27,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 28,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 29,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 58,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            },
+            {
+                "GPLAN_ID": 2,
+                "BEHAVIOR": "FM",
+                "FTYPE_ID": 91,
+                "CANDIDATE_CAP": -1,
+                "SCORING_CAP": -1,
+                "SEND_TO_REDO": "No"
+            }
+        ],
+        "CFG_GPLAN": [
+            {
+                "GPLAN_ID": 1,
+                "GPLAN_CODE": "INGEST",
+                "GPLAN_DESC": "Standard Ingestion"
+            },
+            {
+                "GPLAN_ID": 2,
+                "GPLAN_CODE": "SEARCH",
+                "GPLAN_DESC": "Standard Search"
+            }
+        ],
+        "CFG_RCLASS": [
+            {
+                "RCLASS_ID": 1,
+                "RCLASS_CODE": "DERIVED",
+                "RCLASS_DESC": "Derived",
+                "IS_DISCLOSED": "No"
+            },
+            {
+                "RCLASS_ID": 2,
+                "RCLASS_CODE": "DISCLOSED",
+                "RCLASS_DESC": "Disclosed",
+                "IS_DISCLOSED": "Yes"
+            }
+        ],
+        "CFG_RTYPE": [
+            {
+                "RTYPE_ID": 1,
+                "RTYPE_CODE": "RESOLVED",
+                "RTYPE_DESC": "Resolved",
+                "RCLASS_ID": 1,
+                "BREAK_RES": "No"
+            },
+            {
+                "RTYPE_ID": 2,
+                "RTYPE_CODE": "POSSIBLY_SAME",
+                "RTYPE_DESC": "Possibly same",
+                "RCLASS_ID": 1,
+                "BREAK_RES": "No"
+            },
+            {
+                "RTYPE_ID": 3,
+                "RTYPE_CODE": "POSSIBLY_RELATED",
+                "RTYPE_DESC": "Possibly related",
+                "RCLASS_ID": 1,
+                "BREAK_RES": "No"
+            },
+            {
+                "RTYPE_ID": 4,
+                "RTYPE_CODE": "NAME_ONLY",
+                "RTYPE_DESC": "Name only match",
+                "RCLASS_ID": 1,
+                "BREAK_RES": "No"
+            },
+            {
+                "RTYPE_ID": 11,
+                "RTYPE_CODE": "DISCLOSED",
+                "RTYPE_DESC": "Disclosed",
+                "RCLASS_ID": 2,
+                "BREAK_RES": "No"
+            }
+        ],
+        "CFG_SFCALL": [
+            {
+                "SFCALL_ID": 1,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 1,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 2,
+                "FTYPE_ID": 2,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 2,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 3,
+                "FTYPE_ID": 5,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 7,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 4,
+                "FTYPE_ID": 6,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 8,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 5,
+                "FTYPE_ID": 7,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 4,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 6,
+                "FTYPE_ID": 9,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 7,
+                "FTYPE_ID": 10,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 8,
+                "FTYPE_ID": 12,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 9,
+                "FTYPE_ID": 24,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 10,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 10,
+                "FTYPE_ID": 37,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 11,
+                "FTYPE_ID": 11,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 12,
+                "FTYPE_ID": 52,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 13,
+                "FTYPE_ID": 3,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 2,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 14,
+                "FTYPE_ID": 75,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 2,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 15,
+                "FTYPE_ID": 78,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 16,
+                "FTYPE_ID": 79,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 17,
+                "FTYPE_ID": 80,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 18,
+                "FTYPE_ID": 87,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 6,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 19,
+                "FTYPE_ID": -1,
+                "FELEM_ID": 28,
+                "SFUNC_ID": 11,
+                "EXEC_ORDER": 100
+            },
+            {
+                "SFCALL_ID": 20,
+                "FTYPE_ID": 1,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 12,
+                "EXEC_ORDER": 50
+            },
+            {
+                "SFCALL_ID": 21,
+                "FTYPE_ID": 14,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 13,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 22,
+                "FTYPE_ID": 59,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 12,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 23,
+                "FTYPE_ID": 57,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 12,
+                "EXEC_ORDER": 1
+            },
+            {
+                "SFCALL_ID": 24,
+                "FTYPE_ID": 15,
+                "FELEM_ID": -1,
+                "SFUNC_ID": 15,
+                "EXEC_ORDER": 1
+            }
+        ],
+        "CFG_SFUNC": [
+            {
+                "SFUNC_ID": 1,
+                "SFUNC_CODE": "PARSE_NAME",
+                "SFUNC_DESC": "Parse name",
+                "CONNECT_STR": "g2ParseName",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 2,
+                "SFUNC_CODE": "PARSE_DOB",
+                "SFUNC_DESC": "Parse DOB",
+                "CONNECT_STR": "g2ParseDOB",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 4,
+                "SFUNC_CODE": "FORMAT_SSN",
+                "SFUNC_DESC": "Parse SSN",
+                "CONNECT_STR": "g2FormatSSN",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 6,
+                "SFUNC_CODE": "PARSE_ID",
+                "SFUNC_DESC": "Parse ID numbers",
+                "CONNECT_STR": "g2ParseID",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 7,
+                "SFUNC_CODE": "PARSE_ADDR",
+                "SFUNC_DESC": "Parse address",
+                "CONNECT_STR": "g2ConfigParseAddr",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 8,
+                "SFUNC_CODE": "PARSE_PHONE",
+                "SFUNC_DESC": "Parse phone",
+                "CONNECT_STR": "g2ParsePhone",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 10,
+                "SFUNC_CODE": "STANDARDIZE_GEOLOC",
+                "SFUNC_DESC": "Standardize Geolocation",
+                "CONNECT_STR": "g2ParseGEOLOC",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 11,
+                "SFUNC_CODE": "STANDARDIZE_COUNTRY",
+                "SFUNC_DESC": "Standardize Country",
+                "CONNECT_STR": "g2StdCountry",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 12,
+                "SFUNC_CODE": "TOKENIZE_NAME",
+                "SFUNC_DESC": "Tokenize name",
+                "CONNECT_STR": "g2StdTokenizeName",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 13,
+                "SFUNC_CODE": "PARSE_EMAIL",
+                "SFUNC_DESC": "Parse email",
+                "CONNECT_STR": "g2ParseEmail",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 14,
+                "SFUNC_CODE": "PARSE_CREDITCARD",
+                "SFUNC_DESC": "Parse credit card",
+                "CONNECT_STR": "g2ParseCreditCard",
+                "LANGUAGE": null
+            },
+            {
+                "SFUNC_ID": 15,
+                "SFUNC_CODE": "PARSE_WEBSITE",
+                "SFUNC_DESC": "Parse website",
+                "CONNECT_STR": "g2ParseWebsite",
+                "LANGUAGE": null
+            }
+        ],
+        "CFG_SPROFILE": [
+            {
+                "SPROFILE_ID": 2,
+                "SPROFILE_CODE": "SEARCH",
+                "SPROFILE_DESC": "Standard Search",
+                "GPLAN_ID": 2,
+                "DEFAULT_USED_FOR_CAND": "Normal",
+                "FTYPE_OVERRIDES": "[]"
+            }
+        ],
+        "SYS_OOM": [
+            {
+                "OOM_TYPE": "RF",
+                "OOM_LEVEL": "SYSDEFAULT",
+                "FTYPE_ID": 0,
+                "THRESH1_CNT": 100,
+                "THRESH1_OOM": 10,
+                "NEXT_THRESH": 1000
+            }
+        ],
+        "SETTINGS": {
+            "METAPHONE_VERSION": 3
+        },
+        "CONFIG_BASE_VERSION": {
+            "VERSION": "4.4.0",
+            "BUILD_VERSION": "4.4.0.DEVELOPMENT_VERSION",
+            "BUILD_DATE": "2026-07-31",
+            "BUILD_NUMBER": "DEVELOPMENT_VERSION",
+            "COMPATIBILITY_VERSION": {
+                "CONFIG_VERSION": "11"
+            }
+        }
+    }
+}

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -64,7 +64,6 @@ fn test_element_workflow() {
         code: "TEST_ELEM",
         description: Some("Test Element"),
         data_type: Some("string"),
-        tokenized: None,
     };
 
     let config = elements::add_element(&config, add_params).expect("Failed to add element");

--- a/tests/roundtrip_completeness.rs
+++ b/tests/roundtrip_completeness.rs
@@ -1,0 +1,192 @@
+//! Round-trip completeness tests.
+//!
+//! These guard the invariant behind SENZ9117: the Senzing engine's config
+//! loader requires every key of every CFG_* row to be present (even when its
+//! value is null). A previous bug dropped a null `DISQ_ERFRAG_CODE` from a
+//! CFG_ERRULE row on update, so the engine refused to load the saved config.
+//!
+//! The core check is `assert_no_keys_dropped`: after running a config through an
+//! SDK write operation, every row that existed before must still carry all of
+//! its original keys. Updates replace a row in place (same index) and adds
+//! append, so a positional comparison of the "before" rows is exact.
+
+use serde_json::{Value, json};
+use sz_configtool_lib::{fragments, rules};
+
+/// For every section array under `G2_CONFIG`, assert that each row present in
+/// `before` still has all of its keys in `after` at the same index. New rows
+/// appended by an add operation are ignored (we only verify nothing was lost).
+fn assert_no_keys_dropped(before: &Value, after: &Value) {
+    let b = before["G2_CONFIG"].as_object().expect("before G2_CONFIG");
+    let a = after["G2_CONFIG"].as_object().expect("after G2_CONFIG");
+
+    for (section, b_val) in b {
+        let (Some(b_rows), Some(a_rows)) =
+            (b_val.as_array(), a.get(section).and_then(|v| v.as_array()))
+        else {
+            continue; // not an array section (e.g. scalar or object)
+        };
+
+        for (i, b_row) in b_rows.iter().enumerate() {
+            let Some(b_obj) = b_row.as_object() else {
+                continue;
+            };
+            let a_obj = a_rows
+                .get(i)
+                .and_then(|v| v.as_object())
+                .unwrap_or_else(|| panic!("{section}[{i}] missing after round-trip"));
+
+            for key in b_obj.keys() {
+                assert!(
+                    a_obj.contains_key(key),
+                    "{section}[{i}] dropped key '{key}' during round-trip"
+                );
+            }
+        }
+    }
+}
+
+/// A representative slice of a g2config document: complete CFG_ERRULE and
+/// CFG_ERFRAG rows, including a rule whose DISQ_ERFRAG_CODE is null (the exact
+/// shape that triggered SENZ9117).
+fn sample_config() -> Value {
+    json!({
+        "G2_CONFIG": {
+            "CFG_ERRULE": [
+                {
+                    "ERRULE_ID": 100, "ERRULE_CODE": "SAME_A1", "RESOLVE": "Yes",
+                    "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "SAME_A1",
+                    "DISQ_ERFRAG_CODE": null, "ERRULE_TIER": 10
+                },
+                {
+                    "ERRULE_ID": 110, "ERRULE_CODE": "SF1_PNAME_CSTAB", "RESOLVE": "Yes",
+                    "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "SF1_PNAME",
+                    "DISQ_ERFRAG_CODE": "DIST_NAME", "ERRULE_TIER": 20
+                }
+            ],
+            "CFG_ERFRAG": [
+                {
+                    "ERFRAG_ID": 10, "ERFRAG_CODE": "SAME_A1", "ERFRAG_DESC": "SAME_A1",
+                    "ERFRAG_SOURCE": "./FRAGMENT[./SAME_NAME>0]", "ERFRAG_DEPENDS": null
+                }
+            ]
+        }
+    })
+}
+
+/// Updating a rule must not drop any key from any row anywhere in the config.
+#[test]
+fn roundtrip_set_rule_drops_no_keys() {
+    let before = sample_config();
+    let config_str = serde_json::to_string(&before).unwrap();
+
+    // The operation that originally corrupted the config: flip RESOLVE on a rule
+    // whose DISQ_ERFRAG_CODE is null.
+    let params = rules::SetRuleParams {
+        code: "SAME_A1",
+        resolve: Some("No"),
+        relate: None,
+        rtype_id: None,
+        fragment: None,
+        disqualifier: None,
+        tier: None,
+    };
+    let modified = rules::set_rule(&config_str, params).unwrap();
+    let after: Value = serde_json::from_str(&modified).unwrap();
+
+    assert_no_keys_dropped(&before, &after);
+
+    // Explicitly confirm the field that used to vanish is still present as null.
+    let rule = &after["G2_CONFIG"]["CFG_ERRULE"][0];
+    assert!(rule.as_object().unwrap().contains_key("DISQ_ERFRAG_CODE"));
+    assert_eq!(rule["DISQ_ERFRAG_CODE"], Value::Null);
+    assert_eq!(rule["RESOLVE"], json!("No"));
+}
+
+/// Updating a fragment must not drop any key from any row anywhere in the config.
+#[test]
+fn roundtrip_set_fragment_drops_no_keys() {
+    let before = sample_config();
+    let config_str = serde_json::to_string(&before).unwrap();
+
+    // Update only the description; ERFRAG_ID / ERFRAG_SOURCE / ERFRAG_DEPENDS
+    // must be carried forward, not dropped by the full-row replace.
+    let update = json!({"ERFRAG_DESC": "Updated"});
+    let modified = fragments::set_fragment(&config_str, "SAME_A1", &update).unwrap();
+    let after: Value = serde_json::from_str(&modified).unwrap();
+
+    assert_no_keys_dropped(&before, &after);
+    let frag = &after["G2_CONFIG"]["CFG_ERFRAG"][0];
+    assert_eq!(frag["ERFRAG_ID"], json!(10));
+    assert_eq!(frag["ERFRAG_SOURCE"], json!("./FRAGMENT[./SAME_NAME>0]"));
+}
+
+/// Real-config round-trip against a genuine engine template.
+///
+/// By default this runs against the committed fixture
+/// `tests/fixtures/g2config_template.json` (a real Senzing v4 engine template),
+/// so it exercises a full config on every CI run. Set
+/// `SZ_CONFIG_FIXTURE=/path/to/g2config.json` to point it at your own config
+/// instead.
+///
+/// Reads the ENTIRE config, runs every CFG_ERRULE row back through `set_rule`
+/// (a no-op update that still rebuilds the row via the serde struct) and every
+/// CFG_ERFRAG row through `set_fragment` (an empty update), then asserts no key
+/// was dropped anywhere. This proves the SDK round-trips a genuine engine config
+/// without dropping keys. If `SZ_CONFIG_OUT` is set, the re-serialized config is
+/// written there so it can be fed to a real Senzing engine to confirm it loads.
+#[test]
+fn roundtrip_real_config_fixture() {
+    let path = std::env::var("SZ_CONFIG_FIXTURE").unwrap_or_else(|_| {
+        format!(
+            "{}/tests/fixtures/g2config_template.json",
+            env!("CARGO_MANIFEST_DIR")
+        )
+    });
+
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"));
+    let before: Value = serde_json::from_str(&raw).expect("fixture is not valid JSON");
+
+    let mut config_str = raw.clone();
+
+    // Re-run every rule through set_rule with no field changes: this rebuilds
+    // each CFG_ERRULE row via ErruleRow, exercising the full-replace path.
+    if let Some(rules_arr) = before["G2_CONFIG"]["CFG_ERRULE"].as_array() {
+        for row in rules_arr {
+            if let Some(code) = row.get("ERRULE_CODE").and_then(|v| v.as_str()) {
+                let params = rules::SetRuleParams {
+                    code,
+                    resolve: None,
+                    relate: None,
+                    rtype_id: None,
+                    fragment: None,
+                    disqualifier: None,
+                    tier: None,
+                };
+                config_str = rules::set_rule(&config_str, params)
+                    .unwrap_or_else(|e| panic!("set_rule({code}) failed: {e}"));
+            }
+        }
+    }
+
+    // Re-run every fragment through set_fragment with an empty update.
+    if let Some(frags) = before["G2_CONFIG"]["CFG_ERFRAG"].as_array() {
+        for row in frags {
+            if let Some(code) = row.get("ERFRAG_CODE").and_then(|v| v.as_str()) {
+                let empty = json!({});
+                config_str = fragments::set_fragment(&config_str, code, &empty)
+                    .unwrap_or_else(|e| panic!("set_fragment({code}) failed: {e}"));
+            }
+        }
+    }
+
+    let after: Value = serde_json::from_str(&config_str).unwrap();
+    assert_no_keys_dropped(&before, &after);
+
+    if let Ok(out) = std::env::var("SZ_CONFIG_OUT") {
+        std::fs::write(&out, serde_json::to_string_pretty(&after).unwrap())
+            .unwrap_or_else(|e| panic!("cannot write SZ_CONFIG_OUT '{out}': {e}"));
+        eprintln!("round-tripped config written to {out}; load it into the engine to confirm");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the **SENZ9117** config-load failure (`CONFIG information for DISQ_ERFRAG_CODE not found in CFG_ERRULE`) and generalizes the fix into a single, schema-conformant source of truth for every config-section row.

Root cause: `set_rule` rebuilt a rule row from only the fields supplied in the update and full-replaced the array element, so a null `DISQ_ERFRAG_CODE` was dropped. The engine's config loader requires **every** `CFG_*` key to be present, even when its value is `null`.

## What changed

- **`src/config_rows.rs` (new):** one crate-internal serde row struct per section, deriving `Serialize` with **no** `skip_serializing_if` — so `Option::None` serializes as JSON `null` and every key is always emitted. This replaces the 8 sections that previously had **two divergent struct definitions** across modules with a single definition each.
- **All `add_*`/`set_*` builders** that write a full row now route through these structs.
- **Schema alignment** to the authoritative Senzing v4 schema (`config/engine/*.data`, confirmed against the template `g2config.json`):
  - `CFG_DFCALL` trimmed to its 3 real columns (`DFCALL_ID, FTYPE_ID, DFUNC_ID`).
  - `CFG_DFUNC` gains the required `ANON_SUPPORT` column.
  - `CFG_FELEM` drops the non-existent `TOKENIZE`/`TOKENIZED` column.
- **Round-trip completeness tests** (`tests/roundtrip_completeness.rs`), including one over the **real template** `g2config.json` (`tests/fixtures/g2config_template.json`): runs every rule through `set_rule` and every fragment through `set_fragment`, asserting no row loses a key.

## ⚠️ Breaking changes (minor bump 0.4.0 → 0.5.0, pre-1.0)

- Removed the `tokenized` field from `AddElementParams`/`SetElementParams` and its FFI plumbing — `CFG_FELEM` has no such column in the v4 schema.
- Removed `functions::comparison::add_comparison_func_return_code`, which wrote a malformed `CFG_CFRTN` shape (`CFRTN_CODE`/`CFRTN_DESC` don't exist); use `thresholds::add_comparison_threshold` for real `CFG_CFRTN` rows.

Downstream note: the `sz_configtool_rust` CLI uses these APIs and will need the corresponding adjustments.

## Test plan

- [x] `cargo test` — 133 passed, 0 failed (incl. real-config round-trip)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --lib --release` (cdylib/FFI) — builds
- [ ] CI matrix green
