### PR TITLE
Release v0.6.0: SDK audit fixes (#32–#43)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,12 +11,19 @@
         "statusBar.background": "#f45425",
         "statusBar.foreground": "#e7e7e7",
         "statusBarItem.hoverBackground": "#f67a56",
-        "statusBarItem.remoteBackground": "#f45425",
+        "statusBarItem.remoteBackground": "#0cf341",
         "statusBarItem.remoteForeground": "#e7e7e7",
         "titleBar.activeBackground": "#f45425",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#f4542599",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "activityBarTop.activeBackground": "#f67a56",
+        "activityBarTop.background": "#f67a56",
+        "activityBarTop.foreground": "#15202b",
+        "activityBarTop.inactiveForeground": "#15202b99",
+        "commandCenter.foreground": "#e7e7e7",
+        "statusBar.debuggingBackground": "#f45425",
+        "statusBar.debuggingForeground": "#e7e7e7"
     },
     "peacock.remoteColor": "#f45425"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,117 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-08-22
+
+Coordinated breaking release resolving the SDK audit (issues #32–#43). Delivered in six
+reviewed waves; every public-API and behavioural change is listed below. Test suite grew
+from ~90 to 216 unit tests + 80 doc-tests (all green; clippy `-D warnings`, `cargo deny`,
+`cargo fmt` clean).
+
+> **Two parity assumptions to confirm against the Python `sz_configtool` reference** (both
+> one-line fixes if wrong, flagged because the reference is not in this repo): `list_rules`
+> default sort key (assumed `ERRULE_ID` ascending) and the A1-family slot in the
+> `BEHAVIOR_CODES` ordering (not present in the shipped template). The `LOCKED_FEATURES`
+> protected set below was ratified by the maintainer.
+
+### Fixed (correctness — some were silent data corruption)
+
+- **`set_generic_threshold` no longer corrupts the wrong row.** It now matches on the full
+  `(GPLAN_ID, BEHAVIOR, FTYPE_ID)` identity; `feature` is a lookup key (with `all` → `FTYPE_ID 0`)
+  and is never written into the matched row's `FTYPE_ID`. A set with no matching per-feature row
+  now returns `NotFound` instead of silently editing (and corrupting) a `(plan, behavior)` row.
+  Unknown `sendToRedo` is rejected; the value is stored canonical title-case `"Yes"`/`"No"`. (#32)
+- **`add_generic_threshold`** stores `SEND_TO_REDO` as `"Yes"`/`"No"` (was `"YES"`/`"NO"`, which
+  disagreed with the shipped config). (#32)
+- **`add_config_section_field` no longer overwrites existing values** — it inserts only where the
+  key is absent. (#32)
+- **`LOCKED_FEATURES` corrected** to the ratified protected set `NAME, ADDRESS, PHONE, DOB,
+  REL_LINK, REL_ANCHOR, REL_POINTER`. `EMAIL, RECORD_TYPE, NATIONAL_ID, TAX_ID, ACCT_NUM` are now
+  correctly deletable; `DOB` and the `REL_*` features are now correctly protected; four inert
+  non-feature-code entries were removed. (#35)
+- **Read projections preserve stored `null`.** `get_rule`/`list_rules`, `get_fragment`/
+  `list_fragments`, and all four `list_*_functions` now emit JSON `null` (not `""`) for a stored
+  or absent nullable column — the engine's loader distinguishes them. `list_comparison_functions`
+  also now emits the previously-missing `description` and a fixed field order. (#33)
+- **`get_standardize_call`/`get_distinct_call` return the correct call** when addressed by
+  feature: they now scan `CFG_SFCALL`/`CFG_DFCALL` by `FTYPE_ID` instead of using the feature id
+  as the call id. (#40)
+- **`add_rule` now validates** (duplicate code, fragment/disqualifier existence, RESOLVE/RELATE
+  domain and mutual exclusivity, RTYPE_ID coherence) via a validator shared with `set_rule`, so
+  the two cannot drift; it auto-assigns `ERRULE_ID` (seed 1000) and returns the assigned id. (#39)
+- **`get_config_section` filter** now matches on `json.dumps`-spaced JSON (Python parity) instead
+  of compact JSON, so filter terms spanning a `": "`/`", "` boundary behave correctly. (#36)
+- Fixed truncated not-found messages: `Standardize call ID {id}` and the comparison get path now
+  read `… does not exist`, consistent across all four call families. (#42)
+
+### Added
+
+- **`add_element_to_feature` / `delete_element_from_feature`** — typed `CFG_FBOM` add/remove with
+  duplicate detection and whole-table `EXEC_ORDER` allocation. (#38)
+- **`settings` module + `set_setting`** — manage `G2_CONFIG.SETTINGS` (uppercases NAME,
+  create-if-absent, overwrite). (#38)
+- **Cascading function deletes** — `delete_{comparison,expression,standardize}_function_cascade`
+  (the existing non-cascading deletes are unchanged). (#38)
+- **Caller-supplied ids** — `id: Option<i64>` on `AddDataSourceParams`, `AddAttributeParams`,
+  `AddElementParams`, `AddFeatureParams`, `AddComparisonCallParams`; `add_fragment` now honours a
+  supplied `ERFRAG_ID`. Absent/≤0 auto-assigns; a taken id is rejected. (#37)
+- **By-feature call resolution** — `calls::CallSelector { Id | Feature }` accepted by all four
+  `get_*_call`; by-feature helpers resolve a feature code to its call id. (#40)
+- **`list_behavior_overrides_resolved`** — display shape `{feature, usageType, behavior}` with
+  id→code resolution, composed behaviour, sorted `(FTYPE_ID, UTYPE_CODE)`. (#43)
+- **`validate_config`** (structure-only gate) and **`render_config(config, indent)`** (canonical
+  key-sorted export renderer). (#43)
+- **`config_section_is_empty`** — distinguishes an empty section from a filter that matched
+  nothing, without changing `get_config_section`'s return type. (#36)
+- **Public config domains** — `behavior_domain::{BEHAVIOR_CODES, compute_behavior,
+  parse_behavior_code}` (the two private copies collapsed into one), `ATTRIBUTE_CLASSES`. (#43)
+- **`SzErrorKind` + `SzConfigError::kind()`/`reason_code()`** — a stable machine-readable error
+  surface so callers branch on a discriminant rather than message text. (#42)
+- **Shared building blocks** — `FieldUpdate<T>` tri-state, `field_or_null`, and a `filter`
+  substrate module (`Compact`/`JsonDumps`/`PythonRepr`).
+- New additive FFI wrappers + header declarations for all of the above; the pre-existing
+  `SzConfigTool_listBehaviorOverrides` gained its missing header declaration.
+
+### Changed (breaking — Rust API)
+
+- `delete_comparison_threshold(config, cfunc_code, ftype_code, cfunc_rtnval)` — new required
+  `cfunc_rtnval`; full 3-key match; `all` → `FTYPE_ID 0`. (#32)
+- `add_config_section_field` returns `(String, AddFieldCounts { existed, updated })` (was
+  `(String, usize)`). (#32)
+- Four `Add*FunctionParams`: `connect_str: &str` → `Option<&str>`; the four function row structs'
+  `connect_str: String` → `Option<String>` (can now serialise `null`). The `add_distinct_function`
+  blank-CONNECTSTR rejection was removed (Python accepts blank). (#34)
+- Tri-state via `FieldUpdate<T>` on `SetRuleParams.{fragment, disqualifier, tier}`, the four
+  `Set*FunctionParams.connect_str`, and a new `SetFragmentParams` (replacing `set_fragment`'s
+  `&Value`; clearing SOURCE also clears DEPENDS). (#34)
+- `get_*_call(config, CallSelector)` (was `(config, id: i64)`); `delete_*_call_element(config,
+  CallSelector, element_code)` now derive `EXEC_ORDER` internally. Removed
+  `DeleteComparisonCallElementParams`, `DeleteDistinctCallElementParams`, `ExpressionCallElementKey`.
+  (#40)
+- `Add*Params` gained a public `id` field — exhaustive struct literals must add it; builder /
+  `..Default::default()` callers are unaffected. (#37)
+
+### Changed (breaking — behaviour/output; no signature change)
+
+- `add_data_source`/`add_attribute` now seed ids at 1000 (were unseeded `max+1`); a fresh data
+  source moves from `DSRC_ID 3` to `1000` and is no longer accidentally treated as a protected
+  low id. (#37)
+- List functions (`list_*_calls`, `list_generic_thresholds`, `list_rules`) now return rows in
+  SDK-owned sorted order; the three call lists with BOMs emit an `EXEC_ORDER`-ordered
+  `elementList`; `list_generic_thresholds` gained an `id`. Snapshot tests asserting the old stored
+  order will observe the change. (#41)
+- Not-found wording for standardize get/delete and comparison get gained `… does not exist`. (#42)
+- `set_rule` with an explicit empty-string fragment now stores `""` (was `NotFound`); the taken-id
+  message now includes the id. (#39)
+
+### Notes / follow-ups
+
+- FFI C ABI: no existing wrapper signature changed; the call-element delete redesign had no prior
+  C wrapper, so it is additive at the C level.
+- Deferred (own decision + tests): unify `add_feature`'s lenient inline `elementList`
+  DISPLAY_LEVEL/DERIVED handling onto the shared strict validators used by `add_element_to_feature`
+  and `set_feature_element`.
+
 ## [0.5.0] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ reviewed waves; every public-API and behavioural change is listed below. Test su
 from ~90 to 216 unit tests + 80 doc-tests (all green; clippy `-D warnings`, `cargo deny`,
 `cargo fmt` clean).
 
-> **Two parity assumptions to confirm against the Python `sz_configtool` reference** (both
-> one-line fixes if wrong, flagged because the reference is not in this repo): `list_rules`
-> default sort key (assumed `ERRULE_ID` ascending) and the A1-family slot in the
-> `BEHAVIOR_CODES` ordering (not present in the shipped template). The `LOCKED_FEATURES`
-> protected set below was ratified by the maintainer.
+> Both parity questions raised during review are now **verified** against the Python
+> `sz_configtool` reference (`/opt/senzing/er/bin/sz_configtool`, 4.4.0): `list_rules` sorts by
+> `ERRULE_ID` ascending (`do_listRules` `key=lambda k: k["ERRULE_ID"]`), and the `BEHAVIOR_CODES`
+> ordering — including the A1-family slot — is byte-identical to Python's `valid_behavior_codes`.
+> The `LOCKED_FEATURES` protected set was ratified by the maintainer.
 
 ### Fixed (correctness — some were silent data corruption)
 
@@ -107,14 +107,17 @@ from ~90 to 216 unit tests + 80 doc-tests (all green; clippy `-D warnings`, `car
 - Not-found wording for standardize get/delete and comparison get gained `… does not exist`. (#42)
 - `set_rule` with an explicit empty-string fragment now stores `""` (was `NotFound`); the taken-id
   message now includes the id. (#39)
+- `add_feature` now validates per-element `elementList` `DISPLAY_LEVEL` and `DERIVED` via the shared
+  strict validators (`elements::validate_display_level` / `validate_derived`): a negative display
+  level and an unknown `DERIVED` value in an element are now rejected rather than stored verbatim /
+  silently coerced to `"No"`. Unifies the last of the three DISPLAY_LEVEL/DERIVED code paths (D25).
 
-### Notes / follow-ups
+### Notes
 
 - FFI C ABI: no existing wrapper signature changed; the call-element delete redesign had no prior
   C wrapper, so it is additive at the C level.
-- Deferred (own decision + tests): unify `add_feature`'s lenient inline `elementList`
-  DISPLAY_LEVEL/DERIVED handling onto the shared strict validators used by `add_element_to_feature`
-  and `set_feature_element`.
+- No dependency changes in this release (`Cargo.toml`/`Cargo.lock` unchanged bar the version bump);
+  `cargo deny` posture is identical to 0.5.0.
 
 ## [0.5.0] - 2026-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/examples/feature_operations.rs
+++ b/examples/feature_operations.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         code: "EMAIL",
         description: Some("Email Address"),
         data_type: Some("string"),
+        id: None,
     };
 
     config = elements::add_element(&config, add_params)?;

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -642,6 +642,37 @@ struct SzConfigTool_result SzConfigTool_deleteExpressionFunctionCascade(const ch
 struct SzConfigTool_result SzConfigTool_deleteStandardizeFunctionCascade(const char *config_json,
                                                                          const char *sfunc_code);
 
+// Wave 4B additions (#40): by-feature call gets and code-addressed call-element deletes.
+//
+// Get the call bound to a feature (scans CFG_*CALL by FTYPE_ID). This replaces
+// the previous, incorrect practice of using the feature id directly as a call
+// id. Standardize/expression error if the feature has more than one such call
+// (address those by id via the existing get*Call functions).
+struct SzConfigTool_result SzConfigTool_getComparisonCallByFeature(const char *config_json,
+                                                                   const char *feature_code);
+struct SzConfigTool_result SzConfigTool_getDistinctCallByFeature(const char *config_json,
+                                                                 const char *feature_code);
+struct SzConfigTool_result SzConfigTool_getStandardizeCallByFeature(const char *config_json,
+                                                                    const char *feature_code);
+struct SzConfigTool_result SzConfigTool_getExpressionCallByFeature(const char *config_json,
+                                                                   const char *feature_code);
+
+// Delete a call element addressed by code; EXEC_ORDER is derived internally, so
+// (unlike the removed Rust exec_order argument) no execution order is passed.
+// NOTE: this is NEW FFI surface — there were no prior call-element delete
+// wrappers — so it does not break an existing ABI. Comparison/distinct address
+// the call by feature code (0-or-1 call per feature); expression addresses the
+// call by its EFCALL_ID because expression calls are many-per-feature.
+struct SzConfigTool_result SzConfigTool_deleteComparisonCallElement(const char *config_json,
+                                                                    const char *feature_code,
+                                                                    const char *element_code);
+struct SzConfigTool_result SzConfigTool_deleteDistinctCallElement(const char *config_json,
+                                                                  const char *feature_code,
+                                                                  const char *element_code);
+struct SzConfigTool_result SzConfigTool_deleteExpressionCallElement(const char *config_json,
+                                                                    int64_t efcall_id,
+                                                                    const char *element_code);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -675,6 +675,24 @@ struct SzConfigTool_result SzConfigTool_deleteExpressionCallElement(const char *
                                                                     int64_t efcall_id,
                                                                     const char *element_code);
 
+// Wave 6 additions (#42, #43): API-surface helpers. All additive.
+//
+// List behavior overrides in the resolved display shape: a JSON array of
+// { "feature", "usageType", "behavior" } objects, sorted by (FTYPE_ID,
+// UTYPE_CODE). Richer than SzConfigTool_listBehaviorOverrides (raw rows).
+struct SzConfigTool_result SzConfigTool_listBehaviorOverridesResolved(const char *config_json);
+
+// Validate the top-level structure of a config document (structure-only:
+// G2_CONFIG must be an object; any present CFG_* section must be an array).
+// Returns "OK" with return code 0 on success, or an error result otherwise.
+struct SzConfigTool_result SzConfigTool_validateConfig(const char *config_json);
+
+// Render a config document to its canonical export form: recursive object-key
+// sort (Python sort_keys=True semantics) then pretty-print at `indent` spaces
+// per level. `indent` is required; a negative value is treated as 0.
+struct SzConfigTool_result SzConfigTool_renderConfig(const char *config_json,
+                                                     int64_t indent);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -387,6 +387,8 @@ struct SzConfigTool_result SzConfigTool_verifyCompatibilityVersion(const char *c
 struct SzConfigTool_result SzConfigTool_addConfigSection(const char *config_json, const char *section_name, const char *section_json);
 struct SzConfigTool_result SzConfigTool_removeConfigSection(const char *config_json, const char *section_name);
 struct SzConfigTool_result SzConfigTool_getConfigSection(const char *config_json, const char *section_name, const char *filter_json);
+/* Returns JSON boolean "true"/"false": whether the section is empty (null or []); errors if the section is missing. */
+struct SzConfigTool_result SzConfigTool_configSectionIsEmpty(const char *config_json, const char *section_name);
 struct SzConfigTool_result SzConfigTool_listConfigSections(const char *config_json);
 struct SzConfigTool_result SzConfigTool_addConfigSectionField(const char *config_json, const char *section_name, const char *field_name, const char *field_value_json);
 struct SzConfigTool_result SzConfigTool_removeConfigSectionField(const char *config_json, const char *section_name, const char *field_name);

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -677,6 +677,9 @@ struct SzConfigTool_result SzConfigTool_deleteExpressionCallElement(const char *
 
 // Wave 6 additions (#42, #43): API-surface helpers. All additive.
 //
+// List behavior overrides as raw CFG_FBOVR rows (thin projection).
+struct SzConfigTool_result SzConfigTool_listBehaviorOverrides(const char *config_json);
+
 // List behavior overrides in the resolved display shape: a JSON array of
 // { "feature", "usageType", "behavior" } objects, sorted by (FTYPE_ID,
 // UTYPE_CODE). Richer than SzConfigTool_listBehaviorOverrides (raw rows).

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -615,6 +615,33 @@ struct SzConfigTool_result SzConfigTool_setScoringFunction(const char *config_js
                                                            const char *rtype_code,
                                                            const char *scoring_func);
 
+// Wave 4A additions (#38): feature-element mutators, settings, cascade deletes
+
+// Append a feature-element mapping (CFG_FBOM row). options_json may be NULL, or a
+// JSON object carrying displayLevel (int), displayDelim (string), derived (Yes/No).
+struct SzConfigTool_result SzConfigTool_addElementToFeature(const char *config_json,
+                                                            const char *feature_code,
+                                                            const char *element_code,
+                                                            const char *options_json);
+
+// Remove a single feature-element mapping (CFG_FBOM row).
+struct SzConfigTool_result SzConfigTool_deleteElementFromFeature(const char *config_json,
+                                                                 const char *feature_code,
+                                                                 const char *element_code);
+
+// Create or overwrite a named setting under G2_CONFIG.SETTINGS (name is uppercased).
+struct SzConfigTool_result SzConfigTool_setSetting(const char *config_json,
+                                                   const char *name,
+                                                   const char *value);
+
+// Delete a function and all of its dependent rows (cascade).
+struct SzConfigTool_result SzConfigTool_deleteComparisonFunctionCascade(const char *config_json,
+                                                                        const char *cfunc_code);
+struct SzConfigTool_result SzConfigTool_deleteExpressionFunctionCascade(const char *config_json,
+                                                                        const char *efunc_code);
+struct SzConfigTool_result SzConfigTool_deleteStandardizeFunctionCascade(const char *config_json,
+                                                                         const char *sfunc_code);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -364,6 +364,12 @@ struct SzConfigTool_result SzConfigTool_setScoringFunctionWithJson(const char *c
  * Batch 1-4: System, Generic Plans, Rules, Config Sections
  * ============================================================================ */
 
+/*
+ * Set/update a fragment from JSON. The updates object is tri-state per field
+ * (ERFRAG_SOURCE, ERFRAG_DESC): an absent key leaves the stored value untouched,
+ * an explicit JSON null clears it (writes null), and a string sets it. Clearing
+ * ERFRAG_SOURCE also clears ERFRAG_DEPENDS to null.
+ */
 struct SzConfigTool_result SzConfigTool_setFragmentWithJson(const char *config_json, const char *fragment_code, const char *updates_json);
 struct SzConfigTool_result SzConfigTool_cloneGenericPlan(const char *config_json, const char *source_code, const char *new_code, const char *new_desc);
 struct SzConfigTool_result SzConfigTool_setGenericPlan(const char *config_json, const char *gplan_code, const char *gplan_desc, const char *updates_json);
@@ -388,6 +394,12 @@ struct SzConfigTool_result SzConfigTool_addRule(const char *config_json, const c
 struct SzConfigTool_result SzConfigTool_deleteRule(const char *config_json, const char *rule_code);
 struct SzConfigTool_result SzConfigTool_getRule(const char *config_json, const char *code_or_id);
 struct SzConfigTool_result SzConfigTool_listRules(const char *config_json);
+/*
+ * Set/update a rule from JSON. The fragment, disqualifier and tier fields are
+ * tri-state: an absent key leaves the stored value untouched, an explicit JSON
+ * null clears the column (writes null), and a value sets it. (The direct-arg
+ * function wrappers below cannot express a null-clear; this JSON API can.)
+ */
 struct SzConfigTool_result SzConfigTool_setRule(const char *config_json, const char *rule_code, const char *rule_json);
 
 
@@ -395,11 +407,30 @@ struct SzConfigTool_result SzConfigTool_setRule(const char *config_json, const c
  * Comparison Function Operations (Batch 5c)
  * ============================================================================ */
 
+/* Direct-arg add: connect_str NULL stores JSON null; a non-null pointer
+ * (including "") stores that value. */
 struct SzConfigTool_result SzConfigTool_addComparisonFunction(const char *config_json, const char *cfunc_code, const char *connect_str, const char *cfunc_desc, const char *language, const char *anon_support);
 struct SzConfigTool_result SzConfigTool_deleteComparisonFunction(const char *config_json, const char *cfunc_code);
 struct SzConfigTool_result SzConfigTool_getComparisonFunction(const char *config_json, const char *cfunc_code);
 struct SzConfigTool_result SzConfigTool_listComparisonFunctions(const char *config_json);
+/* Direct-arg set: connect_str NULL leaves the stored value untouched; a non-null
+ * pointer (including "") sets it. This form cannot clear a value to null (use the
+ * JSON-based set API for that). */
 struct SzConfigTool_result SzConfigTool_setComparisonFunction(const char *config_json, const char *cfunc_code, const char *connect_str, const char *cfunc_desc, const char *language, const char *anon_support);
+
+/* ----------------------------------------------------------------------------
+ * Standardize / Expression Function Operations (direct-arg forms)
+ *
+ * Direct-arg add: connect_str NULL stores JSON null; a non-null pointer
+ *   (including "") stores that value.
+ * Direct-arg set: connect_str NULL leaves the stored value untouched; a non-null
+ *   pointer (including "") sets it. This form cannot clear a value to null (use
+ *   the JSON-based set API for that).
+ * ---------------------------------------------------------------------------- */
+struct SzConfigTool_result SzConfigTool_addStandardizeFunction(const char *config_json, const char *sfunc_code, const char *connect_str, const char *sfunc_desc, const char *language);
+struct SzConfigTool_result SzConfigTool_setStandardizeFunction(const char *config_json, const char *sfunc_code, const char *connect_str, const char *sfunc_desc, const char *language);
+struct SzConfigTool_result SzConfigTool_addExpressionFunction(const char *config_json, const char *efunc_code, const char *connect_str, const char *efunc_desc, const char *language);
+struct SzConfigTool_result SzConfigTool_setExpressionFunction(const char *config_json, const char *efunc_code, const char *connect_str, const char *efunc_desc, const char *language);
 
 /* ============================================================================
  * Standardize Call Operations (Batch 6a)
@@ -532,6 +563,8 @@ struct SzConfigTool_result SzConfigTool_setMatchingFunction(const char *config_j
                                                             const char *matching_func);
 
 // Distinct Function Operations (Batch 12)
+/* Direct-arg add: connect_str NULL stores JSON null; a non-null pointer
+ * (including "") stores that value. A blank connect_str is accepted. */
 struct SzConfigTool_result SzConfigTool_addDistinctFunction(const char *config_json,
                                                             const char *dfunc_code,
                                                             const char *connect_str,
@@ -540,6 +573,9 @@ struct SzConfigTool_result SzConfigTool_addDistinctFunction(const char *config_j
 struct SzConfigTool_result SzConfigTool_deleteDistinctFunction(const char *config_json, const char *dfunc_code);
 struct SzConfigTool_result SzConfigTool_getDistinctFunction(const char *config_json, const char *dfunc_code);
 struct SzConfigTool_result SzConfigTool_listDistinctFunctions(const char *config_json);
+/* Direct-arg set: connect_str NULL leaves the stored value untouched; a non-null
+ * pointer (including "") sets it. This form cannot clear a value to null (use the
+ * JSON-based set API for that). */
 struct SzConfigTool_result SzConfigTool_setDistinctFunction(const char *config_json,
                                                             const char *dfunc_code,
                                                             const char *connect_str,

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -61,6 +61,11 @@ struct AttrRow {
 // ============================================================================
 
 /// Parameters for adding an attribute
+///
+/// `id` is a caller-supplied `ATTR_ID`. Leave it `None` (or pass a non-positive
+/// value) to auto-assign the next free id (seeded at the user-range floor of
+/// 1000); pass `Some(id > 0)` to request that exact id — [`add_attribute`] then
+/// fails with `AlreadyExists` if it is already taken.
 #[derive(Debug, Clone)]
 pub struct AddAttributeParams<'a> {
     pub attribute: &'a str,
@@ -70,6 +75,7 @@ pub struct AddAttributeParams<'a> {
     pub default_value: Option<&'a str>,
     pub internal: Option<&'a str>,
     pub required: Option<&'a str>,
+    pub id: Option<i64>,
 }
 
 impl<'a> TryFrom<&'a Value> for AddAttributeParams<'a> {
@@ -96,6 +102,7 @@ impl<'a> TryFrom<&'a Value> for AddAttributeParams<'a> {
             default_value: json.get("default").and_then(|v| v.as_str()),
             internal: json.get("internal").and_then(|v| v.as_str()),
             required: json.get("required").and_then(|v| v.as_str()),
+            id: json.get("id").and_then(|v| v.as_i64()),
         })
     }
 }
@@ -213,8 +220,10 @@ pub fn add_attribute(config_json: &str, params: AddAttributeParams) -> Result<(S
         "No"
     };
 
-    // Get next ATTR_ID
-    let next_attr_id = helpers::get_next_id_from_array(attrs, "ATTR_ID")?;
+    // Get next ATTR_ID. Caller-supplied id (#37): None / non-positive ->
+    // auto-assign at the user-range floor of 1000; a specific id > 0 is honoured
+    // unless already taken (get_desired_or_next_id returns AlreadyExists).
+    let next_attr_id = helpers::get_desired_or_next_id(attrs, "ATTR_ID", params.id, 1000)?;
 
     // Build a complete row via AttrRow so every CFG_ATTR key is present
     // (the nullable DEFAULT_VALUE serializes as null) matching Python lines
@@ -431,6 +440,7 @@ mod tests {
             default_value: None,
             internal: None,
             required: None,
+            id: None,
         };
 
         let (modified, returned) = add_attribute(TEST_CONFIG, params).unwrap();
@@ -461,6 +471,7 @@ mod tests {
             default_value: Some("DFLT"),
             internal: Some("Yes"),
             required: Some("Desired"),
+            id: None,
         };
 
         let (modified, _returned) = add_attribute(TEST_CONFIG, params).unwrap();
@@ -471,5 +482,59 @@ mod tests {
         assert_eq!(attr["DEFAULT_VALUE"], json!("DFLT"));
         assert_eq!(attr["INTERNAL"], json!("Yes"));
         assert_eq!(attr["FELEM_REQ"], json!("Desired"));
+    }
+
+    fn add_params(id: Option<i64>) -> AddAttributeParams<'static> {
+        AddAttributeParams {
+            attribute: "my_attr",
+            feature: "NAME",
+            element: "FULL_NAME",
+            class: "NAME",
+            default_value: None,
+            internal: None,
+            required: None,
+            id,
+        }
+    }
+
+    #[test]
+    fn test_add_attribute_auto_id_seeds_1000() {
+        // D18: attributes now seed at ATTR_ID 1000, not max+1, on a stock config.
+        let config = r#"{
+            "G2_CONFIG": {
+                "CFG_ATTR": [{"ATTR_ID": 5, "ATTR_CODE": "EXISTING"}],
+                "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+                "CFG_FELEM": [{"FELEM_ID": 1, "FELEM_CODE": "FULL_NAME"}]
+            }
+        }"#;
+        let (modified, _) = add_attribute(config, add_params(None)).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let attr = value["G2_CONFIG"]["CFG_ATTR"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(attr["ATTR_ID"], json!(1000));
+    }
+
+    #[test]
+    fn test_add_attribute_specific_id_honoured() {
+        let (modified, _) = add_attribute(TEST_CONFIG, add_params(Some(2500))).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let attr = &value["G2_CONFIG"]["CFG_ATTR"][0];
+        assert_eq!(attr["ATTR_ID"], json!(2500));
+    }
+
+    #[test]
+    fn test_add_attribute_taken_id_rejected() {
+        let config = r#"{
+            "G2_CONFIG": {
+                "CFG_ATTR": [{"ATTR_ID": 2500, "ATTR_CODE": "OTHER"}],
+                "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+                "CFG_FELEM": [{"FELEM_ID": 1, "FELEM_CODE": "FULL_NAME"}]
+            }
+        }"#;
+        let err = add_attribute(config, add_params(Some(2500))).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -3,6 +3,29 @@ use crate::helpers;
 use serde::Serialize;
 use serde_json::{Value, json};
 
+/// Canonical set of valid attribute classes (`ATTR_CLASS`).
+///
+/// An attribute's class must be one of these values. This is the single source
+/// of truth used by [`add_attribute`] to validate the `class` parameter.
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::attributes::ATTRIBUTE_CLASSES;
+///
+/// assert!(ATTRIBUTE_CLASSES.contains(&"IDENTIFIER"));
+/// assert!(!ATTRIBUTE_CLASSES.contains(&"NOT_A_CLASS"));
+/// ```
+pub const ATTRIBUTE_CLASSES: &[&str] = &[
+    "NAME",
+    "ATTRIBUTE",
+    "IDENTIFIER",
+    "ADDRESS",
+    "PHONE",
+    "RELATIONSHIP",
+    "OTHER",
+];
+
 // ============================================================================
 // Row Structs
 // ============================================================================
@@ -122,20 +145,11 @@ pub fn add_attribute(config_json: &str, params: AddAttributeParams) -> Result<(S
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     // Validate attribute class (matches Python line 173-181)
-    let valid_classes = [
-        "NAME",
-        "ATTRIBUTE",
-        "IDENTIFIER",
-        "ADDRESS",
-        "PHONE",
-        "RELATIONSHIP",
-        "OTHER",
-    ];
-    if !valid_classes.contains(&params.class) {
+    if !ATTRIBUTE_CLASSES.contains(&params.class) {
         return Err(SzConfigError::InvalidInput(format!(
             "Invalid attribute class '{}'. Must be one of: {}",
             params.class,
-            valid_classes.join(", ")
+            ATTRIBUTE_CLASSES.join(", ")
         )));
     }
 

--- a/src/behavior_domain.rs
+++ b/src/behavior_domain.rs
@@ -1,0 +1,263 @@
+//! Canonical behaviour-code domain.
+//!
+//! A feature's *behaviour* is encoded as a short code combining a frequency
+//! (`A1`, `F1`, `FF`, `FM`, `FVM`, plus the special `NAME` and `NONE`) with
+//! optional `E` (exclusivity) and `S` (stability) suffixes. This module is the
+//! single home for that domain:
+//!
+//! - [`BEHAVIOR_CODES`] — the canonical **ordered** list of the 17 recognised
+//!   behaviour codes, used as the sort key for behaviour-ordered listings.
+//! - [`parse_behavior_code`] — split a code into `(frequency, exclusivity, stability)`.
+//! - [`compute_behavior`] — reconstruct a code from a `CFG_FTYPE` row.
+//! - [`behavior_position`] — index of a code within [`BEHAVIOR_CODES`].
+//!
+//! Historically `parse_behavior_code`/`compute_behavior` existed as two
+//! byte-identical private copies (in `features.rs` and `behavior_overrides.rs`).
+//! They now live here once and both modules delegate to these functions.
+
+use crate::error::{Result, SzConfigError};
+use serde_json::Value;
+
+/// Canonical, ordered list of the 17 recognised behaviour codes.
+///
+/// The order is the authoritative Senzing display/sort order: the special
+/// `NAME` first, then each frequency (`A1`, `F1`, `FF`, `FM`, `FVM`) with its
+/// plain / `E` / `ES` variants, and finally `NONE`. This ordering is the sort
+/// key for behaviour-ordered listings (e.g. generic thresholds).
+///
+/// Note that this is the canonical *display* domain: [`parse_behavior_code`]
+/// accepts a slightly broader input set (for example a bare `S` suffix), but
+/// only the codes listed here participate in ordering.
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::behavior_domain::BEHAVIOR_CODES;
+///
+/// assert_eq!(BEHAVIOR_CODES.len(), 17);
+/// assert_eq!(BEHAVIOR_CODES[0], "NAME");
+/// assert_eq!(BEHAVIOR_CODES[BEHAVIOR_CODES.len() - 1], "NONE");
+/// ```
+pub const BEHAVIOR_CODES: &[&str] = &[
+    "NAME", "A1", "A1E", "A1ES", "F1", "F1E", "F1ES", "FF", "FFE", "FFES", "FM", "FME", "FMES",
+    "FVM", "FVME", "FVMES", "NONE",
+];
+
+/// Parse a behaviour code string into `(frequency, exclusivity, stability)`.
+///
+/// The frequency must be one of `A1`, `F1`, `FF`, `FM`, `FVM`, `NONE`, `NAME`
+/// (case-insensitive). An `E` suffix sets exclusivity to `"Yes"` and an `S`
+/// suffix sets stability to `"Yes"`; the special codes `NAME` and `NONE` do not
+/// take suffixes. Exclusivity and stability default to `"No"`.
+///
+/// # Arguments
+/// * `behavior` - Behaviour code (e.g. `"FM"`, `"F1E"`, `"F1ES"`, `"NAME"`)
+///
+/// # Returns
+/// * `Ok((frequency, exclusivity, stability))` on success
+/// * `Err(SzConfigError::InvalidInput)` if the frequency code is not recognised
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::behavior_domain::parse_behavior_code;
+///
+/// assert_eq!(parse_behavior_code("F1ES").unwrap(), ("F1", "Yes", "Yes"));
+/// assert_eq!(parse_behavior_code("fm").unwrap(), ("FM", "No", "No"));
+/// assert_eq!(parse_behavior_code("NAME").unwrap(), ("NAME", "No", "No"));
+/// assert!(parse_behavior_code("BOGUS").is_err());
+/// ```
+pub fn parse_behavior_code(behavior: &str) -> Result<(&'static str, &'static str, &'static str)> {
+    let mut code = behavior.to_uppercase();
+    let mut exclusivity = "No";
+    let mut stability = "No";
+
+    // Special cases that don't get E/S parsing
+    if code != "NAME" && code != "NONE" {
+        if code.contains('E') {
+            exclusivity = "Yes";
+            code = code.replace('E', "");
+        }
+        if code.contains('S') {
+            stability = "Yes";
+            code = code.replace('S', "");
+        }
+    }
+
+    // Validate frequency code
+    let frequency: &'static str = match code.as_str() {
+        "A1" => "A1",
+        "F1" => "F1",
+        "FF" => "FF",
+        "FM" => "FM",
+        "FVM" => "FVM",
+        "NONE" => "NONE",
+        "NAME" => "NAME",
+        _ => {
+            return Err(SzConfigError::InvalidInput(format!(
+                "Invalid behavior code '{behavior}'. Valid codes: A1, F1, FF, FM, FVM, NONE, NAME (with optional E/S suffixes)"
+            )));
+        }
+    };
+
+    Ok((frequency, exclusivity, stability))
+}
+
+/// Reconstruct a behaviour code from a `CFG_FTYPE` row.
+///
+/// Reads `FTYPE_FREQ`, `FTYPE_EXCL` and `FTYPE_STAB` from the row and appends
+/// `E` and/or `S` when exclusivity / stability are truthy. A value is truthy
+/// when it is `"Y"`, `"1"` or `"YES"` (case-insensitive).
+///
+/// # Arguments
+/// * `ftype` - A `CFG_FTYPE` row as a JSON object
+///
+/// # Returns
+/// The behaviour code string (e.g. `"F1ES"`).
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::behavior_domain::compute_behavior;
+///
+/// let ftype = json!({"FTYPE_FREQ": "F1", "FTYPE_EXCL": "Yes", "FTYPE_STAB": "No"});
+/// assert_eq!(compute_behavior(&ftype), "F1E");
+/// ```
+pub fn compute_behavior(ftype: &Value) -> String {
+    let freq = ftype["FTYPE_FREQ"].as_str().unwrap_or("");
+    let excl = ftype["FTYPE_EXCL"].as_str().unwrap_or("");
+    let stab = ftype["FTYPE_STAB"].as_str().unwrap_or("");
+
+    let mut behavior = freq.to_string();
+    if excl.to_uppercase() == "Y" || excl == "1" || excl.to_uppercase() == "YES" {
+        behavior.push('E');
+    }
+    if stab.to_uppercase() == "Y" || stab == "1" || stab.to_uppercase() == "YES" {
+        behavior.push('S');
+    }
+    behavior
+}
+
+/// Return the position of a behaviour code within [`BEHAVIOR_CODES`].
+///
+/// The comparison is case-insensitive. Returns `None` if `behavior` is not one
+/// of the canonical ordered codes (even if it is otherwise parseable, such as a
+/// bare `S`-suffixed code). Use this as a sort key for behaviour-ordered lists.
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::behavior_domain::behavior_position;
+///
+/// assert_eq!(behavior_position("NAME"), Some(0));
+/// assert!(behavior_position("F1E").unwrap() < behavior_position("FF").unwrap());
+/// assert_eq!(behavior_position("nonsense"), None);
+/// ```
+pub fn behavior_position(behavior: &str) -> Option<usize> {
+    BEHAVIOR_CODES
+        .iter()
+        .position(|c| c.eq_ignore_ascii_case(behavior))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_behavior_codes_ordered_and_sized() {
+        assert_eq!(BEHAVIOR_CODES.len(), 17);
+        assert_eq!(BEHAVIOR_CODES[0], "NAME");
+        assert_eq!(*BEHAVIOR_CODES.last().unwrap(), "NONE");
+        // Strictly increasing positions (no duplicates, monotonic).
+        for (i, code) in BEHAVIOR_CODES.iter().enumerate() {
+            assert_eq!(behavior_position(code), Some(i));
+        }
+    }
+
+    #[test]
+    fn test_parse_behavior_code_frequencies() {
+        assert_eq!(parse_behavior_code("A1").unwrap(), ("A1", "No", "No"));
+        assert_eq!(parse_behavior_code("F1").unwrap(), ("F1", "No", "No"));
+        assert_eq!(parse_behavior_code("FF").unwrap(), ("FF", "No", "No"));
+        assert_eq!(parse_behavior_code("FM").unwrap(), ("FM", "No", "No"));
+        assert_eq!(parse_behavior_code("FVM").unwrap(), ("FVM", "No", "No"));
+    }
+
+    #[test]
+    fn test_parse_behavior_code_suffixes() {
+        assert_eq!(parse_behavior_code("F1E").unwrap(), ("F1", "Yes", "No"));
+        assert_eq!(parse_behavior_code("F1S").unwrap(), ("F1", "No", "Yes"));
+        assert_eq!(parse_behavior_code("F1ES").unwrap(), ("F1", "Yes", "Yes"));
+        // Order of suffix letters does not matter.
+        assert_eq!(parse_behavior_code("F1SE").unwrap(), ("F1", "Yes", "Yes"));
+    }
+
+    #[test]
+    fn test_parse_behavior_code_lowercase() {
+        assert_eq!(parse_behavior_code("f1es").unwrap(), ("F1", "Yes", "Yes"));
+        assert_eq!(parse_behavior_code("fvm").unwrap(), ("FVM", "No", "No"));
+    }
+
+    #[test]
+    fn test_parse_behavior_code_name_and_none() {
+        assert_eq!(parse_behavior_code("NAME").unwrap(), ("NAME", "No", "No"));
+        assert_eq!(parse_behavior_code("name").unwrap(), ("NAME", "No", "No"));
+        assert_eq!(parse_behavior_code("NONE").unwrap(), ("NONE", "No", "No"));
+        // NAME/NONE do not undergo E/S stripping.
+        assert_eq!(parse_behavior_code("NONE").unwrap().1, "No");
+    }
+
+    #[test]
+    fn test_parse_behavior_code_invalid() {
+        let err = parse_behavior_code("BOGUS").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Invalid behavior code 'BOGUS'"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_compute_behavior_variants() {
+        assert_eq!(
+            compute_behavior(&json!({"FTYPE_FREQ": "F1", "FTYPE_EXCL": "No", "FTYPE_STAB": "No"})),
+            "F1"
+        );
+        assert_eq!(
+            compute_behavior(&json!({"FTYPE_FREQ": "F1", "FTYPE_EXCL": "Yes", "FTYPE_STAB": "No"})),
+            "F1E"
+        );
+        assert_eq!(
+            compute_behavior(
+                &json!({"FTYPE_FREQ": "FVM", "FTYPE_EXCL": "Yes", "FTYPE_STAB": "Yes"})
+            ),
+            "FVMES"
+        );
+        // Truthy variants: Y / 1 / YES (case-insensitive).
+        assert_eq!(
+            compute_behavior(&json!({"FTYPE_FREQ": "A1", "FTYPE_EXCL": "y", "FTYPE_STAB": "1"})),
+            "A1ES"
+        );
+    }
+
+    /// The two former private copies of these functions (features.rs and
+    /// behavior_overrides.rs) were byte-identical. This asserts the single
+    /// shared copy round-trips every canonical code, standing in for the
+    /// "collapsed copies still agree" guarantee.
+    #[test]
+    fn test_compute_behavior_roundtrips_full_domain() {
+        for code in BEHAVIOR_CODES {
+            let (freq, excl, stab) = parse_behavior_code(code).unwrap();
+            let ftype = json!({
+                "FTYPE_FREQ": freq,
+                "FTYPE_EXCL": excl,
+                "FTYPE_STAB": stab,
+            });
+            // NAME/NONE compute back to themselves (no suffixes emitted).
+            assert_eq!(
+                &compute_behavior(&ftype),
+                code,
+                "round-trip failed for {code}"
+            );
+        }
+    }
+}

--- a/src/behavior_domain.rs
+++ b/src/behavior_domain.rs
@@ -25,6 +25,11 @@ use serde_json::Value;
 /// plain / `E` / `ES` variants, and finally `NONE`. This ordering is the sort
 /// key for behaviour-ordered listings (e.g. generic thresholds).
 ///
+/// Verified byte-for-byte against the Python `sz_configtool` reference
+/// (`/opt/senzing/er/bin/sz_configtool`, 4.4.0) `self.valid_behavior_codes`,
+/// which is the exact list used by its own generic-threshold sort
+/// (`valid_behavior_codes.index(BEHAVIOR)`).
+///
 /// Note that this is the canonical *display* domain: [`parse_behavior_code`]
 /// accepts a slightly broader input set (for example a bare `S` suffix), but
 /// only the codes listed here participate in ordering.

--- a/src/behavior_overrides.rs
+++ b/src/behavior_overrides.rs
@@ -4,11 +4,12 @@
 //! Overrides allow different behavior codes for features depending on context
 //! (e.g., BUSINESS vs MOBILE usage).
 
-use crate::behavior_domain::parse_behavior_code;
+use crate::behavior_domain::{compute_behavior, parse_behavior_code};
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashMap;
 
 // ============================================================================
 // Row Structs
@@ -233,6 +234,123 @@ pub fn list_behavior_overrides(config_json: &str) -> Result<Vec<Value>> {
     Ok(result)
 }
 
+/// Display-shaped, fully resolved behaviour override row.
+///
+/// Unlike the raw `CFG_FBOVR` rows returned by [`list_behavior_overrides`],
+/// this carries the human-readable feature code (resolved from `FTYPE_ID`) and
+/// the composed behaviour code (via [`compute_behavior`]) rather than the raw
+/// `FTYPE_FREQ`/`FTYPE_EXCL`/`FTYPE_STAB` triple. It serialises to the display
+/// JSON shape `{ "feature", "usageType", "behavior" }`.
+#[derive(Debug, Clone, Serialize)]
+struct BehaviorOverrideDisplay {
+    feature: String,
+    #[serde(rename = "usageType")]
+    usage_type: String,
+    behavior: String,
+}
+
+/// List all behavior overrides in a display-ready, resolved shape.
+///
+/// This is the richer counterpart to [`list_behavior_overrides`]. Each returned
+/// value has the shape `{ "feature", "usageType", "behavior" }`, where:
+///
+/// - `feature` is the feature code resolved from the row's `FTYPE_ID`,
+/// - `usageType` is the row's `UTYPE_CODE`,
+/// - `behavior` is the composed behaviour code (frequency plus `E`/`S`
+///   suffixes) produced by [`compute_behavior`].
+///
+/// Rows are sorted by `(FTYPE_ID, UTYPE_CODE)` — the numeric feature id first,
+/// then the usage-type code as a tiebreak — which is the ordering the CLI's
+/// `listBehaviorOverrides` display expects and which [`list_behavior_overrides`]
+/// (sorted by `FTYPE_ID` only) cannot provide.
+///
+/// A row whose `FTYPE_ID` has no matching `CFG_FTYPE` entry falls back to the
+/// numeric id rendered as a string for its `feature` field, so malformed
+/// configs still list rather than error.
+///
+/// # Arguments
+/// * `config_json` - Configuration JSON string
+///
+/// # Returns
+/// Vector of resolved override values, sorted by `(FTYPE_ID, UTYPE_CODE)`.
+///
+/// # Errors
+/// - `JsonParse` if `config_json` is not valid JSON
+/// - `MissingSection` if `CFG_FBOVR` is absent
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::behavior_overrides::list_behavior_overrides_resolved;
+/// let config = r#"{"G2_CONFIG":{
+///     "CFG_FTYPE":[{"FTYPE_ID":3,"FTYPE_CODE":"ADDRESS"}],
+///     "CFG_FBOVR":[{"FTYPE_ID":3,"UTYPE_CODE":"HOME",
+///                   "FTYPE_FREQ":"FF","FTYPE_EXCL":"Yes","FTYPE_STAB":"No"}]
+/// }}"#;
+/// let rows = list_behavior_overrides_resolved(config)?;
+/// assert_eq!(rows[0]["feature"], "ADDRESS");
+/// assert_eq!(rows[0]["usageType"], "HOME");
+/// assert_eq!(rows[0]["behavior"], "FFE");
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn list_behavior_overrides_resolved(config_json: &str) -> Result<Vec<Value>> {
+    let config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let g2 = config
+        .get("G2_CONFIG")
+        .ok_or_else(|| SzConfigError::MissingSection("G2_CONFIG".to_string()))?;
+
+    // Build an FTYPE_ID -> FTYPE_CODE resolution map from CFG_FTYPE.
+    let mut ftype_codes: HashMap<i64, String> = HashMap::new();
+    if let Some(ftypes) = g2.get("CFG_FTYPE").and_then(|v| v.as_array()) {
+        for ftype in ftypes {
+            if let (Some(id), Some(code)) = (
+                ftype.get("FTYPE_ID").and_then(|v| v.as_i64()),
+                ftype.get("FTYPE_CODE").and_then(|v| v.as_str()),
+            ) {
+                ftype_codes.insert(id, code.to_string());
+            }
+        }
+    }
+
+    let fbovr_array = g2
+        .get("CFG_FBOVR")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| SzConfigError::MissingSection("CFG_FBOVR".to_string()))?;
+
+    // Collect (ftype_id, utype_code, display) so we can sort by the raw keys
+    // before projecting away FTYPE_ID.
+    let mut rows: Vec<(i64, String, BehaviorOverrideDisplay)> =
+        Vec::with_capacity(fbovr_array.len());
+    for item in fbovr_array {
+        let ftype_id = item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0);
+        let utype_code = item
+            .get("UTYPE_CODE")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let feature = ftype_codes
+            .get(&ftype_id)
+            .cloned()
+            .unwrap_or_else(|| ftype_id.to_string());
+        let display = BehaviorOverrideDisplay {
+            feature,
+            usage_type: utype_code.clone(),
+            behavior: compute_behavior(item),
+        };
+        rows.push((ftype_id, utype_code, display));
+    }
+
+    // Sort by (FTYPE_ID, UTYPE_CODE).
+    rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    rows.into_iter()
+        .map(|(_, _, display)| {
+            serde_json::to_value(&display).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,6 +477,73 @@ mod tests {
         assert_eq!(freq, "NAME");
         assert_eq!(excl, "No");
         assert_eq!(stab, "No");
+    }
+
+    #[test]
+    fn test_list_behavior_overrides_resolved_projection_and_sort() {
+        // Fixture deliberately ordered so a FTYPE_ID-only sort differs from the
+        // required (FTYPE_ID, UTYPE_CODE) sort: feature 3 has two usage types
+        // stored MOBILE-before-BUSINESS, and feature 1 is stored last.
+        let config = json!({
+            "G2_CONFIG": {
+                "CFG_FTYPE": [
+                    {"FTYPE_ID": 3, "FTYPE_CODE": "ADDRESS"},
+                    {"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}
+                ],
+                "CFG_FBOVR": [
+                    {"FTYPE_ID": 3, "UTYPE_CODE": "MOBILE",
+                     "FTYPE_FREQ": "FF", "FTYPE_EXCL": "Yes", "FTYPE_STAB": "No"},
+                    {"FTYPE_ID": 3, "UTYPE_CODE": "BUSINESS",
+                     "FTYPE_FREQ": "F1", "FTYPE_EXCL": "No", "FTYPE_STAB": "Yes"},
+                    {"FTYPE_ID": 1, "UTYPE_CODE": "PRIMARY",
+                     "FTYPE_FREQ": "NAME", "FTYPE_EXCL": "No", "FTYPE_STAB": "No"}
+                ]
+            }
+        })
+        .to_string();
+
+        let rows = list_behavior_overrides_resolved(&config).expect("resolved list");
+        assert_eq!(rows.len(), 3);
+
+        // Expected order: (1,PRIMARY), (3,BUSINESS), (3,MOBILE).
+        assert_eq!(rows[0]["feature"], "NAME");
+        assert_eq!(rows[0]["usageType"], "PRIMARY");
+        assert_eq!(rows[0]["behavior"], "NAME");
+
+        assert_eq!(rows[1]["feature"], "ADDRESS");
+        assert_eq!(rows[1]["usageType"], "BUSINESS");
+        assert_eq!(rows[1]["behavior"], "F1S");
+
+        assert_eq!(rows[2]["feature"], "ADDRESS");
+        assert_eq!(rows[2]["usageType"], "MOBILE");
+        assert_eq!(rows[2]["behavior"], "FFE");
+
+        // Projection is exactly the display shape: feature, usageType, behavior.
+        for row in &rows {
+            let obj = row.as_object().unwrap();
+            assert_eq!(obj.len(), 3);
+            assert!(obj.contains_key("feature"));
+            assert!(obj.contains_key("usageType"));
+            assert!(obj.contains_key("behavior"));
+        }
+    }
+
+    #[test]
+    fn test_list_behavior_overrides_resolved_unknown_ftype_falls_back_to_id() {
+        let config = json!({
+            "G2_CONFIG": {
+                "CFG_FTYPE": [],
+                "CFG_FBOVR": [
+                    {"FTYPE_ID": 99, "UTYPE_CODE": "X",
+                     "FTYPE_FREQ": "F1", "FTYPE_EXCL": "No", "FTYPE_STAB": "No"}
+                ]
+            }
+        })
+        .to_string();
+
+        let rows = list_behavior_overrides_resolved(&config).expect("resolved list");
+        assert_eq!(rows[0]["feature"], "99");
+        assert_eq!(rows[0]["behavior"], "F1");
     }
 
     #[test]

--- a/src/behavior_overrides.rs
+++ b/src/behavior_overrides.rs
@@ -4,6 +4,7 @@
 //! Overrides allow different behavior codes for features depending on context
 //! (e.g., BUSINESS vs MOBILE usage).
 
+use crate::behavior_domain::parse_behavior_code;
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
 use serde::Serialize;
@@ -230,56 +231,6 @@ pub fn list_behavior_overrides(config_json: &str) -> Result<Vec<Value>> {
     result.sort_by_key(|item| item["FTYPE_ID"].as_i64().unwrap_or(0));
 
     Ok(result)
-}
-
-/// Parse a behavior code string into (frequency, exclusivity, stability)
-///
-/// Valid frequency codes: A1, F1, FF, FM, FVM, NONE, NAME
-/// E suffix means EXCLUSIVITY = "Yes"
-/// S suffix means STABILITY = "Yes"
-///
-/// # Arguments
-/// * `behavior` - Behavior code (e.g., "FM", "F1E", "F1ES", "NAME")
-///
-/// # Returns
-/// Tuple of (frequency, exclusivity, stability)
-///
-/// # Errors
-/// - `InvalidInput` if behavior code is invalid
-fn parse_behavior_code(behavior: &str) -> Result<(&'static str, &'static str, &'static str)> {
-    let mut code = behavior.to_uppercase();
-    let mut exclusivity = "No";
-    let mut stability = "No";
-
-    // Special cases that don't get E/S parsing
-    if code != "NAME" && code != "NONE" {
-        if code.contains('E') {
-            exclusivity = "Yes";
-            code = code.replace('E', "");
-        }
-        if code.contains('S') {
-            stability = "Yes";
-            code = code.replace('S', "");
-        }
-    }
-
-    // Validate frequency code
-    let frequency: &'static str = match code.as_str() {
-        "A1" => "A1",
-        "F1" => "F1",
-        "FF" => "FF",
-        "FM" => "FM",
-        "FVM" => "FVM",
-        "NONE" => "NONE",
-        "NAME" => "NAME",
-        _ => {
-            return Err(SzConfigError::InvalidInput(format!(
-                "Invalid behavior code '{behavior}'. Valid codes: A1, F1, FF, FM, FVM, NONE, NAME (with optional E/S suffixes)"
-            )));
-        }
-    };
-
-    Ok((frequency, exclusivity, stability))
 }
 
 #[cfg(test)]

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -6,7 +6,8 @@
 use crate::config_rows::{CfbomRow, CfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
-    find_in_config_array, get_next_id, lookup_cfunc_id, lookup_element_id, lookup_feature_id,
+    find_in_config_array, get_desired_or_next_id_from_section, lookup_cfunc_id, lookup_element_id,
+    lookup_feature_id,
 };
 use serde_json::{Value, json};
 
@@ -15,11 +16,17 @@ use serde_json::{Value, json};
 // ============================================================================
 
 /// Parameters for adding a comparison call
-#[derive(Debug, Clone)]
+///
+/// `id` is a caller-supplied `CFCALL_ID`. Leave it `None` (or pass a
+/// non-positive value) to auto-assign the next free id (seeded at the user-range
+/// floor of 1000); pass `Some(id > 0)` to request that exact id —
+/// [`add_comparison_call`] then fails with `AlreadyExists` if it is already taken.
+#[derive(Debug, Clone, Default)]
 pub struct AddComparisonCallParams {
     pub ftype_code: String,
     pub cfunc_code: String,
     pub element_list: Vec<String>,
+    pub id: Option<i64>,
 }
 
 impl TryFrom<&Value> for AddComparisonCallParams {
@@ -46,6 +53,7 @@ impl TryFrom<&Value> for AddComparisonCallParams {
                         .collect()
                 })
                 .unwrap_or_default(),
+            id: json.get("id").and_then(|v| v.as_i64()),
         })
     }
 }
@@ -147,8 +155,16 @@ pub fn add_comparison_call(
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    // Get next CFCALL_ID (seed at 1000 for user-created calls)
-    let cfcall_id = get_next_id(&config_data, "G2_CONFIG.CFG_CFCALL", "CFCALL_ID", 1000)?;
+    // Get next CFCALL_ID (seed at 1000 for user-created calls). Caller-supplied
+    // id (#37): None/non-positive auto-assigns; a specific id > 0 is honoured
+    // unless already taken (returns AlreadyExists).
+    let cfcall_id = get_desired_or_next_id_from_section(
+        &config_data,
+        "G2_CONFIG.CFG_CFCALL",
+        "CFCALL_ID",
+        params.id,
+        1000,
+    )?;
 
     // Lookup feature ID
     let ftype_id = lookup_feature_id(config, &params.ftype_code)?;
@@ -547,6 +563,7 @@ mod tests {
             ftype_code: "NAME".to_string(),
             cfunc_code: "GNR_COMP".to_string(),
             element_list: vec!["FIRST_NAME".to_string()],
+            id: None,
         };
 
         let (modified, new_record) = add_comparison_call(&config, params).unwrap();
@@ -558,6 +575,8 @@ mod tests {
         assert!(!cfcall.as_object().unwrap().contains_key("EXEC_ORDER"));
         assert_eq!(cfcall["FTYPE_ID"], json!(5));
         assert_eq!(cfcall["CFUNC_ID"], json!(7));
+        // Auto-assigned CFCALL_ID seeds at 1000.
+        assert_eq!(cfcall["CFCALL_ID"], json!(1000));
         assert_all_keys(&new_record, &CFCALL_KEYS);
 
         // CFG_CFBOM row: all 4 keys.
@@ -584,5 +603,41 @@ mod tests {
         assert_all_keys(cfbom, &CFBOM_KEYS);
         assert_all_keys(&new_record, &CFBOM_KEYS);
         assert_eq!(cfbom["EXEC_ORDER"], json!(2));
+    }
+
+    #[test]
+    fn test_add_comparison_call_specific_and_taken_id() {
+        let config = base_config();
+        // Specific free id honoured.
+        let params = AddComparisonCallParams {
+            ftype_code: "NAME".to_string(),
+            cfunc_code: "GNR_COMP".to_string(),
+            element_list: vec!["FIRST_NAME".to_string()],
+            id: Some(2500),
+        };
+        let (modified, _) = add_comparison_call(&config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(
+            value["G2_CONFIG"]["CFG_CFCALL"][0]["CFCALL_ID"],
+            json!(2500)
+        );
+
+        // A taken id is rejected (config already carries CFCALL_ID 2500).
+        let cfg = json!({"G2_CONFIG": {
+            "CFG_CFCALL": [{"CFCALL_ID": 2500, "FTYPE_ID": 9, "CFUNC_ID": 7}],
+            "CFG_CFBOM": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_CFUNC": [{"CFUNC_ID": 7, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}]
+        }})
+        .to_string();
+        let params = AddComparisonCallParams {
+            ftype_code: "NAME".to_string(),
+            cfunc_code: "GNR_COMP".to_string(),
+            element_list: vec!["FIRST_NAME".to_string()],
+            id: Some(2500),
+        };
+        let err = add_comparison_call(&cfg, params).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 }

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -330,7 +330,9 @@ pub fn get_comparison_call(config: &str, selector: CallSelector) -> Result<Value
                 .find(|c| c.get("CFCALL_ID").and_then(|v| v.as_i64()) == Some(cfcall_id))
         })
         .cloned()
-        .ok_or_else(|| SzConfigError::NotFound(format!("Comparison call ID {cfcall_id}")))
+        .ok_or_else(|| {
+            SzConfigError::NotFound(format!("Comparison call ID {cfcall_id} does not exist"))
+        })
 }
 
 /// List all comparison calls with resolved names
@@ -784,6 +786,16 @@ mod tests {
         let config = populated_config();
         assert!(get_comparison_call(&config, CallSelector::Id(999)).is_err());
         assert!(get_comparison_call(&config, CallSelector::Feature("PHONE")).is_err());
+    }
+
+    // #42: get-by-id not-found now carries the canonical
+    // "{X} call ID {id} does not exist" wording, matching delete and the
+    // other call families.
+    #[test]
+    fn test_get_comparison_call_not_found_message() {
+        let config = populated_config();
+        let err = get_comparison_call(&config, CallSelector::Id(999)).unwrap_err();
+        assert_eq!(err.to_string(), "Comparison call ID 999 does not exist");
     }
 
     #[test]

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -3,11 +3,12 @@
 //! Functions for managing CFG_CFCALL (comparison calls) and CFG_CFBOM
 //! (comparison bill of materials) configuration sections.
 
+use crate::calls::{CallSelector, derive_bom_exec_order, resolve_call_id};
 use crate::config_rows::{CfbomRow, CfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
-    find_in_config_array, get_desired_or_next_id_from_section, lookup_cfunc_id, lookup_element_id,
-    lookup_feature_id,
+    get_desired_or_next_id_from_section, lookup_cfunc_id, lookup_element_id, lookup_feature_id,
+    resolve_cfcall_id_for_feature,
 };
 use serde_json::{Value, json};
 
@@ -90,14 +91,6 @@ impl TryFrom<&Value> for AddComparisonCallElementParams {
                 .ok_or_else(|| SzConfigError::MissingField("execOrder".to_string()))?,
         })
     }
-}
-
-/// Parameters for deleting a comparison call element
-#[derive(Debug, Clone)]
-pub struct DeleteComparisonCallElementParams {
-    pub ftype_id: i64,
-    pub felem_id: i64,
-    pub exec_order: i64,
 }
 
 /// Parameters for setting (updating) a comparison call
@@ -293,19 +286,50 @@ pub fn delete_comparison_call(config: &str, cfcall_id: i64) -> Result<String> {
     serde_json::to_string(&config_data).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
 
-/// Get a single comparison call by ID
+/// Get a single comparison call, addressed by id or by feature code.
+///
+/// Pass [`CallSelector::Id`] to look the call up by its `CFCALL_ID`, or
+/// [`CallSelector::Feature`] to resolve the (0-or-1) comparison call bound to a
+/// feature. The feature path scans `CFG_CFCALL` by `FTYPE_ID` via
+/// [`resolve_cfcall_id_for_feature`] rather than treating the feature id as a
+/// call id.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `cfcall_id` - Comparison call ID
+/// * `selector` - Call id or feature code identifying the call
 ///
 /// # Returns
 /// JSON Value representing the comparison call record
 ///
 /// # Errors
-/// - `NotFound` if call ID doesn't exist
-pub fn get_comparison_call(config: &str, cfcall_id: i64) -> Result<Value> {
-    find_in_config_array(config, "CFG_CFCALL", "CFCALL_ID", &cfcall_id.to_string())?
+/// - `NotFound` if no matching call exists
+/// - `InvalidInput` if a feature code matches more than one call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::comparison::get_comparison_call;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}]
+/// }}"#;
+/// let by_id = get_comparison_call(config, CallSelector::Id(7)).unwrap();
+/// let by_feature = get_comparison_call(config, CallSelector::Feature("NAME")).unwrap();
+/// assert_eq!(by_id, by_feature);
+/// ```
+pub fn get_comparison_call(config: &str, selector: CallSelector) -> Result<Value> {
+    let root: Value =
+        serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+    let cfcall_id = resolve_call_id(config, &root, selector, resolve_cfcall_id_for_feature)?;
+
+    root.get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_CFCALL"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|c| c.get("CFCALL_ID").and_then(|v| v.as_i64()) == Some(cfcall_id))
+        })
+        .cloned()
         .ok_or_else(|| SzConfigError::NotFound(format!("Comparison call ID {cfcall_id}")))
 }
 
@@ -464,49 +488,67 @@ pub fn add_comparison_call_element(
     Ok((modified_config, new_record))
 }
 
-/// Delete a comparison call element
+/// Delete a comparison call element, addressed by (call | feature) + element code.
+///
+/// The caller no longer supplies `EXEC_ORDER`: the target `CFG_CFBOM` row is
+/// located by its call id and the element's `FELEM_ID`, and its execution order
+/// is derived from that row. A CFBOM record stores the *element's* feature id in
+/// `FTYPE_ID`, so that column is not part of the address.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `cfcall_id` - Comparison call ID
-/// * `params` - Element parameters (ftype_id, felem_id, exec_order)
+/// * `call` - Call id or feature code identifying the comparison call
+/// * `element_code` - Element code (e.g. `"FIRST_NAME"`) to remove from the call
 ///
 /// # Returns
 /// Modified configuration JSON string
+///
+/// # Errors
+/// - `NotFound` if the element is not on the call (or the call/element codes don't resolve)
+/// - `InvalidInput` if a feature code matches more than one call, or the element
+///   matches more than one BOM row on the call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::comparison::delete_comparison_call_element;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+///     "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+///     "CFG_CFBOM": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}]
+/// }}"#;
+/// let out = delete_comparison_call_element(
+///     config, CallSelector::Feature("NAME"), "FIRST_NAME").unwrap();
+/// let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+/// assert!(v["G2_CONFIG"]["CFG_CFBOM"].as_array().unwrap().is_empty());
+/// ```
 pub fn delete_comparison_call_element(
     config: &str,
-    cfcall_id: i64,
-    params: DeleteComparisonCallElementParams,
+    call: CallSelector,
+    element_code: &str,
 ) -> Result<String> {
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    // Validate that the element exists
-    let element_exists = config_data["G2_CONFIG"]["CFG_CFBOM"]
-        .as_array()
-        .map(|arr| {
-            arr.iter().any(|item| {
-                item.get("CFCALL_ID").and_then(|v| v.as_i64()) == Some(cfcall_id)
-                    && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(params.ftype_id)
-                    && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(params.felem_id)
-                    && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(params.exec_order)
-            })
-        })
-        .unwrap_or(false);
+    let cfcall_id = resolve_call_id(config, &config_data, call, resolve_cfcall_id_for_feature)?;
+    let felem_id = lookup_element_id(config, element_code)?;
 
-    if !element_exists {
-        return Err(SzConfigError::NotFound(
-            "Comparison call element not found".to_string(),
-        ));
-    }
+    // Derive EXEC_ORDER from the located BOM row (also validates existence).
+    let exec_order = derive_bom_exec_order(
+        &config_data,
+        "CFG_CFBOM",
+        "CFCALL_ID",
+        cfcall_id,
+        felem_id,
+        "Comparison",
+    )?;
 
-    // Delete the element
     if let Some(cbom_array) = config_data["G2_CONFIG"]["CFG_CFBOM"].as_array_mut() {
         cbom_array.retain(|item| {
             !(item.get("CFCALL_ID").and_then(|v| v.as_i64()) == Some(cfcall_id)
-                && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(params.ftype_id)
-                && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(params.felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(params.exec_order))
+                && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
+                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order))
         });
     }
 
@@ -639,5 +681,62 @@ mod tests {
         };
         let err = add_comparison_call(&cfg, params).unwrap_err();
         assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    // #40 fixtures: a comparison call whose CFCALL_ID deliberately differs from
+    // its FTYPE_ID, so id-vs-feature addressing is distinguishable.
+    fn populated_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}
+            ],
+            "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1},
+                {"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 12, "EXEC_ORDER": 2}
+            ]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_get_comparison_call_by_id_and_feature_match() {
+        let config = populated_config();
+        let by_id = get_comparison_call(&config, CallSelector::Id(7)).unwrap();
+        let by_feature = get_comparison_call(&config, CallSelector::Feature("NAME")).unwrap();
+        assert_eq!(by_id, by_feature);
+        assert_eq!(by_id["CFCALL_ID"], json!(7));
+    }
+
+    #[test]
+    fn test_get_comparison_call_missing() {
+        let config = populated_config();
+        assert!(get_comparison_call(&config, CallSelector::Id(999)).is_err());
+        assert!(get_comparison_call(&config, CallSelector::Feature("PHONE")).is_err());
+    }
+
+    #[test]
+    fn test_delete_comparison_call_element_derives_exec_order() {
+        let config = populated_config();
+        // No exec_order supplied; the SDK derives it and removes the right row.
+        let out =
+            delete_comparison_call_element(&config, CallSelector::Feature("NAME"), "FIRST_NAME")
+                .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let cfbom = v["G2_CONFIG"]["CFG_CFBOM"].as_array().unwrap();
+        assert_eq!(cfbom.len(), 1);
+        assert_eq!(cfbom[0]["FELEM_ID"], json!(12));
+    }
+
+    #[test]
+    fn test_delete_comparison_call_element_not_found() {
+        let config = populated_config();
+        let err = delete_comparison_call_element(&config, CallSelector::Id(7), "LAST_NAME");
+        assert!(err.is_ok());
+        // Element on a call that has no such BOM row -> NotFound.
+        let err = delete_comparison_call_element(&config, CallSelector::Id(999), "FIRST_NAME");
+        assert_eq!(err.unwrap_err().kind(), crate::error::SzErrorKind::NotFound);
     }
 }

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -335,13 +335,33 @@ pub fn get_comparison_call(config: &str, selector: CallSelector) -> Result<Value
 
 /// List all comparison calls with resolved names
 ///
-/// Returns all comparison calls with feature and function codes resolved.
+/// Returns all comparison calls with feature and function codes resolved, plus
+/// the call's `elementList` (element codes assembled from `CFG_CFBOM`, ordered by
+/// `EXEC_ORDER`).
+///
+/// The rows are sorted inside the SDK by `(FTYPE_ID, CFCALL_ID)` — the same key
+/// Python uses — so callers never need to re-sort. The sort runs on the raw rows
+/// before id→code projection, so the numeric key is never lost.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
 ///
 /// # Returns
-/// Vector of JSON Values with resolved names
+/// Vector of JSON Values with resolved names and an `elementList`
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::comparison::list_comparison_calls;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+///     "CFG_CFUNC": [{"CFUNC_ID": 1, "CFUNC_CODE": "GNR_COMP"}],
+///     "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+///     "CFG_CFBOM": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}]
+/// }}"#;
+/// let calls = list_comparison_calls(config).unwrap();
+/// assert_eq!(calls[0]["elementList"], serde_json::json!(["FIRST_NAME"]));
+/// ```
 pub fn list_comparison_calls(config: &str) -> Result<Vec<Value>> {
     let config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
@@ -362,6 +382,18 @@ pub fn list_comparison_calls(config: &str) -> Result<Vec<Value>> {
     let cfunc_array = config_data
         .get("G2_CONFIG")
         .and_then(|g| g.get("CFG_CFUNC"))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty_array);
+
+    let felem_array = config_data
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_FELEM"))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty_array);
+
+    let cfbom_array = config_data
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_CFBOM"))
         .and_then(|v| v.as_array())
         .unwrap_or(&empty_array);
 
@@ -386,17 +418,54 @@ pub fn list_comparison_calls(config: &str) -> Result<Vec<Value>> {
             .to_string()
     };
 
+    let resolve_felem = |felem_id: i64| -> String {
+        felem_array
+            .iter()
+            .find(|fe| fe.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id))
+            .and_then(|fe| fe.get("FELEM_CODE"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string()
+    };
+
+    // Assemble a call's elementList from CFG_CFBOM, ordered by EXEC_ORDER.
+    let element_list = |cfcall_id: i64| -> Vec<Value> {
+        let mut rows: Vec<&Value> = cfbom_array
+            .iter()
+            .filter(|bom| bom.get("CFCALL_ID").and_then(|v| v.as_i64()) == Some(cfcall_id))
+            .collect();
+        rows.sort_by_key(|bom| bom.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(0));
+        rows.into_iter()
+            .map(|bom| {
+                let felem_id = bom.get("FELEM_ID").and_then(|v| v.as_i64()).unwrap_or(0);
+                Value::from(resolve_felem(felem_id))
+            })
+            .collect()
+    };
+
+    // Sort the raw rows by (FTYPE_ID, CFCALL_ID) before projection so the numeric
+    // sort key is never lost (mirrors Python and list_comparison_thresholds).
+    let mut sorted: Vec<&Value> = cfcall_array.iter().collect();
+    sorted.sort_by_key(|item| {
+        (
+            item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+            item.get("CFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+        )
+    });
+
     // Transform comparison calls
-    let items: Vec<Value> = cfcall_array
-        .iter()
+    let items: Vec<Value> = sorted
+        .into_iter()
         .map(|item| {
+            let cfcall_id = item.get("CFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let ftype_id = item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let cfunc_id = item.get("CFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0);
 
             json!({
-                "id": item.get("CFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                "id": cfcall_id,
                 "feature": resolve_ftype(ftype_id),
-                "function": resolve_cfunc(cfunc_id)
+                "function": resolve_cfunc(cfunc_id),
+                "elementList": element_list(cfcall_id)
             })
         })
         .collect();
@@ -738,5 +807,44 @@ mod tests {
         // Element on a call that has no such BOM row -> NotFound.
         let err = delete_comparison_call_element(&config, CallSelector::Id(999), "FIRST_NAME");
         assert_eq!(err.unwrap_err().kind(), crate::error::SzErrorKind::NotFound);
+    }
+
+    // #41: stored order deliberately differs from the sorted (FTYPE_ID, CFCALL_ID)
+    // order, and the CFBOM rows are stored out of EXEC_ORDER, so the test proves
+    // both the SDK-owned sort and the EXEC_ORDER-ordered elementList assembly.
+    fn unsorted_list_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 3, "FTYPE_CODE": "NAME"},
+                {"FTYPE_ID": 7, "FTYPE_CODE": "ADDRESS"}
+            ],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}
+            ],
+            "CFG_CFUNC": [{"CFUNC_ID": 1, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_CFCALL": [
+                {"CFCALL_ID": 20, "FTYPE_ID": 7, "CFUNC_ID": 1},
+                {"CFCALL_ID": 5, "FTYPE_ID": 3, "CFUNC_ID": 1}
+            ],
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": 12, "EXEC_ORDER": 2},
+                {"CFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}
+            ]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_list_comparison_calls_sorted_with_element_list() {
+        let calls = list_comparison_calls(&unsorted_list_config()).unwrap();
+        // Sorted by (FTYPE_ID, CFCALL_ID): NAME (ftype 3) before ADDRESS (ftype 7).
+        assert_eq!(calls[0]["feature"], json!("NAME"));
+        assert_eq!(calls[0]["id"], json!(5));
+        assert_eq!(calls[1]["feature"], json!("ADDRESS"));
+        // elementList ordered by EXEC_ORDER despite reversed storage.
+        assert_eq!(calls[0]["elementList"], json!(["FIRST_NAME", "LAST_NAME"]));
+        // The ADDRESS call has no BOM rows -> empty elementList.
+        assert_eq!(calls[1]["elementList"], json!([]));
     }
 }

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -307,13 +307,33 @@ pub fn get_distinct_call(config: &str, selector: CallSelector) -> Result<Value> 
 
 /// List all distinct calls with resolved names
 ///
-/// Returns all distinct calls with feature and function codes resolved.
+/// Returns all distinct calls with feature and function codes resolved, plus the
+/// call's `elementList` (element codes assembled from `CFG_DFBOM`, ordered by
+/// `EXEC_ORDER`).
+///
+/// The rows are sorted inside the SDK by `(FTYPE_ID, DFCALL_ID)` — the same key
+/// Python uses — so callers never need to re-sort. `execOrder` is retained on the
+/// distinct projection (the header row's `EXEC_ORDER`, always `1`).
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
 ///
 /// # Returns
-/// Vector of JSON Values with resolved names
+/// Vector of JSON Values with resolved names, `execOrder`, and an `elementList`
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::distinct::list_distinct_calls;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+///     "CFG_DFUNC": [{"DFUNC_ID": 1, "DFUNC_CODE": "FELEM_EXP"}],
+///     "CFG_DFCALL": [{"DFCALL_ID": 7, "FTYPE_ID": 3, "DFUNC_ID": 1, "EXEC_ORDER": 1}],
+///     "CFG_DFBOM": [{"DFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}]
+/// }}"#;
+/// let calls = list_distinct_calls(config).unwrap();
+/// assert_eq!(calls[0]["elementList"], serde_json::json!(["FIRST_NAME"]));
+/// ```
 pub fn list_distinct_calls(config: &str) -> Result<Vec<Value>> {
     let config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
@@ -334,6 +354,18 @@ pub fn list_distinct_calls(config: &str) -> Result<Vec<Value>> {
     let dfunc_array = config_data
         .get("G2_CONFIG")
         .and_then(|g| g.get("CFG_DFUNC"))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty_array);
+
+    let felem_array = config_data
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_FELEM"))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty_array);
+
+    let dfbom_array = config_data
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_DFBOM"))
         .and_then(|v| v.as_array())
         .unwrap_or(&empty_array);
 
@@ -358,18 +390,55 @@ pub fn list_distinct_calls(config: &str) -> Result<Vec<Value>> {
             .to_string()
     };
 
+    let resolve_felem = |felem_id: i64| -> String {
+        felem_array
+            .iter()
+            .find(|fe| fe.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id))
+            .and_then(|fe| fe.get("FELEM_CODE"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string()
+    };
+
+    // Assemble a call's elementList from CFG_DFBOM, ordered by EXEC_ORDER.
+    let element_list = |dfcall_id: i64| -> Vec<Value> {
+        let mut rows: Vec<&Value> = dfbom_array
+            .iter()
+            .filter(|bom| bom.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(dfcall_id))
+            .collect();
+        rows.sort_by_key(|bom| bom.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(0));
+        rows.into_iter()
+            .map(|bom| {
+                let felem_id = bom.get("FELEM_ID").and_then(|v| v.as_i64()).unwrap_or(0);
+                Value::from(resolve_felem(felem_id))
+            })
+            .collect()
+    };
+
+    // Sort the raw rows by (FTYPE_ID, DFCALL_ID) before projection so the numeric
+    // sort key is never lost (mirrors Python).
+    let mut sorted: Vec<&Value> = dfcall_array.iter().collect();
+    sorted.sort_by_key(|item| {
+        (
+            item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+            item.get("DFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+        )
+    });
+
     // Transform distinct calls
-    let items: Vec<Value> = dfcall_array
-        .iter()
+    let items: Vec<Value> = sorted
+        .into_iter()
         .map(|item| {
+            let dfcall_id = item.get("DFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let ftype_id = item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let dfunc_id = item.get("DFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0);
 
             json!({
-                "id": item.get("DFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                "id": dfcall_id,
                 "feature": resolve_ftype(ftype_id),
                 "function": resolve_dfunc(dfunc_id),
-                "execOrder": item.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(1)
+                "execOrder": item.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(1),
+                "elementList": element_list(dfcall_id)
             })
         })
         .collect();
@@ -648,5 +717,38 @@ mod tests {
         let dfbom = v["G2_CONFIG"]["CFG_DFBOM"].as_array().unwrap();
         assert_eq!(dfbom.len(), 1);
         assert_eq!(dfbom[0]["FELEM_ID"], json!(11));
+    }
+
+    #[test]
+    fn test_list_distinct_calls_sorted_element_list_and_exec_order() {
+        // Stored order differs from (FTYPE_ID, DFCALL_ID); BOM stored out of order.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 3, "FTYPE_CODE": "NAME"},
+                {"FTYPE_ID": 7, "FTYPE_CODE": "ADDRESS"}
+            ],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}
+            ],
+            "CFG_DFUNC": [{"DFUNC_ID": 1, "DFUNC_CODE": "FELEM_EXP"}],
+            "CFG_DFCALL": [
+                {"DFCALL_ID": 20, "FTYPE_ID": 7, "DFUNC_ID": 1, "EXEC_ORDER": 1},
+                {"DFCALL_ID": 5, "FTYPE_ID": 3, "DFUNC_ID": 1, "EXEC_ORDER": 1}
+            ],
+            "CFG_DFBOM": [
+                {"DFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": 12, "EXEC_ORDER": 2},
+                {"DFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+
+        let calls = list_distinct_calls(config).unwrap();
+        assert_eq!(calls[0]["feature"], json!("NAME"));
+        assert_eq!(calls[0]["id"], json!(5));
+        // execOrder ruling retained (D28).
+        assert_eq!(calls[0]["execOrder"], json!(1));
+        // elementList ordered by EXEC_ORDER despite reversed storage.
+        assert_eq!(calls[0]["elementList"], json!(["FIRST_NAME", "LAST_NAME"]));
+        assert_eq!(calls[1]["feature"], json!("ADDRESS"));
     }
 }

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -3,10 +3,12 @@
 //! Functions for managing CFG_DFCALL (distinct calls) and CFG_DFBOM
 //! (distinct bill of materials) configuration sections.
 
+use crate::calls::{CallSelector, derive_bom_exec_order, resolve_call_id};
 use crate::config_rows::{DfbomRow, DfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
-    find_in_config_array, get_next_id, lookup_dfunc_id, lookup_element_id, lookup_feature_id,
+    get_next_id, lookup_dfunc_id, lookup_element_id, lookup_feature_id,
+    resolve_dfcall_id_for_feature,
 };
 use serde_json::{Value, json};
 
@@ -53,15 +55,6 @@ impl TryFrom<&Value> for AddDistinctCallParams {
 /// Parameters for adding a distinct call element
 #[derive(Debug, Clone)]
 pub struct AddDistinctCallElementParams {
-    pub dfcall_id: i64,
-    pub ftype_id: i64,
-    pub felem_id: i64,
-    pub exec_order: i64,
-}
-
-/// Parameters for deleting a distinct call element
-#[derive(Debug, Clone)]
-pub struct DeleteDistinctCallElementParams {
     pub dfcall_id: i64,
     pub ftype_id: i64,
     pub felem_id: i64,
@@ -263,21 +256,53 @@ pub fn delete_distinct_call(config: &str, dfcall_id: i64) -> Result<String> {
     serde_json::to_string(&config_data).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
 
-/// Get a single distinct call by ID
+/// Get a single distinct call, addressed by id or by feature code.
+///
+/// Pass [`CallSelector::Id`] to look the call up by its `DFCALL_ID`, or
+/// [`CallSelector::Feature`] to resolve the (0-or-1) distinct call bound to a
+/// feature. The feature path scans `CFG_DFCALL` by `FTYPE_ID` via
+/// [`resolve_dfcall_id_for_feature`] rather than treating the feature id as a
+/// call id (the historical bug this fixes).
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `dfcall_id` - Distinct call ID
+/// * `selector` - Call id or feature code identifying the call
 ///
 /// # Returns
 /// JSON Value representing the distinct call record
 ///
 /// # Errors
-/// - `NotFound` if call ID doesn't exist
-pub fn get_distinct_call(config: &str, dfcall_id: i64) -> Result<Value> {
-    find_in_config_array(config, "CFG_DFCALL", "DFCALL_ID", &dfcall_id.to_string())?.ok_or_else(
-        || SzConfigError::NotFound(format!("Distinct call ID {dfcall_id} does not exist")),
-    )
+/// - `NotFound` if no matching call exists
+/// - `InvalidInput` if a feature code matches more than one call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::distinct::get_distinct_call;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_DFCALL": [{"DFCALL_ID": 11, "FTYPE_ID": 3, "DFUNC_ID": 1}]
+/// }}"#;
+/// let by_id = get_distinct_call(config, CallSelector::Id(11)).unwrap();
+/// let by_feature = get_distinct_call(config, CallSelector::Feature("NAME")).unwrap();
+/// assert_eq!(by_id, by_feature);
+/// ```
+pub fn get_distinct_call(config: &str, selector: CallSelector) -> Result<Value> {
+    let root: Value =
+        serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+    let dfcall_id = resolve_call_id(config, &root, selector, resolve_dfcall_id_for_feature)?;
+
+    root.get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_DFCALL"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|c| c.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(dfcall_id))
+        })
+        .cloned()
+        .ok_or_else(|| {
+            SzConfigError::NotFound(format!("Distinct call ID {dfcall_id} does not exist"))
+        })
 }
 
 /// List all distinct calls with resolved names
@@ -423,47 +448,67 @@ pub fn add_distinct_call_element(
     Ok((modified_config, new_record))
 }
 
-/// Delete a distinct call element
+/// Delete a distinct call element, addressed by (call | feature) + element code.
+///
+/// The caller no longer supplies `EXEC_ORDER`: the target `CFG_DFBOM` row is
+/// located by its call id and the element's `FELEM_ID`, and its execution order
+/// is derived from that row. A DFBOM record stores the *element's* feature id in
+/// `FTYPE_ID`, so that column is not part of the address.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `params` - Element parameters (dfcall_id, ftype_id, felem_id, exec_order)
+/// * `call` - Call id or feature code identifying the distinct call
+/// * `element_code` - Element code to remove from the call
 ///
 /// # Returns
 /// Modified configuration JSON string
+///
+/// # Errors
+/// - `NotFound` if the element is not on the call (or the call/element codes don't resolve)
+/// - `InvalidInput` if a feature code matches more than one call, or the element
+///   matches more than one BOM row on the call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::distinct::delete_distinct_call_element;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+///     "CFG_DFCALL": [{"DFCALL_ID": 11, "FTYPE_ID": 3, "DFUNC_ID": 1}],
+///     "CFG_DFBOM": [{"DFCALL_ID": 11, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}]
+/// }}"#;
+/// let out = delete_distinct_call_element(
+///     config, CallSelector::Id(11), "FIRST_NAME").unwrap();
+/// let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+/// assert!(v["G2_CONFIG"]["CFG_DFBOM"].as_array().unwrap().is_empty());
+/// ```
 pub fn delete_distinct_call_element(
     config: &str,
-    params: DeleteDistinctCallElementParams,
+    call: CallSelector,
+    element_code: &str,
 ) -> Result<String> {
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    // Validate that the element exists
-    let element_exists = config_data["G2_CONFIG"]["CFG_DFBOM"]
-        .as_array()
-        .map(|arr| {
-            arr.iter().any(|item| {
-                item.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(params.dfcall_id)
-                    && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(params.ftype_id)
-                    && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(params.felem_id)
-                    && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(params.exec_order)
-            })
-        })
-        .unwrap_or(false);
+    let dfcall_id = resolve_call_id(config, &config_data, call, resolve_dfcall_id_for_feature)?;
+    let felem_id = lookup_element_id(config, element_code)?;
 
-    if !element_exists {
-        return Err(SzConfigError::NotFound(
-            "Distinct call element not found".to_string(),
-        ));
-    }
+    // Derive EXEC_ORDER from the located BOM row (also validates existence).
+    let exec_order = derive_bom_exec_order(
+        &config_data,
+        "CFG_DFBOM",
+        "DFCALL_ID",
+        dfcall_id,
+        felem_id,
+        "Distinct",
+    )?;
 
-    // Delete the element
     if let Some(dbom_array) = config_data["G2_CONFIG"]["CFG_DFBOM"].as_array_mut() {
         dbom_array.retain(|item| {
-            !(item.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(params.dfcall_id)
-                && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(params.ftype_id)
-                && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(params.felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(params.exec_order))
+            !(item.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(dfcall_id)
+                && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
+                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order))
         });
     }
 
@@ -563,5 +608,45 @@ mod tests {
         assert_all_keys(dfbom, &DFBOM_KEYS);
         assert_all_keys(&new_record, &DFBOM_KEYS);
         assert_eq!(dfbom["EXEC_ORDER"], json!(3));
+    }
+
+    // #40 fixtures: DFCALL_ID (11) deliberately differs from FTYPE_ID (3). The
+    // historical bug used the feature id directly as the call id; the by-feature
+    // path must instead scan CFG_DFCALL and return DFCALL_ID 11.
+    fn populated_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}
+            ],
+            "CFG_DFCALL": [{"DFCALL_ID": 11, "FTYPE_ID": 3, "DFUNC_ID": 1}],
+            "CFG_DFBOM": [
+                {"DFCALL_ID": 11, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1},
+                {"DFCALL_ID": 11, "FTYPE_ID": 3, "FELEM_ID": 12, "EXEC_ORDER": 2}
+            ]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_get_distinct_call_by_feature_returns_correct_call() {
+        let config = populated_config();
+        let by_id = get_distinct_call(&config, CallSelector::Id(11)).unwrap();
+        let by_feature = get_distinct_call(&config, CallSelector::Feature("NAME")).unwrap();
+        assert_eq!(by_id, by_feature);
+        // Regression: the returned call id is the real DFCALL_ID (11), NOT the
+        // feature id (3) that the old FTYPE_ID-as-call-id bug would have used.
+        assert_eq!(by_feature["DFCALL_ID"], json!(11));
+    }
+
+    #[test]
+    fn test_delete_distinct_call_element_derives_exec_order() {
+        let config = populated_config();
+        let out = delete_distinct_call_element(&config, CallSelector::Id(11), "LAST_NAME").unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let dfbom = v["G2_CONFIG"]["CFG_DFBOM"].as_array().unwrap();
+        assert_eq!(dfbom.len(), 1);
+        assert_eq!(dfbom[0]["FELEM_ID"], json!(11));
     }
 }

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -3,10 +3,12 @@
 //! Functions for managing CFG_EFCALL (expression calls) and CFG_EFBOM
 //! (expression bill of materials) configuration sections.
 
+use crate::calls::{CallSelector, derive_bom_exec_order, resolve_call_id};
 use crate::config_rows::{EfbomRow, EfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
-    find_in_config_array, get_next_id, lookup_efunc_id, lookup_element_id, lookup_feature_id,
+    get_next_id, lookup_efunc_id, lookup_element_id, lookup_feature_id,
+    resolve_efcall_id_for_feature,
 };
 use serde_json::{Value, json};
 
@@ -56,24 +58,6 @@ impl ExpressionCallElementParams {
             felem_id,
             exec_order,
             felem_req,
-        }
-    }
-}
-
-/// Parameters for identifying expression call element (for delete operations)
-#[derive(Debug, Clone)]
-pub struct ExpressionCallElementKey {
-    pub ftype_id: i64,
-    pub felem_id: i64,
-    pub exec_order: i64,
-}
-
-impl ExpressionCallElementKey {
-    pub fn new(ftype_id: i64, felem_id: i64, exec_order: i64) -> Self {
-        Self {
-            ftype_id,
-            felem_id,
-            exec_order,
         }
     }
 }
@@ -310,21 +294,55 @@ pub fn delete_expression_call(config: &str, efcall_id: i64) -> Result<String> {
     serde_json::to_string(&config_data).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
 
-/// Get a single expression call by ID
+/// Get a single expression call, addressed by id or by feature code.
+///
+/// Pass [`CallSelector::Id`] to look the call up by its `EFCALL_ID`, or
+/// [`CallSelector::Feature`] to resolve the expression call bound to a feature.
+/// Expression calls are genuinely many-per-feature (`EXEC_ORDER` exists for
+/// exactly this reason), so a feature code that matches more than one call
+/// errors clearly via [`resolve_efcall_id_for_feature`] rather than silently
+/// picking one — address such calls by id.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `efcall_id` - Expression call ID
+/// * `selector` - Call id or feature code identifying the call
 ///
 /// # Returns
 /// JSON Value representing the expression call record
 ///
 /// # Errors
-/// - `NotFound` if call ID doesn't exist
-pub fn get_expression_call(config: &str, efcall_id: i64) -> Result<Value> {
-    find_in_config_array(config, "CFG_EFCALL", "EFCALL_ID", &efcall_id.to_string())?.ok_or_else(
-        || SzConfigError::NotFound(format!("Expression call ID {efcall_id} does not exist")),
-    )
+/// - `NotFound` if no matching call exists
+/// - `InvalidInput` if a feature code matches more than one call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::expression::get_expression_call;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_EFCALL": [{"EFCALL_ID": 9, "FTYPE_ID": 3, "FELEM_ID": -1, "EFUNC_ID": 1,
+///                     "EXEC_ORDER": 1, "EFEAT_FTYPE_ID": -1, "IS_VIRTUAL": "No"}]
+/// }}"#;
+/// let by_id = get_expression_call(config, CallSelector::Id(9)).unwrap();
+/// let by_feature = get_expression_call(config, CallSelector::Feature("NAME")).unwrap();
+/// assert_eq!(by_id, by_feature);
+/// ```
+pub fn get_expression_call(config: &str, selector: CallSelector) -> Result<Value> {
+    let root: Value =
+        serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+    let efcall_id = resolve_call_id(config, &root, selector, resolve_efcall_id_for_feature)?;
+
+    root.get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_EFCALL"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|c| c.get("EFCALL_ID").and_then(|v| v.as_i64()) == Some(efcall_id))
+        })
+        .cloned()
+        .ok_or_else(|| {
+            SzConfigError::NotFound(format!("Expression call ID {efcall_id} does not exist"))
+        })
 }
 
 /// List all expression calls with resolved names
@@ -516,49 +534,69 @@ pub fn add_expression_call_element(
     Ok((modified_config, new_record))
 }
 
-/// Delete an expression call element
+/// Delete an expression call element, addressed by (call | feature) + element code.
+///
+/// The caller no longer supplies `EXEC_ORDER`: the target `CFG_EFBOM` row is
+/// located by its call id and the element's `FELEM_ID`, and its execution order
+/// is derived from that row. An EFBOM record stores the *element's* feature id in
+/// `FTYPE_ID`, so that column is not part of the address.
+///
+/// Because expression calls are many-per-feature, addressing by
+/// [`CallSelector::Feature`] errors when the feature has more than one
+/// expression call — use [`CallSelector::Id`] to name the specific call.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `efcall_id` - Expression call ID
-/// * `key` - Expression call element key (identifying the element to delete)
+/// * `call` - Call id or feature code identifying the expression call
+/// * `element_code` - Element code to remove from the call
 ///
 /// # Returns
 /// Modified configuration JSON string
+///
+/// # Errors
+/// - `NotFound` if the element is not on the call (or the call/element codes don't resolve)
+/// - `InvalidInput` if a feature code matches more than one call, or the element
+///   matches more than one BOM row on the call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::expression::delete_expression_call_element;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+///     "CFG_EFBOM": [{"EFCALL_ID": 9, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "No"}]
+/// }}"#;
+/// let out = delete_expression_call_element(
+///     config, CallSelector::Id(9), "FIRST_NAME").unwrap();
+/// let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+/// assert!(v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap().is_empty());
+/// ```
 pub fn delete_expression_call_element(
     config: &str,
-    efcall_id: i64,
-    key: ExpressionCallElementKey,
+    call: CallSelector,
+    element_code: &str,
 ) -> Result<String> {
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    // Validate that the element exists
-    let element_exists = config_data["G2_CONFIG"]["CFG_EFBOM"]
-        .as_array()
-        .map(|arr| {
-            arr.iter().any(|item| {
-                item.get("EFCALL_ID").and_then(|v| v.as_i64()) == Some(efcall_id)
-                    && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(key.ftype_id)
-                    && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(key.felem_id)
-                    && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(key.exec_order)
-            })
-        })
-        .unwrap_or(false);
+    let efcall_id = resolve_call_id(config, &config_data, call, resolve_efcall_id_for_feature)?;
+    let felem_id = lookup_element_id(config, element_code)?;
 
-    if !element_exists {
-        return Err(SzConfigError::NotFound(
-            "Expression call element not found".to_string(),
-        ));
-    }
+    // Derive EXEC_ORDER from the located BOM row (also validates existence).
+    let exec_order = derive_bom_exec_order(
+        &config_data,
+        "CFG_EFBOM",
+        "EFCALL_ID",
+        efcall_id,
+        felem_id,
+        "Expression",
+    )?;
 
-    // Delete the element
     if let Some(ebom_array) = config_data["G2_CONFIG"]["CFG_EFBOM"].as_array_mut() {
         ebom_array.retain(|item| {
             !(item.get("EFCALL_ID").and_then(|v| v.as_i64()) == Some(efcall_id)
-                && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(key.ftype_id)
-                && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(key.felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(key.exec_order))
+                && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
+                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order))
         });
     }
 
@@ -666,5 +704,67 @@ mod tests {
         assert_all_keys(&new_record, &EFBOM_KEYS);
         assert_eq!(efbom["FELEM_REQ"], json!("Yes"));
         assert_eq!(efbom["EXEC_ORDER"], json!(2));
+    }
+
+    // #40 fixtures: two expression calls bound to the same feature (legitimate —
+    // expression is many-per-feature) plus a BOM row per call.
+    fn populated_config() -> String {
+        r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+            "CFG_EFCALL": [
+                {"EFCALL_ID": 9, "FTYPE_ID": 3, "FELEM_ID": -1, "EFUNC_ID": 1,
+                 "EXEC_ORDER": 1, "EFEAT_FTYPE_ID": -1, "IS_VIRTUAL": "No"},
+                {"EFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": -1, "EFUNC_ID": 2,
+                 "EXEC_ORDER": 2, "EFEAT_FTYPE_ID": -1, "IS_VIRTUAL": "No"}
+            ],
+            "CFG_EFBOM": [
+                {"EFCALL_ID": 9, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "No"},
+                {"EFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "No"}
+            ]
+        }}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_get_expression_call_by_id() {
+        let config = populated_config();
+        let by_id = get_expression_call(&config, CallSelector::Id(10)).unwrap();
+        assert_eq!(by_id["EFCALL_ID"], json!(10));
+    }
+
+    #[test]
+    fn test_get_expression_call_ambiguous_feature_errors() {
+        let config = populated_config();
+        // The feature has two expression calls -> by-feature must error clearly,
+        // not silently pick one.
+        let err = get_expression_call(&config, CallSelector::Feature("NAME"));
+        assert_eq!(
+            err.unwrap_err().kind(),
+            crate::error::SzErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn test_delete_expression_call_element_ambiguous_feature_errors() {
+        let config = populated_config();
+        let err =
+            delete_expression_call_element(&config, CallSelector::Feature("NAME"), "FIRST_NAME");
+        assert_eq!(
+            err.unwrap_err().kind(),
+            crate::error::SzErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn test_delete_expression_call_element_by_id_derives_exec_order() {
+        let config = populated_config();
+        // Addressing the specific call by id disambiguates; exec_order derived.
+        let out =
+            delete_expression_call_element(&config, CallSelector::Id(9), "FIRST_NAME").unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let efbom = v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
+        assert_eq!(efbom.len(), 1);
+        assert_eq!(efbom[0]["EFCALL_ID"], json!(10));
     }
 }

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -383,6 +383,12 @@ pub fn list_expression_calls(config: &str) -> Result<Vec<Value>> {
         .and_then(|v| v.as_array())
         .unwrap_or(&empty_array);
 
+    let efbom_array = config_data
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_EFBOM"))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty_array);
+
     // Helper functions for ID resolution
     let resolve_ftype = |ftype_id: i64| -> String {
         if ftype_id <= 0 {
@@ -422,10 +428,37 @@ pub fn list_expression_calls(config: &str) -> Result<Vec<Value>> {
             .to_string()
     };
 
+    // Assemble a call's elementList from CFG_EFBOM, ordered by EXEC_ORDER.
+    let element_list = |efcall_id: i64| -> Vec<Value> {
+        let mut rows: Vec<&Value> = efbom_array
+            .iter()
+            .filter(|bom| bom.get("EFCALL_ID").and_then(|v| v.as_i64()) == Some(efcall_id))
+            .collect();
+        rows.sort_by_key(|bom| bom.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(0));
+        rows.into_iter()
+            .map(|bom| {
+                let felem_id = bom.get("FELEM_ID").and_then(|v| v.as_i64()).unwrap_or(0);
+                Value::from(resolve_felem(felem_id))
+            })
+            .collect()
+    };
+
+    // Sort the raw rows by (FTYPE_ID, FELEM_ID, EXEC_ORDER) before projection so
+    // the numeric sort key is never lost (mirrors Python).
+    let mut sorted: Vec<&Value> = efcall_array.iter().collect();
+    sorted.sort_by_key(|item| {
+        (
+            item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+            item.get("FELEM_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+            item.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(0),
+        )
+    });
+
     // Transform expression calls
-    let items: Vec<Value> = efcall_array
-        .iter()
+    let items: Vec<Value> = sorted
+        .into_iter()
         .map(|item| {
+            let efcall_id = item.get("EFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let ftype_id = item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let felem_id = item.get("FELEM_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let efunc_id = item.get("EFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -433,13 +466,14 @@ pub fn list_expression_calls(config: &str) -> Result<Vec<Value>> {
             let efeat_ftype_id = item.get("EFEAT_FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(-1);
 
             json!({
-                "id": item.get("EFCALL_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                "id": efcall_id,
                 "feature": resolve_ftype(ftype_id),
                 "element": resolve_felem(felem_id),
                 "execOrder": item.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(0),
                 "function": resolve_efunc(efunc_id),
                 "isVirtual": item.get("IS_VIRTUAL").and_then(|v| v.as_str()).unwrap_or("No"),
-                "expressionFeature": if efeat_ftype_id <= 0 { "n/a".to_string() } else { resolve_ftype(efeat_ftype_id) }
+                "expressionFeature": if efeat_ftype_id <= 0 { "n/a".to_string() } else { resolve_ftype(efeat_ftype_id) },
+                "elementList": element_list(efcall_id)
             })
         })
         .collect();
@@ -766,5 +800,34 @@ mod tests {
         let efbom = v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
         assert_eq!(efbom.len(), 1);
         assert_eq!(efbom[0]["EFCALL_ID"], json!(10));
+    }
+
+    #[test]
+    fn test_list_expression_calls_sorted_with_element_list() {
+        // Stored order differs from (FTYPE_ID, FELEM_ID, EXEC_ORDER); BOM out of order.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}
+            ],
+            "CFG_EFUNC": [{"EFUNC_ID": 1, "EFUNC_CODE": "EXP_X"}],
+            "CFG_EFCALL": [
+                {"EFCALL_ID": 30, "FTYPE_ID": 3, "FELEM_ID": 12, "EFUNC_ID": 1, "EXEC_ORDER": 1, "EFEAT_FTYPE_ID": -1, "IS_VIRTUAL": "No"},
+                {"EFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 11, "EFUNC_ID": 1, "EXEC_ORDER": 1, "EFEAT_FTYPE_ID": -1, "IS_VIRTUAL": "No"}
+            ],
+            "CFG_EFBOM": [
+                {"EFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 12, "EXEC_ORDER": 2, "FELEM_REQ": "Yes"},
+                {"EFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "Yes"}
+            ]
+        }}"#;
+
+        let calls = list_expression_calls(config).unwrap();
+        // Sorted by (FTYPE_ID, FELEM_ID, EXEC_ORDER): FELEM_ID 11 (id 10) before 12 (id 30).
+        assert_eq!(calls[0]["id"], json!(10));
+        assert_eq!(calls[0]["element"], json!("FIRST_NAME"));
+        assert_eq!(calls[1]["id"], json!(30));
+        // elementList ordered by EXEC_ORDER despite reversed storage.
+        assert_eq!(calls[0]["elementList"], json!(["FIRST_NAME", "LAST_NAME"]));
     }
 }

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides functions for managing the four types of calls in
 //! Senzing configuration:
 //!
-//! - **Standardize calls** (CFG_SFCALL/CFG_SBOM) - Data standardization operations
+//! - **Standardize calls** (CFG_SFCALL) - Data standardization operations
 //! - **Expression calls** (CFG_EFCALL/CFG_EFBOM) - Feature expression operations
 //! - **Comparison calls** (CFG_CFCALL/CFG_CFBOM) - Feature comparison operations
 //! - **Distinct calls** (CFG_DFCALL/CFG_DFBOM) - Feature distinctness operations

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -16,6 +16,111 @@ pub mod distinct;
 pub mod expression;
 pub mod standardize;
 
+use crate::error::{Result, SzConfigError};
+use serde_json::Value;
+
+/// Selects a call either by its numeric call id or by the feature code it is
+/// bound to.
+///
+/// The `get_*_call` and `delete_*_call_element` entry points accept this so a
+/// caller can pass whichever it already holds — a raw `*CALL_ID` or the feature
+/// code the user typed — without a pre-resolution round trip. When a feature
+/// code is given the SDK scans the relevant `CFG_*CALL` section by `FTYPE_ID`
+/// (see the `helpers::resolve_*call_id_for_feature` resolvers), which owns the
+/// per-family multiplicity policy and errors on an ambiguous match rather than
+/// silently picking the wrong call.
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+///
+/// let by_id = CallSelector::Id(1001);
+/// let by_feature = CallSelector::Feature("NAME");
+/// assert_ne!(by_id, by_feature);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallSelector<'a> {
+    /// Address the call directly by its `*CALL_ID`.
+    Id(i64),
+    /// Address the call by the feature code it is bound to.
+    Feature(&'a str),
+}
+
+/// Resolve a [`CallSelector`] to a concrete call id.
+///
+/// For [`CallSelector::Id`] the id is returned as-is. For
+/// [`CallSelector::Feature`] the feature code is resolved to its `FTYPE_ID`
+/// (via [`crate::helpers::lookup_feature_id`]) and then to the bound call id via
+/// `resolver` (one of the `helpers::resolve_*call_id_for_feature` functions),
+/// which errors on an ambiguous or missing match.
+///
+/// `root` is the already-parsed configuration; `config` is the same document as
+/// a string (needed by the string-based feature lookup helper).
+pub(crate) fn resolve_call_id(
+    config: &str,
+    root: &Value,
+    selector: CallSelector,
+    resolver: fn(&Value, i64) -> Result<i64>,
+) -> Result<i64> {
+    match selector {
+        CallSelector::Id(id) => Ok(id),
+        CallSelector::Feature(code) => {
+            let ftype_id = crate::helpers::lookup_feature_id(config, code)?;
+            resolver(root, ftype_id)
+        }
+    }
+}
+
+/// Derive the `EXEC_ORDER` of the single BOM row addressed by (call, element).
+///
+/// A BOM record (`CFG_CFBOM` / `CFG_DFBOM` / `CFG_EFBOM`) stores the *element's*
+/// feature id in its `FTYPE_ID`, not the call's, so `FTYPE_ID` is deliberately
+/// **not** part of the address here — the row is located by (call id, element
+/// id) alone. Returns the located row's `EXEC_ORDER`, so callers no longer need
+/// to supply it.
+///
+/// Errors with `NotFound` when no row matches and `InvalidInput` when more than
+/// one does (the element cannot be uniquely addressed without more information).
+pub(crate) fn derive_bom_exec_order(
+    root: &Value,
+    section: &str,
+    call_id_field: &str,
+    call_id: i64,
+    felem_id: i64,
+    label: &str,
+) -> Result<i64> {
+    let empty: Vec<Value> = Vec::new();
+    let rows = root
+        .get("G2_CONFIG")
+        .and_then(|g| g.get(section))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+
+    let orders: Vec<i64> = rows
+        .iter()
+        .filter(|r| {
+            r.get(call_id_field).and_then(|v| v.as_i64()) == Some(call_id)
+                && r.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
+        })
+        .filter_map(|r| r.get("EXEC_ORDER").and_then(|v| v.as_i64()))
+        .collect();
+
+    match orders.as_slice() {
+        [] => Err(SzConfigError::NotFound(format!(
+            "{label} call element not found"
+        ))),
+        [order] => Ok(*order),
+        many => Err(SzConfigError::InvalidInput(format!(
+            "Ambiguous {label} call element: element matches {} rows; cannot derive execution order",
+            many.len()
+        ))),
+    }
+}
+
+// `CallSelector` is exported at the module root so callers can write
+// `calls::CallSelector` regardless of which call family they are addressing.
+
 // Re-export commonly used functions for convenience
 pub use standardize::{
     add_standardize_call, add_standardize_call_element, delete_standardize_call,

--- a/src/calls/standardize.rs
+++ b/src/calls/standardize.rs
@@ -357,9 +357,20 @@ pub fn list_standardize_calls(config: &str) -> Result<Vec<Value>> {
             .to_string()
     };
 
+    // Sort the raw rows by (FTYPE_ID, EXEC_ORDER) before projection so the numeric
+    // sort key is never lost (mirrors Python). Standardize calls have no BOM, so
+    // there is deliberately no elementList.
+    let mut sorted: Vec<&Value> = sfcall_array.iter().collect();
+    sorted.sort_by_key(|item| {
+        (
+            item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+            item.get("EXEC_ORDER").and_then(|v| v.as_i64()).unwrap_or(0),
+        )
+    });
+
     // Transform standardize calls
-    let items: Vec<Value> = sfcall_array
-        .iter()
+    let items: Vec<Value> = sorted
+        .into_iter()
         .map(|item| {
             let ftype_id = item.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0);
             let felem_id = item.get("FELEM_ID").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -644,5 +655,31 @@ mod tests {
         );
         // Addressing the specific call by id still works.
         assert!(get_standardize_call(config, CallSelector::Id(6)).is_ok());
+    }
+
+    #[test]
+    fn test_list_standardize_calls_sorted_no_element_list() {
+        // Stored order differs from (FTYPE_ID, EXEC_ORDER).
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 3, "FTYPE_CODE": "NAME"},
+                {"FTYPE_ID": 7, "FTYPE_CODE": "ADDRESS"}
+            ],
+            "CFG_FELEM": [],
+            "CFG_SFUNC": [{"SFUNC_ID": 1, "SFUNC_CODE": "PARSE_NAME"}],
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 20, "FTYPE_ID": 7, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 1},
+                {"SFCALL_ID": 8, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 2},
+                {"SFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+
+        let calls = list_standardize_calls(config).unwrap();
+        // (FTYPE_ID, EXEC_ORDER): (3,1) id 5, (3,2) id 8, (7,1) id 20.
+        assert_eq!(calls[0]["id"], json!(5));
+        assert_eq!(calls[1]["id"], json!(8));
+        assert_eq!(calls[2]["id"], json!(20));
+        // Standardize calls carry no BOM, so no elementList key.
+        assert!(!calls[0].as_object().unwrap().contains_key("elementList"));
     }
 }

--- a/src/calls/standardize.rs
+++ b/src/calls/standardize.rs
@@ -3,10 +3,12 @@
 //! Functions for managing CFG_SFCALL (standardize calls) and CFG_SBOM
 //! (standardize bill of materials) configuration sections.
 
+use crate::calls::{CallSelector, resolve_call_id};
 use crate::config_rows::SfcallRow;
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
-    find_in_config_array, get_next_id, lookup_element_id, lookup_feature_id, lookup_sfunc_id,
+    get_next_id, lookup_element_id, lookup_feature_id, lookup_sfunc_id,
+    resolve_sfcall_id_for_feature,
 };
 use serde_json::{Value, json};
 
@@ -230,19 +232,51 @@ pub fn delete_standardize_call(config: &str, sfcall_id: i64) -> Result<String> {
     serde_json::to_string(&config_data).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
 
-/// Get a single standardize call by ID
+/// Get a single standardize call, addressed by id or by feature code.
+///
+/// Pass [`CallSelector::Id`] to look the call up by its `SFCALL_ID`, or
+/// [`CallSelector::Feature`] to resolve the standardize call bound to a feature.
+/// The feature path scans `CFG_SFCALL` by `FTYPE_ID` via
+/// [`resolve_sfcall_id_for_feature`] rather than treating the feature id as a
+/// call id (the historical bug this fixes). Standardize calls can legitimately
+/// be many-per-feature, so an ambiguous feature match errors — address by id.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
-/// * `sfcall_id` - Standardize call ID
+/// * `selector` - Call id or feature code identifying the call
 ///
 /// # Returns
 /// JSON Value representing the standardize call record
 ///
 /// # Errors
-/// - `NotFound` if call ID doesn't exist
-pub fn get_standardize_call(config: &str, sfcall_id: i64) -> Result<Value> {
-    find_in_config_array(config, "CFG_SFCALL", "SFCALL_ID", &sfcall_id.to_string())?
+/// - `NotFound` if no matching call exists
+/// - `InvalidInput` if a feature code matches more than one call (ambiguous)
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::calls::CallSelector;
+/// use sz_configtool_lib::calls::standardize::get_standardize_call;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+///     "CFG_SFCALL": [{"SFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 1}]
+/// }}"#;
+/// let by_id = get_standardize_call(config, CallSelector::Id(5)).unwrap();
+/// let by_feature = get_standardize_call(config, CallSelector::Feature("NAME")).unwrap();
+/// assert_eq!(by_id, by_feature);
+/// ```
+pub fn get_standardize_call(config: &str, selector: CallSelector) -> Result<Value> {
+    let root: Value =
+        serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+    let sfcall_id = resolve_call_id(config, &root, selector, resolve_sfcall_id_for_feature)?;
+
+    root.get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_SFCALL"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|c| c.get("SFCALL_ID").and_then(|v| v.as_i64()) == Some(sfcall_id))
+        })
+        .cloned()
         .ok_or_else(|| SzConfigError::NotFound(format!("Standardize call ID {sfcall_id}")))
 }
 
@@ -574,5 +608,41 @@ mod tests {
         assert_all_keys(sfcall, &SFCALL_KEYS);
         assert_eq!(sfcall["EXEC_ORDER"], Value::Null);
         assert_eq!(sfcall["FELEM_ID"], json!(-1));
+    }
+
+    // #40 regression fixtures: SFCALL_ID (5) deliberately differs from FTYPE_ID
+    // (3). getStandardizeCall by feature must scan CFG_SFCALL and return the
+    // call with SFCALL_ID 5, not the (wrong) row the FTYPE_ID-as-call-id bug hit.
+    #[test]
+    fn test_get_standardize_call_by_feature_fixes_ftype_as_id_bug() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+        let by_id = get_standardize_call(config, CallSelector::Id(5)).unwrap();
+        let by_feature = get_standardize_call(config, CallSelector::Feature("NAME")).unwrap();
+        assert_eq!(by_id, by_feature);
+        assert_eq!(by_feature["SFCALL_ID"], json!(5));
+    }
+
+    #[test]
+    fn test_get_standardize_call_ambiguous_feature_errors() {
+        // Two standardize calls for one feature -> by-feature is ambiguous.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 1},
+                {"SFCALL_ID": 6, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 2, "EXEC_ORDER": 2}
+            ]
+        }}"#;
+        let err = get_standardize_call(config, CallSelector::Feature("NAME"));
+        assert_eq!(
+            err.unwrap_err().kind(),
+            crate::error::SzErrorKind::InvalidInput
+        );
+        // Addressing the specific call by id still works.
+        assert!(get_standardize_call(config, CallSelector::Id(6)).is_ok());
     }
 }

--- a/src/calls/standardize.rs
+++ b/src/calls/standardize.rs
@@ -1,7 +1,8 @@
 //! Standardize call management operations
 //!
-//! Functions for managing CFG_SFCALL (standardize calls) and CFG_SBOM
-//! (standardize bill of materials) configuration sections.
+//! Functions for managing CFG_SFCALL (standardize calls) configuration rows.
+//! Standardize calls and their elements are both represented as CFG_SFCALL
+//! rows; there is no separate standardize bill-of-materials table.
 
 use crate::calls::{CallSelector, resolve_call_id};
 use crate::config_rows::SfcallRow;
@@ -220,7 +221,7 @@ pub fn delete_standardize_call(config: &str, sfcall_id: i64) -> Result<String> {
 
     if !call_exists {
         return Err(SzConfigError::NotFound(format!(
-            "Standardize call ID {sfcall_id}"
+            "Standardize call ID {sfcall_id} does not exist"
         )));
     }
 
@@ -277,7 +278,9 @@ pub fn get_standardize_call(config: &str, selector: CallSelector) -> Result<Valu
                 .find(|c| c.get("SFCALL_ID").and_then(|v| v.as_i64()) == Some(sfcall_id))
         })
         .cloned()
-        .ok_or_else(|| SzConfigError::NotFound(format!("Standardize call ID {sfcall_id}")))
+        .ok_or_else(|| {
+            SzConfigError::NotFound(format!("Standardize call ID {sfcall_id} does not exist"))
+        })
 }
 
 /// List all standardize calls with resolved names
@@ -402,9 +405,9 @@ pub fn set_standardize_call(config: &str, _params: SetStandardizeCallParams) -> 
     Ok(config.to_string())
 }
 
-/// Add a standardize call element (SBOM record)
+/// Add a standardize call element (CFG_SFCALL record)
 ///
-/// Creates a new standardize bill of materials entry.
+/// Creates a new standardize call element as a CFG_SFCALL row.
 ///
 /// # Arguments
 /// * `config` - Configuration JSON string
@@ -681,5 +684,22 @@ mod tests {
         assert_eq!(calls[2]["id"], json!(20));
         // Standardize calls carry no BOM, so no elementList key.
         assert!(!calls[0].as_object().unwrap().contains_key("elementList"));
+    }
+
+    // #42: the not-found message must carry the canonical
+    // "{X} call ID {id} does not exist" wording, matching the comparison/
+    // distinct/expression siblings (previously it was truncated).
+    #[test]
+    fn test_delete_standardize_call_not_found_message() {
+        let config = r#"{"G2_CONFIG": {"CFG_SFCALL": []}}"#;
+        let err = delete_standardize_call(config, 99).unwrap_err();
+        assert_eq!(err.to_string(), "Standardize call ID 99 does not exist");
+    }
+
+    #[test]
+    fn test_get_standardize_call_not_found_message() {
+        let config = r#"{"G2_CONFIG": {"CFG_SFCALL": []}}"#;
+        let err = get_standardize_call(config, CallSelector::Id(99)).unwrap_err();
+        assert_eq!(err.to_string(), "Standardize call ID 99 does not exist");
     }
 }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -238,6 +238,7 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                     default_value,
                     internal,
                     required,
+                    id: params.get("id").and_then(|v| v.as_i64()),
                 },
             )
             .map(|(cfg, _)| cfg)
@@ -262,6 +263,7 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                 code: element,
                 description: None, // Will default to code
                 data_type: datatype,
+                id: params.get("id").and_then(|v| v.as_i64()),
             };
 
             crate::elements::add_element(config, add_params)
@@ -313,6 +315,7 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                     comparison: get_opt_str_param(params, "comparison").filter(|s| !s.is_empty()),
                     version: params.get("version").and_then(|v| v.as_i64()),
                     rtype_id: params.get("rtypeId").and_then(|v| v.as_i64()),
+                    id: params.get("id").and_then(|v| v.as_i64()),
                 },
             )
         }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -543,64 +543,15 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
 
         // ===== Call Commands - Comparison =====
         "deleteComparisonCallElement" => {
+            // The SDK now owns the feature->call resolution and exec_order
+            // derivation (#40); the tool is a thin pass-through of the codes.
             let feature = get_str_param(params, "feature")?;
             let element = get_str_param(params, "element")?;
 
-            // Lookup IDs
-            let ftype_id = crate::helpers::lookup_feature_id(config, feature)?;
-            let felem_id = crate::helpers::lookup_element_id(config, element)?;
-
-            // Find the cfcall_id for this feature
-            let config_val: Value = serde_json::from_str(config)?;
-            let cfcall_array = config_val["G2_CONFIG"]["CFG_CFCALL"]
-                .as_array()
-                .ok_or_else(|| SzConfigError::MissingSection("CFG_CFCALL".to_string()))?;
-
-            // Find comparison call for this feature
-            let cfcall = cfcall_array
-                .iter()
-                .find(|call| call["FTYPE_ID"].as_i64() == Some(ftype_id))
-                .ok_or_else(|| {
-                    SzConfigError::NotFound(format!(
-                        "No comparison call found for feature {feature}"
-                    ))
-                })?;
-
-            let cfcall_id = cfcall["CFCALL_ID"]
-                .as_i64()
-                .ok_or_else(|| SzConfigError::InvalidStructure("CFCALL_ID missing".to_string()))?;
-
-            // Find exec_order from CFBOM
-            let cfbom_array = config_val["G2_CONFIG"]["CFG_CFBOM"]
-                .as_array()
-                .ok_or_else(|| SzConfigError::MissingSection("CFG_CFBOM".to_string()))?;
-
-            let cfbom = cfbom_array
-                .iter()
-                .find(|bom| {
-                    bom["CFCALL_ID"].as_i64() == Some(cfcall_id)
-                        && bom["FTYPE_ID"].as_i64() == Some(ftype_id)
-                        && bom["FELEM_ID"].as_i64() == Some(felem_id)
-                })
-                .ok_or_else(|| {
-                    SzConfigError::NotFound(format!(
-                        "Element {element} not found in comparison call for feature {feature}"
-                    ))
-                })?;
-
-            let exec_order = cfbom["EXEC_ORDER"]
-                .as_i64()
-                .ok_or_else(|| SzConfigError::InvalidStructure("EXEC_ORDER missing".to_string()))?;
-
-            // Call underlying SDK function
             crate::calls::comparison::delete_comparison_call_element(
                 config,
-                cfcall_id,
-                crate::calls::comparison::DeleteComparisonCallElementParams {
-                    ftype_id,
-                    felem_id,
-                    exec_order,
-                },
+                crate::calls::CallSelector::Feature(feature),
+                element,
             )
         }
 
@@ -662,61 +613,15 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
 
         // ===== Call Commands - Distinct =====
         "deleteDistinctCallElement" => {
+            // Thin pass-through: the SDK resolves the feature->call id and
+            // derives the BOM exec_order internally (#40).
             let feature = get_str_param(params, "feature")?;
             let element = get_str_param(params, "element")?;
 
-            // Lookup IDs
-            let ftype_id = crate::helpers::lookup_feature_id(config, feature)?;
-            let felem_id = crate::helpers::lookup_element_id(config, element)?;
-
-            // Find the dfcall_id for this feature
-            let config_val: Value = serde_json::from_str(config)?;
-            let dfcall_array = config_val["G2_CONFIG"]["CFG_DFCALL"]
-                .as_array()
-                .ok_or_else(|| SzConfigError::MissingSection("CFG_DFCALL".to_string()))?;
-
-            let dfcall = dfcall_array
-                .iter()
-                .find(|call| call["FTYPE_ID"].as_i64() == Some(ftype_id))
-                .ok_or_else(|| {
-                    SzConfigError::NotFound(format!("No distinct call found for feature {feature}"))
-                })?;
-
-            let dfcall_id = dfcall["DFCALL_ID"]
-                .as_i64()
-                .ok_or_else(|| SzConfigError::InvalidStructure("DFCALL_ID missing".to_string()))?;
-
-            // Find exec_order from DFBOM
-            let dfbom_array = config_val["G2_CONFIG"]["CFG_DFBOM"]
-                .as_array()
-                .ok_or_else(|| SzConfigError::MissingSection("CFG_DFBOM".to_string()))?;
-
-            let dfbom = dfbom_array
-                .iter()
-                .find(|bom| {
-                    bom["DFCALL_ID"].as_i64() == Some(dfcall_id)
-                        && bom["FTYPE_ID"].as_i64() == Some(ftype_id)
-                        && bom["FELEM_ID"].as_i64() == Some(felem_id)
-                })
-                .ok_or_else(|| {
-                    SzConfigError::NotFound(format!(
-                        "Element {element} not found in distinct call for feature {feature}"
-                    ))
-                })?;
-
-            let exec_order = dfbom["EXEC_ORDER"]
-                .as_i64()
-                .ok_or_else(|| SzConfigError::InvalidStructure("EXEC_ORDER missing".to_string()))?;
-
-            // Call underlying SDK function
             crate::calls::distinct::delete_distinct_call_element(
                 config,
-                crate::calls::distinct::DeleteDistinctCallElementParams {
-                    dfcall_id,
-                    ftype_id,
-                    felem_id,
-                    exec_order,
-                },
+                crate::calls::CallSelector::Feature(feature),
+                element,
             )
         }
 

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -366,12 +366,14 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
             let fragment = get_str_param(params, "fragment")?;
             let source = get_str_param(params, "source")?;
 
-            // Construct fragment config with ERFRAG_SOURCE
-            let fragment_config = serde_json::json!({
-                "ERFRAG_SOURCE": source
-            });
-
-            crate::fragments::set_fragment(config, fragment, &fragment_config)
+            crate::fragments::set_fragment(
+                config,
+                fragment,
+                crate::fragments::SetFragmentParams {
+                    source: crate::helpers::FieldUpdate::Set(source),
+                    description: crate::helpers::FieldUpdate::Leave,
+                },
+            )
         }
 
         "addFragment" => {
@@ -417,7 +419,7 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                 config,
                 func,
                 crate::functions::standardize::AddStandardizeFunctionParams {
-                    connect_str: connect,
+                    connect_str: Some(connect),
                     description: desc,
                     language,
                 },
@@ -442,7 +444,7 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                 config,
                 func,
                 crate::functions::comparison::AddComparisonFunctionParams {
-                    connect_str: connect,
+                    connect_str: Some(connect),
                     description: desc,
                     language: None,
                     anon_support: anon,
@@ -462,7 +464,7 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                 config,
                 func,
                 crate::functions::expression::AddExpressionFunctionParams {
-                    connect_str: connect,
+                    connect_str: Some(connect),
                     description: desc,
                     language,
                 },

--- a/src/config_sections.rs
+++ b/src/config_sections.rs
@@ -4,6 +4,7 @@
 //! These functions allow adding, removing, and querying configuration sections.
 
 use crate::error::{Result, SzConfigError};
+use crate::filter::to_json_dumps_string;
 use serde_json::{Value, json};
 
 /// Outcome counts for [`add_config_section_field`].
@@ -106,6 +107,26 @@ pub fn remove_config_section(config_json: &str, section_name: &str) -> Result<St
 
 /// Get items from a configuration section with optional filtering
 ///
+/// # Filter substrate
+///
+/// When a `filter` is supplied each record is stringified with **`json.dumps`
+/// spacing** (`{"K": 1, "J": null}`) — via [`crate::filter::to_json_dumps_string`]
+/// — before the case-insensitive substring test. This matches Python's
+/// `do_getConfigSection`, which filters on `json.dumps(record).lower()`. The
+/// previous implementation used compact `serde_json::to_string`
+/// (`{"K":1,"J":null}`), so a filter term spanning a key/value boundary (a `": "`
+/// or `", "`) matched under Python but missed here. The deliberate `ensure_ascii`
+/// limitation carried by [`crate::filter`] applies (non-ASCII is emitted as
+/// UTF-8, not `\uXXXX`).
+///
+/// # Empty vs. no-match
+///
+/// This function returns an empty `Vec` both when the section is empty and when a
+/// filter matched nothing; it does **not** distinguish the two (its return type
+/// is unchanged for backwards compatibility). Use [`config_section_is_empty`] to
+/// tell them apart — Python emits different messages ("Configuration section is
+/// empty" vs. "Nothing to display").
+///
 /// # Arguments
 ///
 /// * `config_json` - Configuration JSON string
@@ -147,25 +168,25 @@ pub fn get_config_section(
         return Ok(Vec::new());
     }
 
+    // Case-insensitive substring test on the json.dumps-spaced rendering (Python
+    // parity — see the "Filter substrate" doc section).
+    let matches = |record: &Value, needle: &str| -> bool {
+        to_json_dumps_string(record)
+            .to_lowercase()
+            .contains(&needle.to_lowercase())
+    };
+
     // Apply filter if provided
     let output_data = if let Some(filter_str) = filter {
         if let Some(array) = section_data.as_array() {
             array
                 .iter()
-                .filter(|record| {
-                    serde_json::to_string(record)
-                        .unwrap_or_default()
-                        .to_lowercase()
-                        .contains(&filter_str.to_lowercase())
-                })
+                .filter(|record| matches(record, filter_str))
                 .cloned()
                 .collect()
         } else {
             // Not an array, just check the single value
-            let as_string = serde_json::to_string(section_data)
-                .unwrap_or_default()
-                .to_lowercase();
-            if as_string.contains(&filter_str.to_lowercase()) {
+            if matches(section_data, filter_str) {
                 vec![section_data.clone()]
             } else {
                 Vec::new()
@@ -181,6 +202,62 @@ pub fn get_config_section(
     };
 
     Ok(output_data)
+}
+
+/// Report whether a configuration section is empty.
+///
+/// A companion to [`get_config_section`] that lets a caller distinguish an
+/// **empty section** from a **filter that matched nothing** — both of which come
+/// back from `get_config_section` as an empty `Vec`. Python emits different
+/// messages for the two cases ("Configuration section is empty" vs. "Nothing to
+/// display"); this accessor supplies the discriminator without a breaking change
+/// to `get_config_section`'s return type.
+///
+/// A section counts as empty when it is JSON `null` or an empty array. A
+/// non-array, non-null value (e.g. a scalar or object) counts as non-empty.
+///
+/// # Arguments
+///
+/// * `config_json` - Configuration JSON string
+/// * `section_name` - Name of the section to check
+///
+/// # Returns
+///
+/// * `Ok(true)` if the section exists and is empty (null or `[]`)
+/// * `Ok(false)` if the section exists and holds at least one item
+/// * `Err(SzConfigError::NotFound)` if the section does not exist
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::config_sections::{config_section_is_empty, get_config_section};
+///
+/// let config = r#"{"G2_CONFIG": {"CFG_ATTR": [{"ATTR_CODE": "NAME"}], "CFG_EMPTY": []}}"#;
+///
+/// // Empty section -> is_empty is true.
+/// assert!(config_section_is_empty(config, "CFG_EMPTY").unwrap());
+///
+/// // Populated section that a filter excludes: get returns [] but is_empty is false,
+/// // so the caller knows it was "nothing matched", not "section empty".
+/// let matched = get_config_section(config, "CFG_ATTR", Some("PHONE")).unwrap();
+/// assert!(matched.is_empty());
+/// assert!(!config_section_is_empty(config, "CFG_ATTR").unwrap());
+/// ```
+pub fn config_section_is_empty(config_json: &str, section_name: &str) -> Result<bool> {
+    let config_data: Value = serde_json::from_str(config_json)?;
+
+    let section_data = config_data
+        .get("G2_CONFIG")
+        .and_then(|g2| g2.get(section_name))
+        .ok_or_else(|| {
+            SzConfigError::NotFound(format!("Configuration section '{section_name}' not found"))
+        })?;
+
+    Ok(section_data.is_null()
+        || section_data
+            .as_array()
+            .map(|arr| arr.is_empty())
+            .unwrap_or(false))
 }
 
 /// List all configuration section names
@@ -418,5 +495,53 @@ mod tests {
         let config = r#"{"G2_CONFIG": {"CFG_ATTR": []}}"#;
         let err = add_config_section_field(config, "CFG_NOPE", "F", &json!("x")).unwrap_err();
         assert_eq!(err.kind(), SzErrorKind::NotFound);
+    }
+
+    // #36 in-repo repro: a record like {"K":1,"J":null} with a boundary-spanning
+    // filter term. Under the old compact substrate the term missed; under the new
+    // json.dumps substrate it matches (Python parity).
+    #[test]
+    fn test_get_config_section_boundary_spanning_filter_matches_json_dumps() {
+        let config = r#"{"G2_CONFIG": {"CFG_X": [{"K": 1, "J": null}]}}"#;
+
+        // Boundary-spanning term with the json.dumps ", " spacing between items.
+        let matched = get_config_section(config, "CFG_X", Some("1, \"j\"")).unwrap();
+        assert_eq!(matched.len(), 1, "json.dumps substrate should match");
+
+        // Key/value boundary (": ") likewise matches.
+        let matched = get_config_section(config, "CFG_X", Some("\"k\": 1")).unwrap();
+        assert_eq!(matched.len(), 1);
+
+        // A term only present in the compact form (no spaces) must NOT match now.
+        let missed = get_config_section(config, "CFG_X", Some("1,\"j\"")).unwrap();
+        assert!(
+            missed.is_empty(),
+            "compact-only term must miss under json.dumps"
+        );
+    }
+
+    #[test]
+    fn test_config_section_is_empty_distinguishes_empty_vs_no_match() {
+        let config = r#"{"G2_CONFIG": {"CFG_ATTR": [{"ATTR_CODE": "NAME"}], "CFG_EMPTY": []}}"#;
+
+        // Empty section -> is_empty true.
+        assert!(config_section_is_empty(config, "CFG_EMPTY").unwrap());
+
+        // Populated section with a filter that excludes everything: get returns
+        // [] but is_empty is false -> caller can tell "nothing matched" apart from
+        // "section empty".
+        let matched = get_config_section(config, "CFG_ATTR", Some("PHONE")).unwrap();
+        assert!(matched.is_empty());
+        assert!(!config_section_is_empty(config, "CFG_ATTR").unwrap());
+
+        // Missing section -> NotFound, same as get_config_section.
+        let err = config_section_is_empty(config, "CFG_NOPE").unwrap_err();
+        assert_eq!(err.kind(), SzErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_config_section_is_empty_null_section() {
+        let config = r#"{"G2_CONFIG": {"CFG_NULL": null}}"#;
+        assert!(config_section_is_empty(config, "CFG_NULL").unwrap());
     }
 }

--- a/src/config_sections.rs
+++ b/src/config_sections.rs
@@ -6,6 +6,18 @@
 use crate::error::{Result, SzConfigError};
 use serde_json::{Value, json};
 
+/// Outcome counts for [`add_config_section_field`].
+///
+/// `existed` counts items that already carried the field (and were therefore
+/// left untouched); `updated` counts items the field was newly inserted into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AddFieldCounts {
+    /// Number of items that already had the field (value preserved, not overwritten).
+    pub existed: usize,
+    /// Number of items the field was newly added to.
+    pub updated: usize,
+}
+
 /// Add a new configuration section
 ///
 /// # Arguments
@@ -217,7 +229,14 @@ pub fn list_config_sections(config_json: &str) -> Result<Vec<String>> {
 ///
 /// # Returns
 ///
-/// Returns `(modified_config, item_count)` tuple on success
+/// Returns `(modified_config, AddFieldCounts)` on success. The counts report how
+/// many items already had the field (left untouched) versus how many the field
+/// was newly added to.
+///
+/// # Behaviour
+///
+/// The field is inserted only into items that do **not** already have it, so an
+/// existing value is never overwritten.
 ///
 /// # Example
 ///
@@ -226,26 +245,28 @@ pub fn list_config_sections(config_json: &str) -> Result<Vec<String>> {
 /// use serde_json::json;
 ///
 /// let config = r#"{"G2_CONFIG": {"CFG_ATTR": [{"ATTR_CODE": "NAME"}]}}"#;
-/// let (modified, count) = config_sections::add_config_section_field(
+/// let (modified, counts) = config_sections::add_config_section_field(
 ///     config,
 ///     "CFG_ATTR",
 ///     "NEW_FIELD",
 ///     &json!("default")
 /// ).unwrap();
-/// assert_eq!(count, 1);
+/// assert_eq!(counts.updated, 1);
+/// assert_eq!(counts.existed, 0);
 /// ```
 pub fn add_config_section_field(
     config_json: &str,
     section_name: &str,
     field_name: &str,
     field_value: &Value,
-) -> Result<(String, usize)> {
+) -> Result<(String, AddFieldCounts)> {
     let section_name = section_name.to_uppercase();
     let field_name = field_name.to_uppercase();
     let mut config_data: Value = serde_json::from_str(config_json)?;
-    let mut item_count = 0;
+    let mut counts = AddFieldCounts::default();
 
-    // Navigate to section and add field to all items in the array
+    // Navigate to section and add the field only to items that lack it, so an
+    // existing value is never overwritten.
     if let Some(g2_config) = config_data.get_mut("G2_CONFIG") {
         if let Some(section_array) = g2_config
             .get_mut(&section_name)
@@ -253,8 +274,12 @@ pub fn add_config_section_field(
         {
             for item in section_array.iter_mut() {
                 if let Some(item_obj) = item.as_object_mut() {
-                    item_obj.insert(field_name.clone(), field_value.clone());
-                    item_count += 1;
+                    if item_obj.contains_key(&field_name) {
+                        counts.existed += 1;
+                    } else {
+                        item_obj.insert(field_name.clone(), field_value.clone());
+                        counts.updated += 1;
+                    }
                 }
             }
         } else {
@@ -264,7 +289,7 @@ pub fn add_config_section_field(
         }
     }
 
-    Ok((serde_json::to_string(&config_data)?, item_count))
+    Ok((serde_json::to_string(&config_data)?, counts))
 }
 
 /// Remove a field from all items in a configuration section
@@ -323,4 +348,75 @@ pub fn remove_config_section_field(
     }
 
     Ok((serde_json::to_string(&config_data)?, item_count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::SzErrorKind;
+
+    #[test]
+    fn test_add_config_section_field_added() {
+        let config = r#"{"G2_CONFIG": {"CFG_ATTR": [
+            {"ATTR_CODE": "NAME"},
+            {"ATTR_CODE": "PHONE"}
+        ]}}"#;
+
+        let (modified, counts) =
+            add_config_section_field(config, "CFG_ATTR", "NEW_FIELD", &json!("default")).unwrap();
+        assert_eq!(counts.updated, 2);
+        assert_eq!(counts.existed, 0);
+
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let arr = value["G2_CONFIG"]["CFG_ATTR"].as_array().unwrap();
+        assert_eq!(arr[0]["NEW_FIELD"], json!("default"));
+        assert_eq!(arr[1]["NEW_FIELD"], json!("default"));
+    }
+
+    #[test]
+    fn test_add_config_section_field_already_present_preserves_value() {
+        let config = r#"{"G2_CONFIG": {"CFG_ATTR": [
+            {"ATTR_CODE": "NAME", "EXISTING": "keep-me"}
+        ]}}"#;
+
+        let (modified, counts) =
+            add_config_section_field(config, "CFG_ATTR", "EXISTING", &json!("overwrite")).unwrap();
+        assert_eq!(counts.updated, 0);
+        assert_eq!(counts.existed, 1);
+
+        // The pre-existing value must be preserved, never overwritten.
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(
+            value["G2_CONFIG"]["CFG_ATTR"][0]["EXISTING"],
+            json!("keep-me")
+        );
+    }
+
+    #[test]
+    fn test_add_config_section_field_mixed() {
+        let config = r#"{"G2_CONFIG": {"CFG_ATTR": [
+            {"ATTR_CODE": "NAME", "F": "old"},
+            {"ATTR_CODE": "PHONE"},
+            {"ATTR_CODE": "EMAIL"}
+        ]}}"#;
+
+        // Field name is upper-cased before matching, so "f" matches "F".
+        let (modified, counts) =
+            add_config_section_field(config, "CFG_ATTR", "f", &json!("new")).unwrap();
+        assert_eq!(counts.existed, 1);
+        assert_eq!(counts.updated, 2);
+
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let arr = value["G2_CONFIG"]["CFG_ATTR"].as_array().unwrap();
+        assert_eq!(arr[0]["F"], json!("old")); // preserved
+        assert_eq!(arr[1]["F"], json!("new"));
+        assert_eq!(arr[2]["F"], json!("new"));
+    }
+
+    #[test]
+    fn test_add_config_section_field_missing_section_errors() {
+        let config = r#"{"G2_CONFIG": {"CFG_ATTR": []}}"#;
+        let err = add_config_section_field(config, "CFG_NOPE", "F", &json!("x")).unwrap_err();
+        assert_eq!(err.kind(), SzErrorKind::NotFound);
+    }
 }

--- a/src/datasources.rs
+++ b/src/datasources.rs
@@ -29,10 +29,32 @@ struct DsrcRow {
 // ============================================================================
 
 /// Parameters for adding a data source
+///
+/// `id` is a caller-supplied `DSRC_ID`. Leave it `None` (or pass a non-positive
+/// value) to auto-assign the next free id (seeded at the user-range floor of
+/// 1000); pass `Some(id > 0)` to request that exact id — [`add_data_source`]
+/// then fails with `AlreadyExists` if it is already taken.
 #[derive(Debug, Clone, Default)]
 pub struct AddDataSourceParams<'a> {
     pub code: &'a str,
     pub retention_level: Option<&'a str>,
+    pub id: Option<i64>,
+}
+
+impl<'a> AddDataSourceParams<'a> {
+    /// Request a specific `DSRC_ID` for the new data source.
+    ///
+    /// # Example
+    /// ```
+    /// use sz_configtool_lib::datasources::AddDataSourceParams;
+    /// let params = AddDataSourceParams { code: "CUSTOMERS", ..Default::default() }
+    ///     .with_id(1500);
+    /// assert_eq!(params.id, Some(1500));
+    /// ```
+    pub fn with_id(mut self, id: i64) -> Self {
+        self.id = Some(id);
+        self
+    }
 }
 
 /// Parameters for setting (updating) a data source
@@ -54,6 +76,7 @@ impl<'a> TryFrom<&'a Value> for AddDataSourceParams<'a> {
         Ok(Self {
             code,
             retention_level: json.get("retentionLevel").and_then(|v| v.as_str()),
+            id: json.get("id").and_then(|v| v.as_i64()),
         })
     }
 }
@@ -108,7 +131,10 @@ pub fn add_data_source(config_json: &str, params: AddDataSourceParams) -> Result
         )));
     }
 
-    let next_id = helpers::get_next_id_from_array(dsrcs, "DSRC_ID")?;
+    // Caller-supplied id (#37): None / non-positive -> auto-assign the next free
+    // id at the user-range floor of 1000; a specific id > 0 is honoured unless
+    // already taken (get_desired_or_next_id then returns AlreadyExists).
+    let next_id = helpers::get_desired_or_next_id(dsrcs, "DSRC_ID", params.id, 1000)?;
 
     // Validate and use parameters or defaults (case-insensitive with normalization)
     let retention = if let Some(level) = params.retention_level {
@@ -309,6 +335,7 @@ mod tests {
         let params = AddDataSourceParams {
             code: "customers",
             retention_level: None,
+            id: None,
         };
 
         let modified = add_data_source(TEST_CONFIG, params).unwrap();
@@ -329,6 +356,7 @@ mod tests {
         let params = AddDataSourceParams {
             code: "watchlist",
             retention_level: Some("forget"),
+            id: None,
         };
 
         let modified = add_data_source(TEST_CONFIG, params).unwrap();
@@ -340,5 +368,78 @@ mod tests {
             assert!(obj.contains_key(key), "{key} key must be present");
         }
         assert_eq!(dsrc["RETENTION_LEVEL"], json!("Forget"));
+    }
+
+    #[test]
+    fn test_add_data_source_auto_id_seeds_1000() {
+        // D18: a fresh data source now seeds at DSRC_ID 1000, not 3, even when the
+        // reserved system data sources (1, 2) are present.
+        let config = r#"{"G2_CONFIG": {"CFG_DSRC": [
+            {"DSRC_ID": 1, "DSRC_CODE": "TEST"},
+            {"DSRC_ID": 2, "DSRC_CODE": "SEARCH"}
+        ]}}"#;
+        let modified = add_data_source(
+            config,
+            AddDataSourceParams {
+                code: "customers",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dsrc = value["G2_CONFIG"]["CFG_DSRC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(dsrc["DSRC_ID"], json!(1000));
+    }
+
+    #[test]
+    fn test_add_data_source_specific_id_honoured() {
+        let modified = add_data_source(
+            TEST_CONFIG,
+            AddDataSourceParams {
+                code: "customers",
+                id: Some(2500),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dsrc = &value["G2_CONFIG"]["CFG_DSRC"][0];
+        assert_eq!(dsrc["DSRC_ID"], json!(2500));
+    }
+
+    #[test]
+    fn test_add_data_source_taken_id_rejected() {
+        let config = r#"{"G2_CONFIG": {"CFG_DSRC": [{"DSRC_ID": 2500, "DSRC_CODE": "OTHER"}]}}"#;
+        let err = add_data_source(
+            config,
+            AddDataSourceParams {
+                code: "customers",
+                id: Some(2500),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_add_data_source_nonpositive_id_falls_back_to_auto() {
+        // D17: a non-positive requested id auto-assigns rather than erroring.
+        let modified = add_data_source(
+            TEST_CONFIG,
+            AddDataSourceParams {
+                code: "customers",
+                id: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let dsrc = &value["G2_CONFIG"]["CFG_DSRC"][0];
+        assert_eq!(dsrc["DSRC_ID"], json!(1000));
     }
 }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,18 +1,126 @@
+use crate::config_rows::FbomRow;
 use crate::config_rows::FelemRow;
 use crate::error::{Result, SzConfigError};
 use crate::helpers;
 use serde_json::{Value, json};
 
 // ============================================================================
+// Canonical feature-element validation (D25)
+// ============================================================================
+//
+// One source of truth for validating the DISPLAY_LEVEL and DERIVED columns of a
+// CFG_FBOM (feature-element) row, shared by [`add_element_to_feature`] and
+// [`set_feature_element`] so the two cannot drift. `add_feature`'s own
+// element-list builder is intentionally left on its (more lenient, coercing)
+// path this wave to avoid changing its established behaviour.
+
+/// Validate a feature-element `DISPLAY_LEVEL`.
+///
+/// The level is stored as an integer (sz-tools#130); a negative value is
+/// rejected as invalid input.
+pub(crate) fn validate_display_level(level: i64) -> Result<i64> {
+    if level < 0 {
+        return Err(SzConfigError::InvalidInput(format!(
+            "Invalid DISPLAY_LEVEL value '{level}'. Must be a non-negative integer"
+        )));
+    }
+    Ok(level)
+}
+
+/// Validate and canonicalize a feature-element `DERIVED` flag to `"Yes"`/`"No"`.
+pub(crate) fn validate_derived(value: &str) -> Result<&'static str> {
+    match value.to_uppercase().as_str() {
+        "YES" => Ok("Yes"),
+        "NO" => Ok("No"),
+        _ => Err(SzConfigError::InvalidInput(format!(
+            "Invalid DERIVED value '{value}'. Must be 'Yes' or 'No'"
+        ))),
+    }
+}
+
+// ============================================================================
 // Parameter Structs
 // ============================================================================
 
+/// Parameters for adding an element to a feature (a new CFG_FBOM row).
+///
+/// `display_level` defaults to `1`, `derived` to `"No"`, and `display_delim` to
+/// null when omitted. `EXEC_ORDER` is always allocated automatically.
+#[derive(Debug, Clone, Default)]
+pub struct AddElementToFeatureParams<'a> {
+    pub feature_code: &'a str,
+    pub element_code: &'a str,
+    pub display_level: Option<i64>,
+    pub display_delim: Option<&'a str>,
+    pub derived: Option<&'a str>,
+}
+
+impl<'a> AddElementToFeatureParams<'a> {
+    /// Create params for the given feature and element codes.
+    pub fn new(feature_code: &'a str, element_code: &'a str) -> Self {
+        Self {
+            feature_code,
+            element_code,
+            ..Default::default()
+        }
+    }
+
+    /// Set the display level (default `1`).
+    pub fn with_display_level(mut self, level: i64) -> Self {
+        self.display_level = Some(level);
+        self
+    }
+
+    /// Set the display delimiter (default null).
+    pub fn with_display_delim(mut self, delim: &'a str) -> Self {
+        self.display_delim = Some(delim);
+        self
+    }
+
+    /// Set the derived flag (default `"No"`).
+    pub fn with_derived(mut self, derived: &'a str) -> Self {
+        self.derived = Some(derived);
+        self
+    }
+}
+
+impl<'a> TryFrom<&'a Value> for AddElementToFeatureParams<'a> {
+    type Error = SzConfigError;
+
+    fn try_from(json: &'a Value) -> Result<Self> {
+        let feature_code = json
+            .get("featureCode")
+            .or_else(|| json.get("feature"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| SzConfigError::MissingField("featureCode".to_string()))?;
+        let element_code = json
+            .get("elementCode")
+            .or_else(|| json.get("element"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| SzConfigError::MissingField("elementCode".to_string()))?;
+
+        Ok(Self {
+            feature_code,
+            element_code,
+            display_level: json.get("displayLevel").and_then(|v| v.as_i64()),
+            display_delim: json.get("displayDelim").and_then(|v| v.as_str()),
+            derived: json.get("derived").and_then(|v| v.as_str()),
+        })
+    }
+}
+
 /// Parameters for adding an element
+///
+/// `id` is a caller-supplied `FELEM_ID`. Leave it `None` (or pass a non-positive
+/// value) to auto-assign the next free id (seeded at the user-range floor of
+/// 1000); pass `Some(id > 0)` to request that exact id — [`add_element`] then
+/// fails with `AlreadyExists` if it is already taken.
 #[derive(Debug, Clone)]
 pub struct AddElementParams<'a> {
     pub code: &'a str,
     pub description: Option<&'a str>,
     pub data_type: Option<&'a str>,
+    pub id: Option<i64>,
 }
 
 impl<'a> TryFrom<&'a Value> for AddElementParams<'a> {
@@ -28,6 +136,7 @@ impl<'a> TryFrom<&'a Value> for AddElementParams<'a> {
             code,
             description: json.get("description").and_then(|v| v.as_str()),
             data_type: json.get("dataType").and_then(|v| v.as_str()),
+            id: json.get("id").and_then(|v| v.as_i64()),
         })
     }
 }
@@ -171,8 +280,10 @@ pub fn add_element(config_json: &str, params: AddElementParams) -> Result<String
         )));
     }
 
-    // Get next ID
-    let felem_id = helpers::get_next_id_with_min(felem_array, "FELEM_ID", 1000)?;
+    // Get next FELEM_ID. Caller-supplied id (#37): None / non-positive ->
+    // auto-assign at the user-range floor of 1000; a specific id > 0 is honoured
+    // unless already taken (get_desired_or_next_id returns AlreadyExists).
+    let felem_id = helpers::get_desired_or_next_id(felem_array, "FELEM_ID", params.id, 1000)?;
 
     // Validate and normalize datatype (Python lines 1974-1981)
     let data_type = if let Some(dt) = params.data_type {
@@ -443,29 +554,19 @@ pub fn set_feature_element(config_json: &str, params: SetFeatureElementParams) -
             ))
         })?;
 
-    // Update fields if provided (with validation for Python parity)
+    // Update fields if provided, using the canonical validators (D25) shared
+    // with add_element_to_feature.
     if let Some(order) = params.exec_order {
         fbom["EXEC_ORDER"] = json!(order);
     }
     if let Some(level) = params.display_level {
-        fbom["DISPLAY_LEVEL"] = json!(level);
+        fbom["DISPLAY_LEVEL"] = json!(validate_display_level(level)?);
     }
     if let Some(delim) = params.display_delim {
         fbom["DISPLAY_DELIM"] = json!(delim);
     }
     if let Some(der) = params.derived {
-        // Validate derived domain (Python lines 2192-2198)
-        let der_upper = der.to_uppercase();
-        let validated_derived = match der_upper.as_str() {
-            "YES" => "Yes",
-            "NO" => "No",
-            _ => {
-                return Err(SzConfigError::InvalidInput(format!(
-                    "Invalid DERIVED value '{der}'. Must be 'Yes' or 'No'"
-                )));
-            }
-        };
-        fbom["DERIVED"] = json!(validated_derived);
+        fbom["DERIVED"] = json!(validate_derived(der)?);
     }
 
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
@@ -533,6 +634,136 @@ pub fn set_feature_element_derived(
         config_json,
         SetFeatureElementParams::new(feature_code, element_code).with_derived(derived),
     )
+}
+
+/// Add an element to a feature (append a new CFG_FBOM row).
+///
+/// Resolves the feature and element codes to their ids, rejects a duplicate
+/// `(FTYPE_ID, FELEM_ID)` mapping with `AlreadyExists`, allocates a fresh
+/// `EXEC_ORDER` from the whole CFG_FBOM table, and writes a complete
+/// [`FbomRow`](crate::config_rows) (every key present). `DISPLAY_LEVEL` and
+/// `DERIVED` are checked with the canonical validators (D25).
+///
+/// # Arguments
+/// * `config_json` - JSON configuration string
+/// * `params` - Feature/element codes and optional display/derived overrides
+///
+/// # Errors
+/// - `NotFound` if the feature or element code does not exist
+/// - `AlreadyExists` if the feature already maps that element
+/// - `InvalidInput` if `display_level` or `derived` is invalid
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::elements::{add_element_to_feature, AddElementToFeatureParams};
+///
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+///     "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+///     "CFG_FBOM": []
+/// }}"#;
+/// let params = AddElementToFeatureParams::new("NAME", "FULL_NAME");
+/// let updated = add_element_to_feature(config, params)?;
+/// assert!(updated.contains("FULL_NAME") || updated.contains("\"FELEM_ID\":2"));
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn add_element_to_feature(
+    config_json: &str,
+    params: AddElementToFeatureParams,
+) -> Result<String> {
+    let ftype_id = helpers::lookup_feature_id(config_json, params.feature_code)?;
+    let felem_id = helpers::lookup_element_id(config_json, params.element_code)?;
+
+    // Validate the display/derived inputs before mutating anything.
+    let display_level = validate_display_level(params.display_level.unwrap_or(1))?;
+    let derived = validate_derived(params.derived.unwrap_or("No"))?;
+
+    let mut config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let fbom_array = config["G2_CONFIG"]["CFG_FBOM"]
+        .as_array_mut()
+        .ok_or_else(|| SzConfigError::MissingSection("CFG_FBOM".to_string()))?;
+
+    // Duplicate (FTYPE_ID, FELEM_ID) detection.
+    if fbom_array.iter().any(|item| {
+        item["FTYPE_ID"].as_i64() == Some(ftype_id) && item["FELEM_ID"].as_i64() == Some(felem_id)
+    }) {
+        return Err(SzConfigError::AlreadyExists(format!(
+            "Feature element mapping already exists: FTYPE_ID={ftype_id}, FELEM_ID={felem_id}"
+        )));
+    }
+
+    // Whole-table EXEC_ORDER allocation (max over the entire CFG_FBOM + 1).
+    let exec_order = helpers::get_next_id_from_array(fbom_array, "EXEC_ORDER")?;
+
+    let row = FbomRow {
+        ftype_id,
+        felem_id,
+        exec_order: Some(exec_order),
+        display_level: Some(display_level),
+        display_delim: params.display_delim.map(str::to_string),
+        derived: Some(derived.to_string()),
+    };
+    fbom_array.push(serde_json::to_value(&row)?);
+
+    serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+}
+
+/// Delete a single feature-element mapping (one CFG_FBOM row).
+///
+/// The inverse of [`add_element_to_feature`]: removes the row matching both the
+/// resolved feature id and element id. Returns `NotFound` if the mapping is
+/// absent.
+///
+/// # Arguments
+/// * `config_json` - JSON configuration string
+/// * `feature_code` - Feature code (case-insensitive)
+/// * `element_code` - Element code (case-insensitive)
+///
+/// # Errors
+/// - `NotFound` if the feature, element, or the mapping does not exist
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::elements::delete_element_from_feature;
+///
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+///     "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+///     "CFG_FBOM": [{"FTYPE_ID": 1, "FELEM_ID": 2, "EXEC_ORDER": 1, "DISPLAY_LEVEL": 1}]
+/// }}"#;
+/// let updated = delete_element_from_feature(config, "NAME", "FULL_NAME")?;
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn delete_element_from_feature(
+    config_json: &str,
+    feature_code: &str,
+    element_code: &str,
+) -> Result<String> {
+    let ftype_id = helpers::lookup_feature_id(config_json, feature_code)?;
+    let felem_id = helpers::lookup_element_id(config_json, element_code)?;
+
+    let mut config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let fbom_array = config["G2_CONFIG"]["CFG_FBOM"]
+        .as_array_mut()
+        .ok_or_else(|| SzConfigError::MissingSection("CFG_FBOM".to_string()))?;
+
+    let original_len = fbom_array.len();
+    fbom_array.retain(|item| {
+        !(item["FTYPE_ID"].as_i64() == Some(ftype_id)
+            && item["FELEM_ID"].as_i64() == Some(felem_id))
+    });
+
+    if fbom_array.len() == original_len {
+        return Err(SzConfigError::NotFound(format!(
+            "Feature element mapping not found: FTYPE_ID={ftype_id}, FELEM_ID={felem_id}"
+        )));
+    }
+
+    serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
 
 #[cfg(test)]
@@ -654,6 +885,7 @@ mod tests {
             code: "my_elem",
             description: None,
             data_type: None,
+            id: None,
         };
 
         let modified = add_element(config, params).unwrap();
@@ -681,6 +913,7 @@ mod tests {
             code: "my_elem",
             description: Some("My element"),
             data_type: Some("number"),
+            id: None,
         };
 
         let modified = add_element(config, params).unwrap();
@@ -710,5 +943,146 @@ mod tests {
         let config: Value = serde_json::from_str(&result.unwrap()).unwrap();
         let fbom = &config["G2_CONFIG"]["CFG_FBOM"][0];
         assert_eq!(fbom["DISPLAY_LEVEL"], 9);
+    }
+
+    #[test]
+    fn test_add_element_auto_id_seeds_1000() {
+        let config = r#"{"G2_CONFIG": {"CFG_FELEM": [{"FELEM_ID": 5, "FELEM_CODE": "X"}]}}"#;
+        let modified = add_element(
+            config,
+            AddElementParams {
+                code: "my_elem",
+                description: None,
+                data_type: None,
+                id: None,
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let felem = value["G2_CONFIG"]["CFG_FELEM"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(felem["FELEM_ID"], json!(1000));
+    }
+
+    #[test]
+    fn test_add_element_specific_id_and_taken() {
+        let config = r#"{"G2_CONFIG": {"CFG_FELEM": []}}"#;
+        let modified = add_element(
+            config,
+            AddElementParams {
+                code: "my_elem",
+                description: None,
+                data_type: None,
+                id: Some(2500),
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(value["G2_CONFIG"]["CFG_FELEM"][0]["FELEM_ID"], json!(2500));
+
+        // Requesting the now-taken id fails.
+        let err = add_element(
+            &modified,
+            AddElementParams {
+                code: "other",
+                description: None,
+                data_type: None,
+                id: Some(2500),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_add_element_to_feature_emits_all_keys_and_exec_order() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+            "CFG_FBOM": [{"FTYPE_ID": 9, "FELEM_ID": 9, "EXEC_ORDER": 7, "DISPLAY_LEVEL": 1,
+                          "DISPLAY_DELIM": null, "DERIVED": "No"}]
+        }}"#;
+        let modified = add_element_to_feature(
+            config,
+            AddElementToFeatureParams::new("name", "full_name").with_display_level(3),
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let row = value["G2_CONFIG"]["CFG_FBOM"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        let obj = row.as_object().unwrap();
+        for key in [
+            "FTYPE_ID",
+            "FELEM_ID",
+            "EXEC_ORDER",
+            "DISPLAY_LEVEL",
+            "DISPLAY_DELIM",
+            "DERIVED",
+        ] {
+            assert!(obj.contains_key(key), "{key} key must be present");
+        }
+        assert_eq!(row["FTYPE_ID"], json!(1));
+        assert_eq!(row["FELEM_ID"], json!(2));
+        // Whole-table EXEC_ORDER allocation: max(7) + 1.
+        assert_eq!(row["EXEC_ORDER"], json!(8));
+        assert_eq!(row["DISPLAY_LEVEL"], json!(3));
+        assert_eq!(row["DERIVED"], json!("No"));
+        assert_eq!(row["DISPLAY_DELIM"], Value::Null);
+    }
+
+    #[test]
+    fn test_add_element_to_feature_duplicate_rejected() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+            "CFG_FBOM": [{"FTYPE_ID": 1, "FELEM_ID": 2, "EXEC_ORDER": 1, "DISPLAY_LEVEL": 1}]
+        }}"#;
+        let err =
+            add_element_to_feature(config, AddElementToFeatureParams::new("NAME", "FULL_NAME"))
+                .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_add_element_to_feature_invalid_display_level() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+            "CFG_FBOM": []
+        }}"#;
+        let err = add_element_to_feature(
+            config,
+            AddElementToFeatureParams::new("NAME", "FULL_NAME").with_display_level(-1),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_delete_element_from_feature_round_trip() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+            "CFG_FBOM": []
+        }}"#;
+        let added =
+            add_element_to_feature(config, AddElementToFeatureParams::new("NAME", "FULL_NAME"))
+                .unwrap();
+        let v: Value = serde_json::from_str(&added).unwrap();
+        assert_eq!(v["G2_CONFIG"]["CFG_FBOM"].as_array().unwrap().len(), 1);
+
+        let removed = delete_element_from_feature(&added, "name", "full_name").unwrap();
+        let v: Value = serde_json::from_str(&removed).unwrap();
+        assert_eq!(v["G2_CONFIG"]["CFG_FBOM"].as_array().unwrap().len(), 0);
+
+        // Deleting again -> NotFound.
+        let err = delete_element_from_feature(&removed, "NAME", "FULL_NAME").unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,28 @@
 use std::fmt;
 
-/// Custom error type for configuration operations
+/// Custom error type for configuration operations.
+///
+/// # Stable, machine-readable surface
+///
+/// `SzConfigError` is the public error boundary for this crate. Its **variant
+/// set** is a stable contract: callers should branch on the variant — or, more
+/// conveniently, on the payload-free [`SzErrorKind`] discriminant returned by
+/// [`SzConfigError::kind`], or the string returned by
+/// [`SzConfigError::reason_code`] — rather than sniffing the human-facing
+/// [`Display`](std::fmt::Display) text. The `Display` wording is **not** part of
+/// the contract and may change between releases; the variant set,
+/// [`SzErrorKind`], and [`reason_code`](SzConfigError::reason_code) are the
+/// stable surface downstream code (notably the CLI adapter) should rely on.
+///
+/// The variant set will not be restructured without a version bump. The enum is
+/// deliberately **not** `#[non_exhaustive]`, so downstream `match` expressions
+/// can be exhaustive today; adding a variant is therefore a breaking change and
+/// will be released as such.
+///
+/// Note that [`kind`](SzConfigError::kind) and
+/// [`reason_code`](SzConfigError::reason_code) are variant-level only: two
+/// distinct "not found" situations both classify as [`SzErrorKind::NotFound`].
+/// Sub-case discrimination within a variant is not part of this surface.
 #[derive(Debug)]
 pub enum SzConfigError {
     /// JSON parsing error

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,103 @@ pub enum SzConfigError {
     NotImplemented(String),
 }
 
+/// Stable, variant-level discriminant for [`SzConfigError`].
+///
+/// This mirrors the set of [`SzConfigError`] variants without carrying any of
+/// their payloads. It lets callers (notably the CLI) classify an error by
+/// category and branch on it in a `match` without string-sniffing the
+/// `Display` output.
+///
+/// # Note on granularity
+///
+/// This is a **variant-level** discriminant only. It intentionally does not
+/// distinguish sub-cases *within* a variant — for example, two different
+/// "not found" situations both report [`SzErrorKind::NotFound`]. Callers that
+/// need to tell those apart must still inspect the message (or a future
+/// structured field); this method does not discharge that need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SzErrorKind {
+    /// JSON could not be parsed. Corresponds to [`SzConfigError::JsonParse`].
+    JsonParse,
+    /// A requested item was not found. Corresponds to [`SzConfigError::NotFound`].
+    NotFound,
+    /// An item already exists. Corresponds to [`SzConfigError::AlreadyExists`].
+    AlreadyExists,
+    /// Input failed validation. Corresponds to [`SzConfigError::InvalidInput`].
+    InvalidInput,
+    /// A required config section is missing. Corresponds to [`SzConfigError::MissingSection`].
+    MissingSection,
+    /// The config structure is invalid. Corresponds to [`SzConfigError::InvalidStructure`].
+    InvalidStructure,
+    /// A required field is missing. Corresponds to [`SzConfigError::MissingField`].
+    MissingField,
+    /// The configuration state is invalid. Corresponds to [`SzConfigError::InvalidConfig`].
+    InvalidConfig,
+    /// The operation is not implemented. Corresponds to [`SzConfigError::NotImplemented`].
+    NotImplemented,
+}
+
 impl SzConfigError {
+    /// Return the variant-level [`SzErrorKind`] discriminant for this error.
+    ///
+    /// This is a non-allocating classifier that lets callers branch on the
+    /// category of an error without matching on the payload-carrying variants
+    /// or sniffing `Display` text.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sz_configtool_lib::{SzConfigError, error::SzErrorKind};
+    ///
+    /// let err = SzConfigError::not_found("Rule not found: FOO");
+    /// assert_eq!(err.kind(), SzErrorKind::NotFound);
+    /// ```
+    pub fn kind(&self) -> SzErrorKind {
+        match self {
+            Self::JsonParse(_) => SzErrorKind::JsonParse,
+            Self::NotFound(_) => SzErrorKind::NotFound,
+            Self::AlreadyExists(_) => SzErrorKind::AlreadyExists,
+            Self::InvalidInput(_) => SzErrorKind::InvalidInput,
+            Self::MissingSection(_) => SzErrorKind::MissingSection,
+            Self::InvalidStructure(_) => SzErrorKind::InvalidStructure,
+            Self::MissingField(_) => SzErrorKind::MissingField,
+            Self::InvalidConfig(_) => SzErrorKind::InvalidConfig,
+            Self::NotImplemented(_) => SzErrorKind::NotImplemented,
+        }
+    }
+
+    /// Return a stable, machine-readable reason code string for this error.
+    ///
+    /// The returned code is a `SCREAMING_SNAKE_CASE` identifier that is stable
+    /// across releases (unlike the human-facing `Display` message). It is
+    /// suitable for logging, telemetry, or crossing an FFI boundary where a
+    /// compact classifier is preferred over a Rust enum.
+    ///
+    /// Like [`SzConfigError::kind`], this is variant-level only and does not
+    /// distinguish sub-cases within a variant.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sz_configtool_lib::SzConfigError;
+    ///
+    /// let err = SzConfigError::already_exists("Rule 'FOO' already exists");
+    /// assert_eq!(err.reason_code(), "ALREADY_EXISTS");
+    /// ```
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::JsonParse(_) => "JSON_PARSE",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::AlreadyExists(_) => "ALREADY_EXISTS",
+            Self::InvalidInput(_) => "INVALID_INPUT",
+            Self::MissingSection(_) => "MISSING_SECTION",
+            Self::InvalidStructure(_) => "INVALID_STRUCTURE",
+            Self::MissingField(_) => "MISSING_FIELD",
+            Self::InvalidConfig(_) => "INVALID_CONFIG",
+            Self::NotImplemented(_) => "NOT_IMPLEMENTED",
+        }
+    }
+
     /// Create a JSON parse error
     pub fn json_parse<S: Into<String>>(msg: S) -> Self {
         Self::JsonParse(msg.into())
@@ -76,3 +172,73 @@ impl From<serde_json::Error> for SzConfigError {
 
 /// Result type for configuration operations
 pub type Result<T> = std::result::Result<T, SzConfigError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kind_and_reason_code_cover_all_variants() {
+        let cases: [(SzConfigError, SzErrorKind, &str); 9] = [
+            (
+                SzConfigError::JsonParse("x".into()),
+                SzErrorKind::JsonParse,
+                "JSON_PARSE",
+            ),
+            (
+                SzConfigError::NotFound("x".into()),
+                SzErrorKind::NotFound,
+                "NOT_FOUND",
+            ),
+            (
+                SzConfigError::AlreadyExists("x".into()),
+                SzErrorKind::AlreadyExists,
+                "ALREADY_EXISTS",
+            ),
+            (
+                SzConfigError::InvalidInput("x".into()),
+                SzErrorKind::InvalidInput,
+                "INVALID_INPUT",
+            ),
+            (
+                SzConfigError::MissingSection("x".into()),
+                SzErrorKind::MissingSection,
+                "MISSING_SECTION",
+            ),
+            (
+                SzConfigError::InvalidStructure("x".into()),
+                SzErrorKind::InvalidStructure,
+                "INVALID_STRUCTURE",
+            ),
+            (
+                SzConfigError::MissingField("x".into()),
+                SzErrorKind::MissingField,
+                "MISSING_FIELD",
+            ),
+            (
+                SzConfigError::InvalidConfig("x".into()),
+                SzErrorKind::InvalidConfig,
+                "INVALID_CONFIG",
+            ),
+            (
+                SzConfigError::NotImplemented("x".into()),
+                SzErrorKind::NotImplemented,
+                "NOT_IMPLEMENTED",
+            ),
+        ];
+
+        for (err, kind, code) in cases {
+            assert_eq!(err.kind(), kind, "kind mismatch for {err:?}");
+            assert_eq!(err.reason_code(), code, "reason_code mismatch for {err:?}");
+        }
+    }
+
+    #[test]
+    fn test_kind_is_copy_and_comparable() {
+        let err = SzConfigError::not_found("nope");
+        let k = err.kind();
+        // Copy semantics: using k twice must compile and compare equal.
+        assert_eq!(k, k);
+        assert_ne!(k, SzErrorKind::AlreadyExists);
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,151 @@
+//! Canonical config-document export renderer.
+//!
+//! This module provides [`render_config`], the single canonical "render a config
+//! document for export" entry point (decision D31). It reproduces the on-disk
+//! form the CLI's `exportToFile` (and the shell's historic-config path) produce:
+//! a **recursive key sort** — the semantics of Python's `json.dumps(...,
+//! sort_keys=True)` — followed by a pretty-print at a caller-chosen indent.
+//!
+//! The indent is a **required parameter** and is never hardcoded: the CLI
+//! deliberately exports at 2 spaces while the Python tooling uses 4, and both
+//! must be expressible through one renderer.
+//!
+//! # Why the explicit sort
+//!
+//! This crate enables `serde_json`'s `preserve_order` feature, so a parsed
+//! object keeps its original key order rather than sorting. Producing a
+//! canonical (order-independent) rendering therefore requires rebuilding every
+//! object with its keys in sorted order, recursively — which is exactly what
+//! this module does before serialising.
+
+use crate::error::{Result, SzConfigError};
+use serde_json::{Map, Value};
+
+/// Recursively rebuild a JSON value with every object's keys in sorted order.
+///
+/// Arrays keep their element order (only *object keys* are sorted, matching
+/// Python's `sort_keys=True`); each element is itself recursively sorted.
+fn sort_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut sorted = Map::with_capacity(map.len());
+            for key in keys {
+                sorted.insert(key.clone(), sort_value(&map[key]));
+            }
+            Value::Object(sorted)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(sort_value).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Render a config document to its canonical export form.
+///
+/// The input is parsed, every object's keys are sorted recursively (the
+/// semantics of Python's `json.dumps(..., sort_keys=True)`), and the result is
+/// pretty-printed using `indent` spaces per level. `indent` is required and is
+/// applied verbatim — pass `2` for the CLI's on-disk form or `4` for Python
+/// parity.
+///
+/// The rendering is deterministic: two inputs that are semantically equal (equal
+/// as parsed JSON, regardless of key order) render to byte-identical output.
+///
+/// # Arguments
+/// * `config_json` - Configuration JSON string
+/// * `indent` - Number of spaces per indentation level (may be `0`)
+///
+/// # Returns
+/// * `Ok(String)` - the canonical, key-sorted, pretty-printed rendering
+/// * `Err(SzConfigError::JsonParse)` - if `config_json` is not valid JSON
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::export::render_config;
+///
+/// let a = r#"{"b":1,"a":{"y":2,"x":3}}"#;
+/// let rendered = render_config(a, 2)?;
+/// // Keys are sorted at every level.
+/// assert!(rendered.find("\"a\"").unwrap() < rendered.find("\"b\"").unwrap());
+/// assert!(rendered.contains("  \"a\": {"));
+///
+/// // Deterministic: a reordered-but-equal input renders identically.
+/// let b = r#"{"a":{"x":3,"y":2},"b":1}"#;
+/// assert_eq!(render_config(a, 2)?, render_config(b, 2)?);
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn render_config(config_json: &str, indent: usize) -> Result<String> {
+    let value: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let sorted = sort_value(&value);
+
+    let indent_bytes = vec![b' '; indent];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent_bytes);
+    let mut buf = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    serde::Serialize::serialize(&sorted, &mut serializer)
+        .map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    String::from_utf8(buf).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_recursive_key_sort_at_indent_2() {
+        let input = r#"{"b":1,"a":{"y":2,"x":3},"c":[{"z":1,"m":2}]}"#;
+        let out = render_config(input, 2).unwrap();
+        let expected = "{\n  \"a\": {\n    \"x\": 3,\n    \"y\": 2\n  },\n  \"b\": 1,\n  \"c\": [\n    {\n      \"m\": 2,\n      \"z\": 1\n    }\n  ]\n}";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn test_indent_4() {
+        let input = r#"{"a":{"x":1}}"#;
+        let out = render_config(input, 4).unwrap();
+        let expected = "{\n    \"a\": {\n        \"x\": 1\n    }\n}";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn test_indent_is_not_hardcoded() {
+        let input = r#"{"a":1}"#;
+        assert_ne!(
+            render_config(input, 2).unwrap(),
+            render_config(input, 4).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_deterministic_regardless_of_key_order() {
+        let a = r#"{"b":1,"a":{"y":2,"x":3}}"#;
+        let b = r#"{"a":{"x":3,"y":2},"b":1}"#;
+        assert_eq!(render_config(a, 2).unwrap(), render_config(b, 2).unwrap());
+        assert_eq!(render_config(a, 4).unwrap(), render_config(b, 4).unwrap());
+    }
+
+    #[test]
+    fn test_semantic_round_trip() {
+        let input =
+            r#"{"G2_CONFIG":{"CFG_DSRC":[{"DSRC_ID":1,"DSRC_CODE":"TEST"}],"CFG_FTYPE":[]}}"#;
+        let rendered = render_config(input, 2).unwrap();
+        let original: Value = serde_json::from_str(input).unwrap();
+        let round: Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(original, round);
+    }
+
+    #[test]
+    fn test_round_trip_on_stock_template() {
+        let config = include_str!("../tests/fixtures/g2config_template.json");
+        let rendered = render_config(config, 2).unwrap();
+        let original: Value = serde_json::from_str(config).unwrap();
+        let round: Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(original, round);
+        // Rendering the rendered output is a fixed point.
+        assert_eq!(rendered, render_config(&rendered, 2).unwrap());
+    }
+}

--- a/src/features.rs
+++ b/src/features.rs
@@ -264,20 +264,22 @@ impl<'a> AddFeatureDistinctCallElementParams<'a> {
     }
 }
 
-// Protected features that cannot be deleted
+// Protected features that cannot be deleted.
+//
+// This is the ratified (human-approved) locked-feature set that mirrors the
+// authoritative Python `locked_feature_list`. Only these codes are protected;
+// every other shipped feature (EMAIL, RECORD_TYPE, NATIONAL_ID, TAX_ID,
+// ACCT_NUM, ...) is deletable. The previous list also carried codes that do not
+// exist as feature codes in the shipped config (DATE_OF_BIRTH, SSN_NUM,
+// PASSPORT_NUM, DRIVERS_LICENSE_NUM), which were inert but misleading.
 const LOCKED_FEATURES: &[&str] = &[
     "NAME",
     "ADDRESS",
     "PHONE",
-    "EMAIL",
-    "RECORD_TYPE",
-    "DATE_OF_BIRTH",
-    "NATIONAL_ID",
-    "TAX_ID",
-    "ACCT_NUM",
-    "SSN_NUM",
-    "PASSPORT_NUM",
-    "DRIVERS_LICENSE_NUM",
+    "DOB",
+    "REL_LINK",
+    "REL_ANCHOR",
+    "REL_POINTER",
 ];
 
 /// Add a new feature to the configuration
@@ -1919,5 +1921,100 @@ mod tests {
         assert_eq!(dfcall["DFUNC_ID"], json!(2));
         assert!(!dfcall.as_object().unwrap().contains_key("FELEM_ID"));
         assert!(!dfcall.as_object().unwrap().contains_key("EXEC_ORDER"));
+    }
+
+    // ------------------------------------------------------------------
+    // LOCKED_FEATURES (ratified protected set) — #35
+    // ------------------------------------------------------------------
+
+    /// A real feature that is NO LONGER in the protected set (EMAIL) must be
+    /// deletable, and its dependent rows must cascade away.
+    #[test]
+    fn test_delete_feature_email_now_deletable_and_cascades() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 5, "FTYPE_CODE": "EMAIL"},
+                {"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}
+            ],
+            "CFG_FBOM": [
+                {"FTYPE_ID": 5, "FELEM_ID": 1},
+                {"FTYPE_ID": 3, "FELEM_ID": 2}
+            ],
+            "CFG_ATTR": [
+                {"ATTR_CODE": "EMAIL", "FTYPE_CODE": "EMAIL"}
+            ],
+            "CFG_CFCALL": [
+                {"CFCALL_ID": 50, "FTYPE_ID": 5, "CFUNC_ID": 1}
+            ],
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 50, "FELEM_ID": 1}
+            ]
+        }}"#;
+
+        let modified = delete_feature(config, "EMAIL").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &value["G2_CONFIG"];
+
+        // The EMAIL feature is gone; NAME survives.
+        let ftypes = g2["CFG_FTYPE"].as_array().unwrap();
+        assert_eq!(ftypes.len(), 1);
+        assert_eq!(ftypes[0]["FTYPE_CODE"], json!("NAME"));
+
+        // Cascade: EMAIL's FBOM/ATTR/CFCALL/CFBOM rows removed, NAME's kept.
+        let fbom = g2["CFG_FBOM"].as_array().unwrap();
+        assert_eq!(fbom.len(), 1);
+        assert_eq!(fbom[0]["FTYPE_ID"], json!(3));
+        assert!(g2["CFG_ATTR"].as_array().unwrap().is_empty());
+        assert!(g2["CFG_CFCALL"].as_array().unwrap().is_empty());
+        assert!(g2["CFG_CFBOM"].as_array().unwrap().is_empty());
+    }
+
+    /// Every code in the ratified protected set must be blocked from deletion,
+    /// case-insensitively.
+    #[test]
+    fn test_delete_feature_ratified_codes_blocked() {
+        for code in [
+            "NAME",
+            "ADDRESS",
+            "PHONE",
+            "DOB",
+            "REL_LINK",
+            "REL_ANCHOR",
+            "REL_POINTER",
+        ] {
+            let config = format!(
+                r#"{{"G2_CONFIG": {{"CFG_FTYPE": [{{"FTYPE_ID": 1, "FTYPE_CODE": "{code}"}}]}}}}"#
+            );
+            // Exact case.
+            let err = delete_feature(&config, code).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                crate::error::SzErrorKind::InvalidInput,
+                "{code} must be protected"
+            );
+            // Case-insensitive.
+            let err_lower = delete_feature(&config, &code.to_lowercase()).unwrap_err();
+            assert_eq!(err_lower.kind(), crate::error::SzErrorKind::InvalidInput);
+        }
+    }
+
+    /// A former inert entry (a bogus DATE_OF_BIRTH feature) is no longer falsely
+    /// protected: deleting it succeeds rather than being blocked.
+    #[test]
+    fn test_delete_feature_former_inert_entry_not_protected() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 7, "FTYPE_CODE": "DATE_OF_BIRTH"}]
+        }}"#;
+
+        // DATE_OF_BIRTH was in the old list but is not a real protected feature;
+        // it must now be deletable.
+        let modified = delete_feature(config, "DATE_OF_BIRTH").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert!(
+            value["G2_CONFIG"]["CFG_FTYPE"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -27,6 +27,9 @@ pub struct AddFeatureParams<'a> {
     pub comparison: Option<&'a str>,
     pub version: Option<i64>,
     pub rtype_id: Option<i64>,
+    /// Caller-supplied `FTYPE_ID`. `None`/non-positive auto-assigns at the
+    /// user-range floor of 1000; `Some(id > 0)` is honoured unless already taken.
+    pub id: Option<i64>,
 }
 
 impl<'a> AddFeatureParams<'a> {
@@ -36,6 +39,12 @@ impl<'a> AddFeatureParams<'a> {
             element_list,
             ..Default::default()
         }
+    }
+
+    /// Request a specific `FTYPE_ID` for the new feature.
+    pub fn with_id(mut self, id: i64) -> Self {
+        self.id = Some(id);
+        self
     }
 }
 
@@ -76,6 +85,7 @@ impl<'a> TryFrom<&'a Value> for AddFeatureParams<'a> {
                 .filter(|s| !s.is_empty()),
             version: json.get("version").and_then(|v| v.as_i64()),
             rtype_id: json.get("rtypeId").and_then(|v| v.as_i64()),
+            id: json.get("id").and_then(|v| v.as_i64()),
         })
     }
 }
@@ -432,8 +442,10 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
         matchkey_default
     };
 
-    // Get next FTYPE_ID (seed at 1000 for user-created features)
-    let ftype_id = helpers::get_next_id_with_min(ftypes, "FTYPE_ID", 1000)?;
+    // Get next FTYPE_ID (seed at 1000 for user-created features). Caller-supplied
+    // id (#37): None/non-positive auto-assigns; a specific id > 0 is honoured
+    // unless already taken (get_desired_or_next_id returns AlreadyExists).
+    let ftype_id = helpers::get_desired_or_next_id(ftypes, "FTYPE_ID", params.id, 1000)?;
 
     // Parse behavior code (like Python's parseFeatureBehavior)
     // Valid frequency codes: A1, F1, FF, FM, FVM, NONE, NAME
@@ -1788,6 +1800,44 @@ mod tests {
         assert_eq!(fbom["EXEC_ORDER"], json!(1));
         assert_eq!(fbom["DISPLAY_LEVEL"], json!(1));
         assert_eq!(fbom["DERIVED"], json!("No"));
+    }
+
+    #[test]
+    fn test_add_feature_caller_supplied_id() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1000, "FTYPE_CODE": "TAKEN"}],
+            "CFG_FCLASS": [{"FCLASS_ID": 1, "FCLASS_CODE": "OTHER"}],
+            "CFG_FELEM": [],
+            "CFG_FBOM": []
+        }}"#;
+        let elements = json!([{"element": "MYELEM"}]);
+
+        // Specific free id honoured.
+        let params = AddFeatureParams::new("MYFEAT", &elements).with_id(2500);
+        let modified = add_feature(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let ftype = value["G2_CONFIG"]["CFG_FTYPE"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(ftype["FTYPE_ID"], json!(2500));
+
+        // Taken id rejected.
+        let params = AddFeatureParams::new("MYFEAT", &elements).with_id(1000);
+        let err = add_feature(config, params).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+
+        // Auto-assign lands above the existing max (1000) -> 1001.
+        let params = AddFeatureParams::new("MYFEAT", &elements);
+        let modified = add_feature(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let ftype = value["G2_CONFIG"]["CFG_FTYPE"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(ftype["FTYPE_ID"], json!(1001));
     }
 
     /// add_feature with standardize/expression/comparison functions must write

--- a/src/features.rs
+++ b/src/features.rs
@@ -657,7 +657,7 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
                     .to_uppercase();
 
                 // Handle display (backwards compatibility)
-                let disp_level = if let Some(display) = elem_obj
+                let disp_level_raw = if let Some(display) = elem_obj
                     .get("display")
                     .or_else(|| elem_obj.get("DISPLAY"))
                     .and_then(|v| v.as_str())
@@ -675,6 +675,10 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
                         .and_then(|v| v.as_i64())
                         .unwrap_or(1)
                 };
+                // Unify onto the shared strict validator (D25): a negative
+                // DISPLAY_LEVEL is now rejected rather than stored verbatim,
+                // matching set_feature_element / add_element_to_feature.
+                let disp_level = crate::elements::validate_display_level(disp_level_raw)?;
 
                 let disp_delim = elem_obj
                     .get("displaydelim")
@@ -683,19 +687,17 @@ pub fn add_feature(config_json: &str, params: AddFeatureParams) -> Result<String
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 
-                let elem_deriv = elem_obj
+                // Unify onto the shared strict validator (D25): an unknown
+                // DERIVED value is now rejected rather than silently coerced to
+                // "No", matching set_feature_element / add_element_to_feature.
+                let elem_deriv = match elem_obj
                     .get("derived")
                     .or_else(|| elem_obj.get("DERIVED"))
                     .and_then(|v| v.as_str())
-                    .map(|s| {
-                        if s.eq_ignore_ascii_case("yes") {
-                            "Yes"
-                        } else {
-                            "No"
-                        }
-                        .to_string()
-                    })
-                    .unwrap_or_else(|| "No".to_string());
+                {
+                    Some(s) => crate::elements::validate_derived(s)?.to_string(),
+                    None => "No".to_string(),
+                };
 
                 (code, expr, comp, disp_level, disp_delim, elem_deriv)
             } else {
@@ -1800,6 +1802,47 @@ mod tests {
         assert_eq!(fbom["EXEC_ORDER"], json!(1));
         assert_eq!(fbom["DISPLAY_LEVEL"], json!(1));
         assert_eq!(fbom["DERIVED"], json!("No"));
+    }
+
+    // D25: add_feature's per-element elementList handling is now unified onto the
+    // shared strict validators (elements::validate_display_level / validate_derived),
+    // matching set_feature_element and add_element_to_feature.
+    #[test]
+    fn test_add_feature_rejects_negative_display_level_in_element() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [], "CFG_FCLASS": [{"FCLASS_ID": 1, "FCLASS_CODE": "OTHER"}],
+            "CFG_FELEM": [], "CFG_FBOM": []
+        }}"#;
+        let elements = json!([{"element": "MYELEM", "displaylevel": -1}]);
+        let params = AddFeatureParams {
+            feature: "MYFEAT",
+            element_list: &elements,
+            ..Default::default()
+        };
+        let err = add_feature(config, params).unwrap_err();
+        assert!(
+            matches!(err, SzConfigError::InvalidInput(ref m) if m.contains("DISPLAY_LEVEL")),
+            "expected DISPLAY_LEVEL InvalidInput, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_add_feature_rejects_invalid_derived_in_element() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [], "CFG_FCLASS": [{"FCLASS_ID": 1, "FCLASS_CODE": "OTHER"}],
+            "CFG_FELEM": [], "CFG_FBOM": []
+        }}"#;
+        let elements = json!([{"element": "MYELEM", "derived": "maybe"}]);
+        let params = AddFeatureParams {
+            feature: "MYFEAT",
+            element_list: &elements,
+            ..Default::default()
+        };
+        let err = add_feature(config, params).unwrap_err();
+        assert!(
+            matches!(err, SzConfigError::InvalidInput(ref m) if m.contains("DERIVED")),
+            "expected DERIVED InvalidInput, got: {err:?}"
+        );
     }
 
     #[test]

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,3 +1,4 @@
+use crate::behavior_domain::{compute_behavior, parse_behavior_code};
 use crate::config_rows::{
     CfbomRow, CfcallRow, DfcallRow, EfbomRow, EfcallRow, FbomRow, FelemRow, FtypeRow, SfcallRow,
 };
@@ -1306,61 +1307,6 @@ pub fn build_feature_json(config: &Value, ftype: &Value) -> Result<Value> {
         "version": ftype["VERSION"].as_i64().unwrap_or(0),
         "elementList": element_list
     }))
-}
-
-/// Parse a behavior code string into (frequency, exclusivity, stability)
-/// Valid frequency codes: A1, F1, FF, FM, FVM, NONE, NAME
-/// E suffix means EXCLUSIVITY = "Yes"
-/// S suffix means STABILITY = "Yes"
-fn parse_behavior_code(behavior: &str) -> Result<(&'static str, &'static str, &'static str)> {
-    let mut code = behavior.to_uppercase();
-    let mut exclusivity = "No";
-    let mut stability = "No";
-
-    // Special cases that don't get E/S parsing
-    if code != "NAME" && code != "NONE" {
-        if code.contains('E') {
-            exclusivity = "Yes";
-            code = code.replace('E', "");
-        }
-        if code.contains('S') {
-            stability = "Yes";
-            code = code.replace('S', "");
-        }
-    }
-
-    // Validate frequency code
-    let frequency: &'static str = match code.as_str() {
-        "A1" => "A1",
-        "F1" => "F1",
-        "FF" => "FF",
-        "FM" => "FM",
-        "FVM" => "FVM",
-        "NONE" => "NONE",
-        "NAME" => "NAME",
-        _ => {
-            return Err(SzConfigError::InvalidInput(format!(
-                "Invalid behavior code '{behavior}'. Valid codes: A1, F1, FF, FM, FVM, NONE, NAME (with optional E/S suffixes)"
-            )));
-        }
-    };
-
-    Ok((frequency, exclusivity, stability))
-}
-
-fn compute_behavior(ftype: &Value) -> String {
-    let freq = ftype["FTYPE_FREQ"].as_str().unwrap_or("");
-    let excl = ftype["FTYPE_EXCL"].as_str().unwrap_or("");
-    let stab = ftype["FTYPE_STAB"].as_str().unwrap_or("");
-
-    let mut behavior = freq.to_string();
-    if excl.to_uppercase() == "Y" || excl == "1" || excl.to_uppercase() == "YES" {
-        behavior.push('E');
-    }
-    if stab.to_uppercase() == "Y" || stab == "1" || stab.to_uppercase() == "YES" {
-        behavior.push('S');
-    }
-    behavior
 }
 
 fn lookup_feature_id(config: &Value, feature_code: &str) -> Result<i64> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4085,7 +4085,10 @@ pub extern "C" fn SzConfigTool_getStandardizeCall(
         }
     };
 
-    match crate::calls::standardize::get_standardize_call(config, sfcall_id) {
+    match crate::calls::standardize::get_standardize_call(
+        config,
+        crate::calls::CallSelector::Id(sfcall_id),
+    ) {
         Ok(value) => {
             let json_str = serde_json::to_string(&value)
                 .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize: {e}\"}}"));
@@ -6438,7 +6441,10 @@ pub extern "C" fn SzConfigTool_getExpressionCall(
         }
     };
 
-    match crate::calls::expression::get_expression_call(config, efcall_id) {
+    match crate::calls::expression::get_expression_call(
+        config,
+        crate::calls::CallSelector::Id(efcall_id),
+    ) {
         Ok(record) => match serde_json::to_string(&record) {
             Ok(json_str) => match CString::new(json_str) {
                 Ok(c_str) => {
@@ -6818,7 +6824,10 @@ pub extern "C" fn SzConfigTool_getComparisonCall(
         }
     };
 
-    match crate::calls::comparison::get_comparison_call(config, cfcall_id) {
+    match crate::calls::comparison::get_comparison_call(
+        config,
+        crate::calls::CallSelector::Id(cfcall_id),
+    ) {
         Ok(record) => match serde_json::to_string(&record) {
             Ok(json_str) => match CString::new(json_str) {
                 Ok(c_str) => {
@@ -7252,7 +7261,10 @@ pub extern "C" fn SzConfigTool_getDistinctCall(
         }
     };
 
-    match crate::calls::distinct::get_distinct_call(config, dfcall_id) {
+    match crate::calls::distinct::get_distinct_call(
+        config,
+        crate::calls::CallSelector::Id(dfcall_id),
+    ) {
         Ok(record) => match serde_json::to_string(&record) {
             Ok(json_str) => match CString::new(json_str) {
                 Ok(c_str) => {
@@ -9741,6 +9753,181 @@ pub extern "C" fn SzConfigTool_deleteStandardizeFunctionCascade(
     )
 }
 
+// ============================================================================
+// Wave 4B additions (#40): by-feature call gets and code-addressed call-element
+// deletes.
+//
+// The `*CallByFeature` gets resolve a feature code to the call bound to it
+// (scanning CFG_*CALL by FTYPE_ID), fixing the historical bug where the feature
+// id was used directly as a call id. The `delete*CallElement` wrappers address
+// the element by (feature code + element code) and derive the BOM EXEC_ORDER
+// internally, so no pre-resolved exec_order is passed over the ABI. These
+// call-element deletes are new FFI surface (there were no prior wrappers).
+// ============================================================================
+
+/// Serialize a single call `Value` result into an FFI result.
+macro_rules! ffi_json_value {
+    ($result:expr) => {
+        match $result {
+            Ok(value) => match serde_json::to_string(&value) {
+                Ok(s) => handle_result!(Ok::<String, crate::error::SzConfigError>(s)),
+                Err(e) => {
+                    set_error(format!("Failed to serialize result: {e}"), -3);
+                    SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -3,
+                    }
+                }
+            },
+            Err(e) => {
+                set_error(format!("{e}"), -2);
+                SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -2,
+                }
+            }
+        }
+    };
+}
+
+/// Get the comparison call bound to a feature (by feature code).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_getComparisonCallByFeature(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    ffi_json_value!(crate::calls::comparison::get_comparison_call(
+        config,
+        crate::calls::CallSelector::Feature(feature)
+    ))
+}
+
+/// Get the distinct call bound to a feature (by feature code).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_getDistinctCallByFeature(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    ffi_json_value!(crate::calls::distinct::get_distinct_call(
+        config,
+        crate::calls::CallSelector::Feature(feature)
+    ))
+}
+
+/// Get the standardize call bound to a feature (by feature code).
+///
+/// Errors if the feature has more than one standardize call (address by id).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_getStandardizeCallByFeature(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    ffi_json_value!(crate::calls::standardize::get_standardize_call(
+        config,
+        crate::calls::CallSelector::Feature(feature)
+    ))
+}
+
+/// Get the expression call bound to a feature (by feature code).
+///
+/// Errors if the feature has more than one expression call (address by id).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_getExpressionCallByFeature(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    ffi_json_value!(crate::calls::expression::get_expression_call(
+        config,
+        crate::calls::CallSelector::Feature(feature)
+    ))
+}
+
+/// Delete a comparison call element by (feature code + element code).
+///
+/// The BOM `EXEC_ORDER` is derived internally.
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteComparisonCallElement(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+    element_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    let element = ffi_required_str!(element_code, "element_code");
+    handle_result!(crate::calls::comparison::delete_comparison_call_element(
+        config,
+        crate::calls::CallSelector::Feature(feature),
+        element
+    ))
+}
+
+/// Delete a distinct call element by (feature code + element code).
+///
+/// The BOM `EXEC_ORDER` is derived internally.
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteDistinctCallElement(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+    element_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    let element = ffi_required_str!(element_code, "element_code");
+    handle_result!(crate::calls::distinct::delete_distinct_call_element(
+        config,
+        crate::calls::CallSelector::Feature(feature),
+        element
+    ))
+}
+
+/// Delete an expression call element by (call id + element code).
+///
+/// Expression calls are many-per-feature, so this wrapper addresses the call by
+/// its `EFCALL_ID`; the BOM `EXEC_ORDER` is derived internally.
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteExpressionCallElement(
+    config_json: *const c_char,
+    efcall_id: i64,
+    element_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let element = ffi_required_str!(element_code, "element_code");
+    handle_result!(crate::calls::expression::delete_expression_call_element(
+        config,
+        crate::calls::CallSelector::Id(efcall_id),
+        element
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9922,5 +10109,60 @@ mod tests {
         let frag = &v["G2_CONFIG"]["CFG_ERFRAG"][0];
         assert_eq!(frag["ERFRAG_SOURCE"], Value::Null);
         assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null);
+    }
+
+    /// #40: deleteComparisonCallElement FFI addresses the row by (feature,
+    /// element) codes and derives EXEC_ORDER internally — no exec_order arg.
+    #[test]
+    fn test_ffi_delete_comparison_call_element_by_feature() {
+        let base = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}
+            ],
+            "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1},
+                {"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 12, "EXEC_ORDER": 2}
+            ]
+        }}"#;
+        let config = CString::new(base).unwrap();
+        let feature = CString::new("NAME").unwrap();
+        let element = CString::new("FIRST_NAME").unwrap();
+
+        let modified = take_response(SzConfigTool_deleteComparisonCallElement(
+            config.as_ptr(),
+            feature.as_ptr(),
+            element.as_ptr(),
+        ));
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let cfbom = v["G2_CONFIG"]["CFG_CFBOM"].as_array().unwrap();
+        assert_eq!(cfbom.len(), 1);
+        assert_eq!(cfbom[0]["FELEM_ID"], 12);
+    }
+
+    /// #40: getStandardizeCallByFeature returns the feature's call — the same
+    /// row an id lookup returns — proving the FTYPE_ID-as-call-id bug is gone.
+    #[test]
+    fn test_ffi_get_standardize_call_by_feature() {
+        // FTYPE_ID (3) deliberately differs from SFCALL_ID (5): the old code
+        // used the feature id as the call id and returned the wrong/no row.
+        let base = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 5, "FTYPE_ID": 3, "FELEM_ID": -1, "SFUNC_ID": 1, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+        let config = CString::new(base).unwrap();
+        let feature = CString::new("NAME").unwrap();
+
+        let by_feature = take_response(SzConfigTool_getStandardizeCallByFeature(
+            config.as_ptr(),
+            feature.as_ptr(),
+        ));
+        let v: Value = serde_json::from_str(&by_feature).unwrap();
+        assert_eq!(v["SFCALL_ID"], 5);
+        assert_eq!(v["FTYPE_ID"], 3);
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5951,6 +5951,105 @@ pub extern "C" fn SzConfigTool_listBehaviorOverrides(
     handle_result!(result)
 }
 
+/// List behavior overrides in the resolved display shape
+///
+/// Returns a JSON array of `{ "feature", "usageType", "behavior" }` objects,
+/// sorted by `(FTYPE_ID, UTYPE_CODE)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_listBehaviorOverridesResolved(
+    config_json: *const c_char,
+) -> SzConfigTool_result {
+    let config = unsafe {
+        if config_json.is_null() {
+            set_error("config_json is null".to_string(), -1);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -1,
+            };
+        }
+        match CStr::from_ptr(config_json).to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in config_json: {e}"), -2);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -2,
+                };
+            }
+        }
+    };
+
+    let result =
+        crate::behavior_overrides::list_behavior_overrides_resolved(config).and_then(|vec| {
+            serde_json::to_string(&vec).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+        });
+    handle_result!(result)
+}
+
+/// Validate the top-level structure of a config document
+///
+/// Returns `"OK"` with return code 0 when the document is structurally a config
+/// document; otherwise returns an error result (see `SzConfigTool_getLastError`).
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_validateConfig(config_json: *const c_char) -> SzConfigTool_result {
+    let config = unsafe {
+        if config_json.is_null() {
+            set_error("config_json is null".to_string(), -1);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -1,
+            };
+        }
+        match CStr::from_ptr(config_json).to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in config_json: {e}"), -2);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -2,
+                };
+            }
+        }
+    };
+
+    let result = crate::validation::validate_config(config).map(|()| "OK".to_string());
+    handle_result!(result)
+}
+
+/// Render a config document to its canonical export form
+///
+/// Recursively sorts all object keys and pretty-prints at `indent` spaces per
+/// level. `indent` is required; a negative value is treated as 0.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_renderConfig(
+    config_json: *const c_char,
+    indent: i64,
+) -> SzConfigTool_result {
+    let config = unsafe {
+        if config_json.is_null() {
+            set_error("config_json is null".to_string(), -1);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -1,
+            };
+        }
+        match CStr::from_ptr(config_json).to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in config_json: {e}"), -2);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -2,
+                };
+            }
+        }
+    };
+
+    let indent = if indent < 0 { 0usize } else { indent as usize };
+    let result = crate::export::render_config(config, indent);
+    handle_result!(result)
+}
+
 // ===== Element Operations =====
 
 /// Add an element with JSON configuration

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -835,7 +835,20 @@ pub unsafe extern "C" fn SzConfigTool_setFragmentWithJson(
         }
     };
 
-    let result = crate::fragments::set_fragment(config, code, &fragment_config);
+    // JSON-based FFI: build a tri-state SetFragmentParams. An absent key ->
+    // Leave, an explicit null -> Clear (writes null), a value -> Set.
+    let params = match crate::fragments::SetFragmentParams::try_from(&fragment_config) {
+        Ok(p) => p,
+        Err(e) => {
+            set_error(e.to_string(), -3);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -3,
+            };
+        }
+    };
+
+    let result = crate::fragments::set_fragment(config, code, params);
     handle_result!(result)
 }
 
@@ -2360,9 +2373,14 @@ pub extern "C" fn SzConfigTool_setRule(
             .get("rtypeId")
             .and_then(|v| v.as_i64())
             .or_else(|| rule_value.get("RTYPE_ID").and_then(|v| v.as_i64())),
-        fragment: None,
-        disqualifier: None,
-        tier: None,
+        // JSON-based FFI can express Clear: an absent key -> Leave, an explicit
+        // null -> Clear (writes null), a value -> Set.
+        fragment: crate::helpers::field_update_str(&rule_value, &["fragment", "FRAGMENT"]),
+        disqualifier: crate::helpers::field_update_str(
+            &rule_value,
+            &["disqualifier", "DISQUALIFIER"],
+        ),
+        tier: crate::helpers::field_update_i64(&rule_value, &["tier", "TIER"]),
     };
 
     handle_result!(crate::rules::set_rule(config, params))
@@ -2421,22 +2439,21 @@ pub extern "C" fn SzConfigTool_addStandardizeFunction(
         }
     };
 
-    let conn = unsafe {
-        if connect_str.is_null() {
-            set_error("connect_str is null".to_string(), -1);
-            return SzConfigTool_result {
-                response: std::ptr::null_mut(),
-                returnCode: -1,
-            };
-        }
-        match CStr::from_ptr(connect_str).to_str() {
-            Ok(s) => s,
-            Err(e) => {
-                set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
-                return SzConfigTool_result {
-                    response: std::ptr::null_mut(),
-                    returnCode: -2,
-                };
+    // Direct-arg add FFI: a NULL connect_str stores JSON null; a non-null
+    // pointer (including an empty string) stores that value.
+    let conn_opt = if connect_str.is_null() {
+        None
+    } else {
+        unsafe {
+            match CStr::from_ptr(connect_str).to_str() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
+                    return SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -2,
+                    };
+                }
             }
         }
     };
@@ -2481,7 +2498,7 @@ pub extern "C" fn SzConfigTool_addStandardizeFunction(
         config,
         code,
         crate::functions::standardize::AddStandardizeFunctionParams {
-            connect_str: conn,
+            connect_str: conn_opt,
             description: desc_opt,
             language: lang_opt,
         },
@@ -2767,13 +2784,16 @@ pub extern "C" fn SzConfigTool_setStandardizeFunction(
         }
     };
 
-    let conn_opt = if connect_str.is_null() {
-        None
+    // Direct-arg set FFI: a plain pointer can encode only Leave/Set (D12), so a
+    // NULL connect_str leaves the stored value untouched and a non-null pointer
+    // (including an empty string) sets it. Clearing a value to null is only
+    // expressible via the JSON-based set APIs.
+    let conn_update = if connect_str.is_null() {
+        crate::helpers::FieldUpdate::Leave
     } else {
         unsafe {
             match CStr::from_ptr(connect_str).to_str() {
-                Ok(s) if !s.is_empty() => Some(s),
-                Ok(_) => None,
+                Ok(s) => crate::helpers::FieldUpdate::Set(s),
                 Err(e) => {
                     set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
                     return SzConfigTool_result {
@@ -2825,7 +2845,7 @@ pub extern "C" fn SzConfigTool_setStandardizeFunction(
         config,
         code,
         crate::functions::standardize::SetStandardizeFunctionParams {
-            connect_str: conn_opt,
+            connect_str: conn_update,
             description: desc_opt,
             language: lang_opt,
         },
@@ -2909,22 +2929,21 @@ pub extern "C" fn SzConfigTool_addExpressionFunction(
         }
     };
 
-    let conn = unsafe {
-        if connect_str.is_null() {
-            set_error("connect_str is null".to_string(), -1);
-            return SzConfigTool_result {
-                response: std::ptr::null_mut(),
-                returnCode: -1,
-            };
-        }
-        match CStr::from_ptr(connect_str).to_str() {
-            Ok(s) => s,
-            Err(e) => {
-                set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
-                return SzConfigTool_result {
-                    response: std::ptr::null_mut(),
-                    returnCode: -2,
-                };
+    // Direct-arg add FFI: a NULL connect_str stores JSON null; a non-null
+    // pointer (including an empty string) stores that value.
+    let conn_opt = if connect_str.is_null() {
+        None
+    } else {
+        unsafe {
+            match CStr::from_ptr(connect_str).to_str() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
+                    return SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -2,
+                    };
+                }
             }
         }
     };
@@ -2969,7 +2988,7 @@ pub extern "C" fn SzConfigTool_addExpressionFunction(
         config,
         code,
         crate::functions::expression::AddExpressionFunctionParams {
-            connect_str: conn,
+            connect_str: conn_opt,
             description: desc_opt,
             language: lang_opt,
         },
@@ -3255,13 +3274,16 @@ pub extern "C" fn SzConfigTool_setExpressionFunction(
         }
     };
 
-    let conn_opt = if connect_str.is_null() {
-        None
+    // Direct-arg set FFI: a plain pointer can encode only Leave/Set (D12), so a
+    // NULL connect_str leaves the stored value untouched and a non-null pointer
+    // (including an empty string) sets it. Clearing a value to null is only
+    // expressible via the JSON-based set APIs.
+    let conn_update = if connect_str.is_null() {
+        crate::helpers::FieldUpdate::Leave
     } else {
         unsafe {
             match CStr::from_ptr(connect_str).to_str() {
-                Ok(s) if !s.is_empty() => Some(s),
-                Ok(_) => None,
+                Ok(s) => crate::helpers::FieldUpdate::Set(s),
                 Err(e) => {
                     set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
                     return SzConfigTool_result {
@@ -3313,7 +3335,7 @@ pub extern "C" fn SzConfigTool_setExpressionFunction(
         config,
         code,
         crate::functions::expression::SetExpressionFunctionParams {
-            connect_str: conn_opt,
+            connect_str: conn_update,
             description: desc_opt,
             language: lang_opt,
         },
@@ -3398,22 +3420,21 @@ pub extern "C" fn SzConfigTool_addComparisonFunction(
         }
     };
 
-    let conn = unsafe {
-        if connect_str.is_null() {
-            set_error("connect_str is null".to_string(), -1);
-            return SzConfigTool_result {
-                response: std::ptr::null_mut(),
-                returnCode: -1,
-            };
-        }
-        match CStr::from_ptr(connect_str).to_str() {
-            Ok(s) => s,
-            Err(e) => {
-                set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
-                return SzConfigTool_result {
-                    response: std::ptr::null_mut(),
-                    returnCode: -2,
-                };
+    // Direct-arg add FFI: a NULL connect_str stores JSON null; a non-null
+    // pointer (including an empty string) stores that value.
+    let conn_opt = if connect_str.is_null() {
+        None
+    } else {
+        unsafe {
+            match CStr::from_ptr(connect_str).to_str() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
+                    return SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -2,
+                    };
+                }
             }
         }
     };
@@ -3476,7 +3497,7 @@ pub extern "C" fn SzConfigTool_addComparisonFunction(
         config,
         code,
         crate::functions::comparison::AddComparisonFunctionParams {
-            connect_str: conn,
+            connect_str: conn_opt,
             description: desc_opt,
             language: lang_opt,
             anon_support: anon_opt,
@@ -3764,13 +3785,16 @@ pub extern "C" fn SzConfigTool_setComparisonFunction(
         }
     };
 
-    let conn_opt = if connect_str.is_null() {
-        None
+    // Direct-arg set FFI: a plain pointer can encode only Leave/Set (D12), so a
+    // NULL connect_str leaves the stored value untouched and a non-null pointer
+    // (including an empty string) sets it. Clearing a value to null is only
+    // expressible via the JSON-based set APIs.
+    let conn_update = if connect_str.is_null() {
+        crate::helpers::FieldUpdate::Leave
     } else {
         unsafe {
             match CStr::from_ptr(connect_str).to_str() {
-                Ok(s) if !s.is_empty() => Some(s),
-                Ok(_) => None,
+                Ok(s) => crate::helpers::FieldUpdate::Set(s),
                 Err(e) => {
                     set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
                     return SzConfigTool_result {
@@ -3840,7 +3864,7 @@ pub extern "C" fn SzConfigTool_setComparisonFunction(
         config,
         code,
         crate::functions::comparison::SetComparisonFunctionParams {
-            connect_str: conn_opt,
+            connect_str: conn_update,
             description: desc_opt,
             language: lang_opt,
             anon_support: anon_opt,
@@ -7887,22 +7911,21 @@ pub extern "C" fn SzConfigTool_addDistinctFunction(
         }
     };
 
-    let connect = unsafe {
-        if connect_str.is_null() {
-            set_error("connect_str is null".to_string(), -1);
-            return SzConfigTool_result {
-                response: std::ptr::null_mut(),
-                returnCode: -1,
-            };
-        }
-        match CStr::from_ptr(connect_str).to_str() {
-            Ok(s) => s,
-            Err(e) => {
-                set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
-                return SzConfigTool_result {
-                    response: std::ptr::null_mut(),
-                    returnCode: -2,
-                };
+    // Direct-arg add FFI: a NULL connect_str stores JSON null; a non-null
+    // pointer (including an empty string) stores that value.
+    let connect = if connect_str.is_null() {
+        None
+    } else {
+        unsafe {
+            match CStr::from_ptr(connect_str).to_str() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
+                    return SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -2,
+                    };
+                }
             }
         }
     };
@@ -8242,12 +8265,16 @@ pub extern "C" fn SzConfigTool_setDistinctFunction(
         }
     };
 
-    let connect_opt = if connect_str.is_null() {
-        None
+    // Direct-arg set FFI: a plain pointer can encode only Leave/Set (D12), so a
+    // NULL connect_str leaves the stored value untouched and a non-null pointer
+    // (including an empty string) sets it. Clearing a value to null is only
+    // expressible via the JSON-based set APIs.
+    let connect_update = if connect_str.is_null() {
+        crate::helpers::FieldUpdate::Leave
     } else {
         unsafe {
             match CStr::from_ptr(connect_str).to_str() {
-                Ok(s) => Some(s),
+                Ok(s) => crate::helpers::FieldUpdate::Set(s),
                 Err(e) => {
                     set_error(format!("Invalid UTF-8 in connect_str: {e}"), -2);
                     return SzConfigTool_result {
@@ -8297,7 +8324,7 @@ pub extern "C" fn SzConfigTool_setDistinctFunction(
         config,
         dfunc,
         crate::functions::distinct::SetDistinctFunctionParams {
-            connect_str: connect_opt,
+            connect_str: connect_update,
             description: desc_opt,
             language: lang_opt,
             anon_support: None,
@@ -9541,5 +9568,122 @@ pub extern "C" fn SzConfigTool_setScoringFunction(
                 returnCode: -5,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Read (and free) the response string of an FFI result, asserting success.
+    fn take_response(result: SzConfigTool_result) -> String {
+        assert_eq!(result.returnCode, 0, "FFI call returned an error code");
+        assert!(!result.response.is_null(), "response was null");
+        let s = unsafe { CStr::from_ptr(result.response) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        unsafe { SzConfigTool_free(result.response) };
+        s
+    }
+
+    /// D12: a NULL connect_str on the direct-arg add FFI stores JSON null, with
+    /// the key still present.
+    #[test]
+    fn test_ffi_add_standardize_function_null_connect_str_stores_null() {
+        let config = CString::new(r#"{"G2_CONFIG": {"CFG_SFUNC": []}}"#).unwrap();
+        let code = CString::new("CUSTOM_PARSE").unwrap();
+
+        let result = SzConfigTool_addStandardizeFunction(
+            config.as_ptr(),
+            code.as_ptr(),
+            std::ptr::null(), // connect_str NULL -> stored null
+            std::ptr::null(),
+            std::ptr::null(),
+        );
+        let modified = take_response(result);
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let row = v["G2_CONFIG"]["CFG_SFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+    }
+
+    /// A NULL connect_str on the distinct add FFI likewise stores JSON null.
+    #[test]
+    fn test_ffi_add_distinct_function_null_connect_str_stores_null() {
+        let config = CString::new(r#"{"G2_CONFIG": {"CFG_DFUNC": []}}"#).unwrap();
+        let code = CString::new("CUSTOM_DIST").unwrap();
+
+        let result = SzConfigTool_addDistinctFunction(
+            config.as_ptr(),
+            code.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+        );
+        let modified = take_response(result);
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let row = v["G2_CONFIG"]["CFG_DFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+    }
+
+    /// The JSON-based setRule FFI can clear a column: an explicit null for a
+    /// disqualifier writes JSON null.
+    #[test]
+    fn test_ffi_set_rule_json_explicit_null_clears_column() {
+        let config = CString::new(
+            r#"{"G2_CONFIG": {"CFG_ERRULE": [
+                {"ERRULE_ID": 100, "ERRULE_CODE": "R1", "RESOLVE": "Yes",
+                 "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "R1",
+                 "DISQ_ERFRAG_CODE": "SOMETHING", "ERRULE_TIER": 10}
+            ], "CFG_ERFRAG": []}}"#,
+        )
+        .unwrap();
+        let code = CString::new("R1").unwrap();
+        // Explicit JSON null on disqualifier -> Clear.
+        let rule_json = CString::new(r#"{"disqualifier": null}"#).unwrap();
+
+        let result = SzConfigTool_setRule(config.as_ptr(), code.as_ptr(), rule_json.as_ptr());
+        let modified = take_response(result);
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let rule = &v["G2_CONFIG"]["CFG_ERRULE"][0];
+        assert!(rule.as_object().unwrap().contains_key("DISQ_ERFRAG_CODE"));
+        assert_eq!(rule["DISQ_ERFRAG_CODE"], Value::Null);
+        // A field not mentioned is left untouched.
+        assert_eq!(rule["QUAL_ERFRAG_CODE"], serde_json::json!("R1"));
+    }
+
+    /// The JSON-based setFragment FFI can clear ERFRAG_SOURCE (and, per D11, its
+    /// ERFRAG_DEPENDS) via an explicit null.
+    #[test]
+    fn test_ffi_set_fragment_json_explicit_null_clears_source() {
+        let config = CString::new(
+            r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+                {"ERFRAG_ID": 3, "ERFRAG_CODE": "F1", "ERFRAG_DESC": "F1",
+                 "ERFRAG_SOURCE": "./FRAGMENT[./SAME_NAME>0]", "ERFRAG_DEPENDS": "1,2"}
+            ]}}"#,
+        )
+        .unwrap();
+        let code = CString::new("F1").unwrap();
+        let frag_json = CString::new(r#"{"ERFRAG_SOURCE": null}"#).unwrap();
+
+        let result = unsafe {
+            SzConfigTool_setFragmentWithJson(config.as_ptr(), code.as_ptr(), frag_json.as_ptr())
+        };
+        let modified = take_response(result);
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let frag = &v["G2_CONFIG"]["CFG_ERFRAG"][0];
+        assert_eq!(frag["ERFRAG_SOURCE"], Value::Null);
+        assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null);
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1894,7 +1894,7 @@ pub unsafe extern "C" fn SzConfigTool_addConfigSectionField(
     };
 
     match crate::config_sections::add_config_section_field(config, section, field, &field_value) {
-        Ok((modified_config, _count)) => match CString::new(modified_config) {
+        Ok((modified_config, _counts)) => match CString::new(modified_config) {
             Ok(c_str) => {
                 clear_error();
                 SzConfigTool_result {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -407,6 +407,9 @@ pub unsafe extern "C" fn SzConfigTool_addAttribute(
             default_value: def_val,
             internal: int_val,
             required: req_val,
+            // ATTR_ID is not exposed over this fixed C signature; always
+            // auto-assign (#37). Rust/JSON callers can request a specific id.
+            id: None,
         },
     )
     .map(|(json, _item)| json);
@@ -5487,6 +5490,8 @@ pub extern "C" fn SzConfigTool_addFeature(
             comparison,
             version,
             rtype_id,
+            // #37: honour a caller-supplied FTYPE_ID from the feature JSON.
+            id: feature_config.get("id").and_then(|v| v.as_i64()),
         },
     ) {
         Ok(modified_config) => match CString::new(modified_config) {
@@ -5967,6 +5972,8 @@ pub extern "C" fn SzConfigTool_addElement(
             .get("dataType")
             .and_then(|v| v.as_str())
             .or_else(|| element_config.get("DATA_TYPE").and_then(|v| v.as_str())),
+        // #37: honour a caller-supplied FELEM_ID from the element JSON.
+        id: element_config.get("id").and_then(|v| v.as_i64()),
     };
 
     handle_result!(crate::elements::add_element(config, params))
@@ -6723,6 +6730,9 @@ pub extern "C" fn SzConfigTool_addComparisonCall(
             ftype_code: ftype.to_string(),
             cfunc_code: cfunc.to_string(),
             element_list,
+            // CFCALL_ID is not exposed over this fixed C signature; always
+            // auto-assign (#37).
+            id: None,
         },
     ) {
         Ok((modified_config, _record)) => match CString::new(modified_config) {
@@ -9571,6 +9581,166 @@ pub extern "C" fn SzConfigTool_setScoringFunction(
     }
 }
 
+// ============================================================================
+// Wave 4A additions (#38): feature-element mutators, settings, cascade deletes
+// ============================================================================
+
+/// Read a required C string arg, returning an error `SzConfigTool_result` from
+/// the enclosing function on null or invalid UTF-8.
+macro_rules! ffi_required_str {
+    ($ptr:expr, $name:expr) => {{
+        if $ptr.is_null() {
+            set_error(format!("{} is null", $name), -1);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -1,
+            };
+        }
+        match unsafe { CStr::from_ptr($ptr) }.to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in {}: {e}", $name), -2);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -2,
+                };
+            }
+        }
+    }};
+}
+
+/// Add an element to a feature (append a CFG_FBOM row).
+///
+/// `options_json` may be null; when present it is a JSON object that may carry
+/// `displayLevel` (integer), `displayDelim` (string), and `derived`
+/// (`"Yes"`/`"No"`).
+///
+/// # Safety
+/// `config_json`, `feature_code`, and `element_code` must be valid
+/// null-terminated C strings; `options_json` may be null or a valid C string.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_addElementToFeature(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+    element_code: *const c_char,
+    options_json: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    let element = ffi_required_str!(element_code, "element_code");
+
+    let options: serde_json::Value = if options_json.is_null() {
+        serde_json::Value::Null
+    } else {
+        let s = ffi_required_str!(options_json, "options_json");
+        match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(e) => {
+                set_error(format!("Invalid JSON in options_json: {e}"), -3);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -3,
+                };
+            }
+        }
+    };
+
+    let params = crate::elements::AddElementToFeatureParams {
+        feature_code: feature,
+        element_code: element,
+        display_level: options.get("displayLevel").and_then(|v| v.as_i64()),
+        display_delim: options.get("displayDelim").and_then(|v| v.as_str()),
+        derived: options.get("derived").and_then(|v| v.as_str()),
+    };
+
+    handle_result!(crate::elements::add_element_to_feature(config, params))
+}
+
+/// Delete a single feature-element mapping (one CFG_FBOM row).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteElementFromFeature(
+    config_json: *const c_char,
+    feature_code: *const c_char,
+    element_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let feature = ffi_required_str!(feature_code, "feature_code");
+    let element = ffi_required_str!(element_code, "element_code");
+    handle_result!(crate::elements::delete_element_from_feature(
+        config, feature, element
+    ))
+}
+
+/// Set (create or overwrite) a named configuration setting.
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_setSetting(
+    config_json: *const c_char,
+    name: *const c_char,
+    value: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let name = ffi_required_str!(name, "name");
+    let value = ffi_required_str!(value, "value");
+    handle_result!(crate::settings::set_setting(config, name, value))
+}
+
+/// Delete a comparison function and all dependent rows (cascade).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteComparisonFunctionCascade(
+    config_json: *const c_char,
+    cfunc_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let code = ffi_required_str!(cfunc_code, "cfunc_code");
+    handle_result!(
+        crate::functions::comparison::delete_comparison_function_cascade(config, code)
+            .map(|(json, _)| json)
+    )
+}
+
+/// Delete an expression function and all dependent rows (cascade).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteExpressionFunctionCascade(
+    config_json: *const c_char,
+    efunc_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let code = ffi_required_str!(efunc_code, "efunc_code");
+    handle_result!(
+        crate::functions::expression::delete_expression_function_cascade(config, code)
+            .map(|(json, _)| json)
+    )
+}
+
+/// Delete a standardize function and all dependent rows (cascade).
+///
+/// # Safety
+/// All pointers must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_deleteStandardizeFunctionCascade(
+    config_json: *const c_char,
+    sfunc_code: *const c_char,
+) -> SzConfigTool_result {
+    let config = ffi_required_str!(config_json, "config_json");
+    let code = ffi_required_str!(sfunc_code, "sfunc_code");
+    handle_result!(
+        crate::functions::standardize::delete_standardize_function_cascade(config, code)
+            .map(|(json, _)| json)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9586,6 +9756,73 @@ mod tests {
             .to_string();
         unsafe { SzConfigTool_free(result.response) };
         s
+    }
+
+    /// #38.3: setSetting FFI round-trips and uppercases the name.
+    #[test]
+    fn test_ffi_set_setting() {
+        let config = CString::new(r#"{"G2_CONFIG": {}}"#).unwrap();
+        let name = CString::new("my_setting").unwrap();
+        let value = CString::new("42").unwrap();
+        let result = SzConfigTool_setSetting(config.as_ptr(), name.as_ptr(), value.as_ptr());
+        let modified = take_response(result);
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(v["G2_CONFIG"]["SETTINGS"]["MY_SETTING"], "42");
+    }
+
+    /// #38.1/#38.2: addElementToFeature then deleteElementFromFeature round-trip.
+    #[test]
+    fn test_ffi_add_delete_element_to_feature() {
+        let base = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 2, "FELEM_CODE": "FULL_NAME"}],
+            "CFG_FBOM": []
+        }}"#;
+        let config = CString::new(base).unwrap();
+        let feature = CString::new("NAME").unwrap();
+        let element = CString::new("FULL_NAME").unwrap();
+
+        let added = take_response(SzConfigTool_addElementToFeature(
+            config.as_ptr(),
+            feature.as_ptr(),
+            element.as_ptr(),
+            std::ptr::null(),
+        ));
+        let v: Value = serde_json::from_str(&added).unwrap();
+        assert_eq!(v["G2_CONFIG"]["CFG_FBOM"].as_array().unwrap().len(), 1);
+
+        let added_c = CString::new(added).unwrap();
+        let removed = take_response(SzConfigTool_deleteElementFromFeature(
+            added_c.as_ptr(),
+            feature.as_ptr(),
+            element.as_ptr(),
+        ));
+        let v: Value = serde_json::from_str(&removed).unwrap();
+        assert_eq!(v["G2_CONFIG"]["CFG_FBOM"].as_array().unwrap().len(), 0);
+    }
+
+    /// #38.4: deleteComparisonFunctionCascade FFI empties dependents.
+    #[test]
+    fn test_ffi_delete_comparison_function_cascade() {
+        let base = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_CFUNC": [{"CFUNC_ID": 1, "CFUNC_CODE": "CMP_X"}],
+            "CFG_CFCALL": [{"CFCALL_ID": 10, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+            "CFG_CFBOM": [{"CFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 5, "EXEC_ORDER": 1}],
+            "CFG_CFRTN": [{"CFRTN_ID": 100, "CFUNC_ID": 1, "FTYPE_ID": 3, "CFUNC_RTNVAL": "SAME"}]
+        }}"#;
+        let config = CString::new(base).unwrap();
+        let code = CString::new("CMP_X").unwrap();
+        let modified = take_response(SzConfigTool_deleteComparisonFunctionCascade(
+            config.as_ptr(),
+            code.as_ptr(),
+        ));
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &v["G2_CONFIG"];
+        assert_eq!(g2["CFG_CFUNC"].as_array().unwrap().len(), 0);
+        assert_eq!(g2["CFG_CFCALL"].as_array().unwrap().len(), 0);
+        assert_eq!(g2["CFG_CFBOM"].as_array().unwrap().len(), 0);
+        assert_eq!(g2["CFG_CFRTN"].as_array().unwrap().len(), 0);
     }
 
     /// D12: a NULL connect_str on the direct-arg add FFI stores JSON null, with

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1774,6 +1774,73 @@ pub unsafe extern "C" fn SzConfigTool_getConfigSection(
     }
 }
 
+/// Report whether a config section is empty (null or `[]`).
+///
+/// Companion to `SzConfigTool_getConfigSection` that lets a caller distinguish an
+/// empty section from a filter that matched nothing. On success the response is
+/// the JSON boolean `"true"` or `"false"`; a missing section returns an error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn SzConfigTool_configSectionIsEmpty(
+    config_json: *const c_char,
+    section_name: *const c_char,
+) -> SzConfigTool_result {
+    if config_json.is_null() || section_name.is_null() {
+        set_error("Required parameter is null".to_string(), -1);
+        return SzConfigTool_result {
+            response: std::ptr::null_mut(),
+            returnCode: -1,
+        };
+    }
+
+    let config = match unsafe { CStr::from_ptr(config_json) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_error(format!("Invalid UTF-8 in config_json: {e}"), -2);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -2,
+            };
+        }
+    };
+
+    let section = match unsafe { CStr::from_ptr(section_name) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_error(format!("Invalid UTF-8 in section_name: {e}"), -2);
+            return SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -2,
+            };
+        }
+    };
+
+    match crate::config_sections::config_section_is_empty(config, section) {
+        Ok(is_empty) => match CString::new(if is_empty { "true" } else { "false" }) {
+            Ok(c_str) => {
+                clear_error();
+                SzConfigTool_result {
+                    response: c_str.into_raw(),
+                    returnCode: 0,
+                }
+            }
+            Err(e) => {
+                set_error(format!("Failed to convert result: {e}"), -4);
+                SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -4,
+                }
+            }
+        },
+        Err(e) => {
+            set_error(e.to_string(), -5);
+            SzConfigTool_result {
+                response: std::ptr::null_mut(),
+                returnCode: -5,
+            }
+        }
+    }
+}
+
 /// List all config sections
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SzConfigTool_listConfigSections(

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,298 @@
+//! Substring-filter substrate for list/record matching.
+//!
+//! Several listing operations filter records by testing whether a
+//! user-supplied term occurs as a substring of the record's *stringified*
+//! form. The result of such a test depends entirely on **how the record is
+//! stringified** — a term like `"K": 1` (with a space after the colon) matches
+//! under a spaced JSON rendering but misses under a compact one.
+//!
+//! [`FilterSubstrate`] names the three renderings this substrate supports, and
+//! [`matches_filter`] performs the substring test under a chosen rendering.
+//!
+//! ## Deliberate limitation: `ensure_ascii` is *not* reproduced
+//!
+//! Python's `json.dumps` defaults to `ensure_ascii=True`, escaping every
+//! non-ASCII character to a `\uXXXX` sequence. [`to_json_dumps_string`] here
+//! deliberately does **not** reproduce that: it emits UTF-8 text directly (as
+//! `serde_json` does). For records containing non-ASCII text, a filter term may
+//! therefore match here but not under real CPython `json.dumps`, and vice
+//! versa. This mirrors the original tool's behaviour and is intentional; do not
+//! "fix" it without a corresponding decision.
+
+use serde_json::Value;
+
+/// The record-stringification strategy used for substring filtering.
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::filter::FilterSubstrate;
+///
+/// // Default matches the safe, spaced JSON rendering.
+/// assert_eq!(FilterSubstrate::default(), FilterSubstrate::JsonDumps);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum FilterSubstrate {
+    /// `serde_json` compact form: no spaces (`{"K":1,"J":null}`).
+    Compact,
+    /// Python `json.dumps` default spacing: `", "` between items, `": "`
+    /// between key and value (`{"K": 1, "J": null}`), but **without**
+    /// `ensure_ascii` escaping (see the module note).
+    #[default]
+    JsonDumps,
+    /// CPython `repr` of the equivalent Python object: `None`/`True`/`False`,
+    /// single-quoted strings, `", "`/`": "` spacing (`{'K': 1, 'J': None}`).
+    PythonRepr,
+}
+
+/// Render a JSON value the way Python's `json.dumps` does by default.
+///
+/// Containers use `", "` between items and `": "` between an object's key and
+/// value; scalars are rendered as standard JSON. Non-ASCII text is emitted
+/// directly as UTF-8 — the `ensure_ascii` escaping of real `json.dumps` is
+/// **not** reproduced (see the module-level note).
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::filter::to_json_dumps_string;
+///
+/// let v = json!({"K": 1, "J": null});
+/// assert_eq!(to_json_dumps_string(&v), r#"{"K": 1, "J": null}"#);
+/// ```
+pub fn to_json_dumps_string(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let inner: Vec<String> = map
+                .iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}: {}",
+                        serde_json::to_string(k).unwrap_or_else(|_| String::from("\"\"")),
+                        to_json_dumps_string(v)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", inner.join(", "))
+        }
+        Value::Array(arr) => {
+            let inner: Vec<String> = arr.iter().map(to_json_dumps_string).collect();
+            format!("[{}]", inner.join(", "))
+        }
+        // Scalars (null/bool/number/string) render identically to JSON; serde
+        // keeps non-ASCII as UTF-8, which is exactly the limitation we want.
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Render a string the way CPython's `repr` would.
+///
+/// Uses single quotes by default, switching to double quotes when the string
+/// contains a single quote but no double quote (matching CPython). Backslash
+/// and the common control characters (`\n`, `\r`, `\t`) are escaped. Non-ASCII
+/// printable characters are emitted directly (the `\uXXXX` / `\xXX` escaping of
+/// unprintable code points is not reproduced — this is an approximation aimed
+/// at the common cases used in filtering).
+fn python_repr_str(s: &str) -> String {
+    let has_single = s.contains('\'');
+    let has_double = s.contains('"');
+    // CPython prefers single quotes, but uses double quotes to avoid escaping
+    // when the string has a single quote and no double quote.
+    let use_double = has_single && !has_double;
+    let quote = if use_double { '"' } else { '\'' };
+
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push(quote);
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c == quote => {
+                out.push('\\');
+                out.push(c);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push(quote);
+    out
+}
+
+/// Render a JSON value the way CPython's `repr` renders the equivalent object.
+///
+/// `null`/`true`/`false` become `None`/`True`/`False`; strings are
+/// single-quoted (see [`python_repr_str`]); containers use `", "`/`": "`
+/// spacing. Nesting is handled recursively.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::filter::to_python_repr_string;
+///
+/// let v = json!({"K": 1, "J": null, "L": true});
+/// assert_eq!(to_python_repr_string(&v), "{'K': 1, 'J': None, 'L': True}");
+/// ```
+pub fn to_python_repr_string(value: &Value) -> String {
+    match value {
+        Value::Null => "None".to_string(),
+        Value::Bool(true) => "True".to_string(),
+        Value::Bool(false) => "False".to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => python_repr_str(s),
+        Value::Array(arr) => {
+            let inner: Vec<String> = arr.iter().map(to_python_repr_string).collect();
+            format!("[{}]", inner.join(", "))
+        }
+        Value::Object(map) => {
+            let inner: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{}: {}", python_repr_str(k), to_python_repr_string(v)))
+                .collect();
+            format!("{{{}}}", inner.join(", "))
+        }
+    }
+}
+
+/// Test whether `filter` occurs as a substring of `record` rendered under the
+/// given [`FilterSubstrate`].
+///
+/// The match is case-sensitive, mirroring Python's `in` operator on strings.
+/// An empty filter always matches.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::filter::{matches_filter, FilterSubstrate};
+///
+/// let record = json!({"K": 1, "J": null});
+///
+/// // A boundary-spanning term matches under the spaced rendering...
+/// assert!(matches_filter(&record, "\"K\": 1", FilterSubstrate::JsonDumps));
+/// // ...but misses under the compact one (which has no space).
+/// assert!(!matches_filter(&record, "\"K\": 1", FilterSubstrate::Compact));
+/// ```
+pub fn matches_filter(record: &Value, filter: &str, substrate: FilterSubstrate) -> bool {
+    let haystack = match substrate {
+        FilterSubstrate::Compact => serde_json::to_string(record).unwrap_or_default(),
+        FilterSubstrate::JsonDumps => to_json_dumps_string(record),
+        FilterSubstrate::PythonRepr => to_python_repr_string(record),
+    };
+    haystack.contains(filter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_json_dumps_spacing() {
+        let v = json!({"K": 1, "J": null});
+        assert_eq!(to_json_dumps_string(&v), r#"{"K": 1, "J": null}"#);
+        // Compact (serde) has no spaces — this is the contrast the bug hinges on.
+        assert_eq!(serde_json::to_string(&v).unwrap(), r#"{"K":1,"J":null}"#);
+    }
+
+    #[test]
+    fn test_json_dumps_nested_and_arrays() {
+        let v = json!({"a": [1, 2, {"b": "c"}], "d": true});
+        assert_eq!(
+            to_json_dumps_string(&v),
+            r#"{"a": [1, 2, {"b": "c"}], "d": true}"#
+        );
+    }
+
+    #[test]
+    fn test_python_repr_scalars() {
+        assert_eq!(to_python_repr_string(&Value::Null), "None");
+        assert_eq!(to_python_repr_string(&json!(true)), "True");
+        assert_eq!(to_python_repr_string(&json!(false)), "False");
+        assert_eq!(to_python_repr_string(&json!(42)), "42");
+        assert_eq!(to_python_repr_string(&json!("hi")), "'hi'");
+    }
+
+    #[test]
+    fn test_python_repr_nested() {
+        let v = json!({"K": 1, "J": null, "nested": {"x": [true, false, null]}});
+        assert_eq!(
+            to_python_repr_string(&v),
+            "{'K': 1, 'J': None, 'nested': {'x': [True, False, None]}}"
+        );
+    }
+
+    #[test]
+    fn test_python_repr_quote_selection() {
+        // Default single quotes.
+        assert_eq!(to_python_repr_string(&json!("plain")), "'plain'");
+        // Contains a single quote but no double quote -> switch to double quotes.
+        assert_eq!(to_python_repr_string(&json!("it's")), "\"it's\"");
+        // Contains a double quote -> keep single quotes.
+        assert_eq!(to_python_repr_string(&json!("say \"hi\"")), "'say \"hi\"'");
+        // Contains both -> single quotes with the single quote escaped.
+        assert_eq!(
+            to_python_repr_string(&json!("it's \"x\"")),
+            "'it\\'s \"x\"'"
+        );
+    }
+
+    #[test]
+    fn test_matches_filter_boundary_spanning() {
+        // The #36 repro: {"K":1,"J":null} with a boundary-spanning filter.
+        let record = json!({"K": 1, "J": null});
+
+        // A term that spans the item boundary (value, next-key) only matches
+        // under the spaced json.dumps rendering.
+        assert!(matches_filter(
+            &record,
+            "1, \"J\"",
+            FilterSubstrate::JsonDumps
+        ));
+        assert!(!matches_filter(
+            &record,
+            "1, \"J\"",
+            FilterSubstrate::Compact
+        ));
+
+        // The key/value boundary likewise.
+        assert!(matches_filter(
+            &record,
+            "\"K\": 1",
+            FilterSubstrate::JsonDumps
+        ));
+        assert!(!matches_filter(
+            &record,
+            "\"K\": 1",
+            FilterSubstrate::Compact
+        ));
+    }
+
+    #[test]
+    fn test_matches_filter_python_repr_none() {
+        let record = json!({"K": 1, "J": null});
+        // null renders as None under repr, as null under json.dumps.
+        assert!(matches_filter(&record, "None", FilterSubstrate::PythonRepr));
+        assert!(!matches_filter(&record, "None", FilterSubstrate::JsonDumps));
+        assert!(matches_filter(&record, "null", FilterSubstrate::JsonDumps));
+    }
+
+    #[test]
+    fn test_matches_filter_empty_always_matches() {
+        let record = json!({"a": 1});
+        assert!(matches_filter(&record, "", FilterSubstrate::Compact));
+        assert!(matches_filter(&record, "", FilterSubstrate::JsonDumps));
+        assert!(matches_filter(&record, "", FilterSubstrate::PythonRepr));
+    }
+
+    #[test]
+    fn test_ensure_ascii_not_reproduced() {
+        // Deliberate limitation: non-ASCII is emitted as UTF-8, not \uXXXX.
+        let v = json!({"name": "café"});
+        assert_eq!(to_json_dumps_string(&v), r#"{"name": "café"}"#);
+        assert!(!to_json_dumps_string(&v).contains("\\u"));
+    }
+}

--- a/src/fragments.rs
+++ b/src/fragments.rs
@@ -4,7 +4,7 @@
 //! Fragments define matching criteria used by rules.
 
 use crate::error::{Result, SzConfigError};
-use crate::helpers;
+use crate::helpers::{self, FieldUpdate};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -26,6 +26,36 @@ struct ErfragRow {
     erfrag_source: Option<String>,
     #[serde(rename = "ERFRAG_DEPENDS")]
     erfrag_depends: Option<String>,
+}
+
+/// Parameters for setting (updating) a fragment.
+///
+/// Both fields are tri-state [`FieldUpdate`]s so an update can distinguish "leave
+/// unchanged" from "clear to null":
+///
+/// - `source` (`ERFRAG_SOURCE`): `Leave` keeps the stored source and its computed
+///   `ERFRAG_DEPENDS`; `Clear` writes `null` for both source and depends (D11);
+///   `Set` validates the new source and recomputes `ERFRAG_DEPENDS`.
+/// - `description` (`ERFRAG_DESC`): `Leave` keeps the stored description; `Clear`
+///   writes `null`; `Set` writes the new description.
+#[derive(Debug, Clone, Default)]
+pub struct SetFragmentParams<'a> {
+    pub source: FieldUpdate<&'a str>,
+    pub description: FieldUpdate<&'a str>,
+}
+
+impl<'a> TryFrom<&'a Value> for SetFragmentParams<'a> {
+    type Error = SzConfigError;
+
+    fn try_from(json: &'a Value) -> Result<Self> {
+        // Tri-state per field: an absent key -> Leave, an explicit JSON null ->
+        // Clear, a string value -> Set. Both the uppercase CFG_ERFRAG column
+        // names and lowercase aliases are accepted.
+        Ok(Self {
+            source: helpers::field_update_str(json, &["ERFRAG_SOURCE", "source"]),
+            description: helpers::field_update_str(json, &["ERFRAG_DESC", "description"]),
+        })
+    }
 }
 
 /// Validates a fragment source XPath expression and computes dependencies
@@ -319,12 +349,15 @@ pub fn get_fragment(config_json: &str, code_or_id: &str) -> Result<Value> {
         )));
     };
 
-    // Transform to lowercase format (matching list_fragments for consistency)
+    // Transform to lowercase format (matching list_fragments for consistency).
+    // ERFRAG_SOURCE and ERFRAG_DEPENDS are stored-nullable, so they are projected
+    // null-preserving (stored null stays null, stored "" stays "", absent ->
+    // null) via helpers::field_or_null rather than coerced to "".
     Ok(json!({
         "id": item.get("ERFRAG_ID").and_then(|v| v.as_i64()).unwrap_or(0),
         "fragment": item.get("ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-        "source": item.get("ERFRAG_SOURCE").and_then(|v| v.as_str()).unwrap_or(""),
-        "depends": item.get("ERFRAG_DEPENDS").and_then(|v| v.as_str()).unwrap_or("")
+        "source": helpers::field_or_null(&item, "ERFRAG_SOURCE"),
+        "depends": helpers::field_or_null(&item, "ERFRAG_DEPENDS")
     }))
 }
 
@@ -356,11 +389,12 @@ pub fn list_fragments(config_json: &str) -> Result<Vec<Value>> {
             array
                 .iter()
                 .map(|item| {
+                    // ERFRAG_SOURCE and ERFRAG_DEPENDS null-preserved (see get_fragment).
                     json!({
                         "id": item.get("ERFRAG_ID").and_then(|v| v.as_i64()).unwrap_or(0),
                         "fragment": item.get("ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                        "source": item.get("ERFRAG_SOURCE").and_then(|v| v.as_str()).unwrap_or(""),
-                        "depends": item.get("ERFRAG_DEPENDS").and_then(|v| v.as_str()).unwrap_or("")
+                        "source": helpers::field_or_null(item, "ERFRAG_SOURCE"),
+                        "depends": helpers::field_or_null(item, "ERFRAG_DEPENDS")
                     })
                 })
                 .collect()
@@ -380,7 +414,8 @@ pub fn list_fragments(config_json: &str) -> Result<Vec<Value>> {
 ///
 /// * `config_json` - Configuration JSON string
 /// * `fragment_code` - Fragment code to update
-/// * `fragment_config` - New configuration for the fragment
+/// * `params` - Tri-state update for `ERFRAG_SOURCE` / `ERFRAG_DESC`
+///   ([`SetFragmentParams`])
 ///
 /// # Returns
 ///
@@ -389,23 +424,26 @@ pub fn list_fragments(config_json: &str) -> Result<Vec<Value>> {
 /// # Example
 ///
 /// ```
-/// use sz_configtool_lib::fragments;
-/// use serde_json::json;
+/// use sz_configtool_lib::fragments::{self, SetFragmentParams};
+/// use sz_configtool_lib::helpers::FieldUpdate;
 ///
 /// let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [{"ERFRAG_ID": 1, "ERFRAG_CODE": "TEST"}]}}"#;
-/// let new_config = json!({"ERFRAG_SOURCE": "NAME+DOB"});
-/// let modified = fragments::set_fragment(config, "TEST", &new_config).unwrap();
+/// let params = SetFragmentParams {
+///     source: FieldUpdate::Set("NAME+DOB"),
+///     description: FieldUpdate::Leave,
+/// };
+/// let modified = fragments::set_fragment(config, "TEST", params).unwrap();
 /// ```
 pub fn set_fragment(
     config_json: &str,
     fragment_code: &str,
-    fragment_config: &Value,
+    params: SetFragmentParams,
 ) -> Result<String> {
     let code = fragment_code.to_uppercase();
 
-    // Fetch the existing row so fields not part of the update (ERFRAG_ID,
-    // ERFRAG_DESC, and — when SOURCE is unchanged — ERFRAG_SOURCE/ERFRAG_DEPENDS)
-    // are carried forward rather than dropped by the full-row replace.
+    // Fetch the existing row so fields not part of the update (ERFRAG_ID, and any
+    // Leave field) are carried forward rather than dropped by the full-row
+    // replace.
     let existing = helpers::find_in_config_array(config_json, "CFG_ERFRAG", "ERFRAG_CODE", &code)?
         .ok_or_else(|| SzConfigError::NotFound(format!("Fragment not found: {code}")))?;
 
@@ -414,32 +452,37 @@ pub fn set_fragment(
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
-    // If SOURCE is being updated, validate it and recompute ERFRAG_DEPENDS;
-    // otherwise keep the existing SOURCE and DEPENDS.
-    let (erfrag_source, erfrag_depends) = if let Some(new_source) = fragment_config
-        .get("ERFRAG_SOURCE")
-        .and_then(|v| v.as_str())
-    {
-        let (dependency_list, error_message) = validate_fragment_source(config_json, new_source);
-        if !error_message.is_empty() {
-            return Err(SzConfigError::InvalidInput(error_message));
-        }
-        let depends = if dependency_list.is_empty() {
-            None
-        } else {
-            Some(dependency_list.join(","))
-        };
-        (Some(new_source.to_string()), depends)
-    } else {
-        (
+    // SOURCE tri-state:
+    // - Leave: keep the existing SOURCE and DEPENDS.
+    // - Clear: write null for SOURCE and, per D11, also clear DEPENDS to null.
+    // - Set: validate the new SOURCE and recompute DEPENDS.
+    let (erfrag_source, erfrag_depends) = match params.source {
+        FieldUpdate::Leave => (
             helpers::field_as_string(&existing, "ERFRAG_SOURCE"),
             helpers::field_as_string(&existing, "ERFRAG_DEPENDS"),
-        )
+        ),
+        FieldUpdate::Clear => (None, None),
+        FieldUpdate::Set(new_source) => {
+            let (dependency_list, error_message) =
+                validate_fragment_source(config_json, new_source);
+            if !error_message.is_empty() {
+                return Err(SzConfigError::InvalidInput(error_message));
+            }
+            let depends = if dependency_list.is_empty() {
+                None
+            } else {
+                Some(dependency_list.join(","))
+            };
+            (Some(new_source.to_string()), depends)
+        }
     };
 
-    // ERFRAG_DESC from the update if supplied, else preserve existing.
-    let erfrag_desc = helpers::field_as_string(fragment_config, "ERFRAG_DESC")
-        .or_else(|| helpers::field_as_string(&existing, "ERFRAG_DESC"));
+    // ERFRAG_DESC tri-state: Leave preserves, Clear nulls, Set writes.
+    let erfrag_desc = match params.description {
+        FieldUpdate::Leave => helpers::field_as_string(&existing, "ERFRAG_DESC"),
+        FieldUpdate::Clear => None,
+        FieldUpdate::Set(desc) => Some(desc.to_string()),
+    };
 
     let row = ErfragRow {
         erfrag_id,
@@ -495,6 +538,30 @@ mod tests {
         assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null);
     }
 
+    /// #33: get_fragment / list_fragments null-preserve ERFRAG_SOURCE and
+    /// ERFRAG_DEPENDS (stored null -> null, stored "" -> "", absent -> null)
+    /// rather than coercing them to "".
+    #[test]
+    fn test_fragments_source_depends_null_preserved() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+            {"ERFRAG_ID": 1, "ERFRAG_CODE": "A", "ERFRAG_SOURCE": null, "ERFRAG_DEPENDS": ""},
+            {"ERFRAG_ID": 2, "ERFRAG_CODE": "B", "ERFRAG_SOURCE": "NAME"}
+        ]}}"#;
+
+        let list = list_fragments(config).unwrap();
+        // Row A: stored null stays null; stored "" stays "".
+        assert_eq!(list[0]["source"], Value::Null);
+        assert_eq!(list[0]["depends"], json!(""));
+        // Row B: source present; depends absent -> null.
+        assert_eq!(list[1]["source"], json!("NAME"));
+        assert_eq!(list[1]["depends"], Value::Null);
+
+        // get_fragment agrees.
+        let a = get_fragment(config, "A").unwrap();
+        assert_eq!(a["source"], Value::Null);
+        assert_eq!(a["depends"], json!(""));
+    }
+
     /// Regression: updating one field must not drop the row's other keys.
     /// Previously set_fragment replaced the whole row with the partial update,
     /// discarding ERFRAG_ID / ERFRAG_DESC and leaving the engine loader with an
@@ -507,8 +574,11 @@ mod tests {
         ]}}"#;
 
         // Update only the description; SOURCE is not part of the update.
-        let update = json!({"ERFRAG_DESC": "Updated desc"});
-        let modified = set_fragment(config, "TEST", &update).unwrap();
+        let params = SetFragmentParams {
+            source: FieldUpdate::Leave,
+            description: FieldUpdate::Set("Updated desc"),
+        };
+        let modified = set_fragment(config, "TEST", params).unwrap();
         let value: Value = serde_json::from_str(&modified).unwrap();
         let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
 
@@ -525,13 +595,60 @@ mod tests {
             {"ERFRAG_ID": 1, "ERFRAG_CODE": "TEST"}
         ]}}"#;
 
-        let update = json!({"ERFRAG_SOURCE": "NAME+DOB"});
-        let modified = set_fragment(config, "TEST", &update).unwrap();
+        let params = SetFragmentParams {
+            source: FieldUpdate::Set("NAME+DOB"),
+            description: FieldUpdate::Leave,
+        };
+        let modified = set_fragment(config, "TEST", params).unwrap();
         let value: Value = serde_json::from_str(&modified).unwrap();
         let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
 
         assert_all_keys(frag);
         assert_eq!(frag["ERFRAG_ID"], json!(1));
         assert_eq!(frag["ERFRAG_SOURCE"], json!("NAME+DOB"));
+    }
+
+    /// D11: clearing ERFRAG_SOURCE also clears ERFRAG_DEPENDS to null; both keys
+    /// remain present.
+    #[test]
+    fn test_set_fragment_source_clear_clears_depends() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+            {"ERFRAG_ID": 3, "ERFRAG_CODE": "TEST", "ERFRAG_DESC": "TEST",
+             "ERFRAG_SOURCE": "./FRAGMENT[./SAME_NAME>0]", "ERFRAG_DEPENDS": "1,2"}
+        ]}}"#;
+
+        let params = SetFragmentParams {
+            source: FieldUpdate::Clear,
+            description: FieldUpdate::Leave,
+        };
+        let modified = set_fragment(config, "TEST", params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
+
+        assert_all_keys(frag);
+        assert_eq!(frag["ERFRAG_SOURCE"], Value::Null);
+        assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null);
+        // Untouched fields preserved.
+        assert_eq!(frag["ERFRAG_DESC"], json!("TEST"));
+    }
+
+    /// The description can be cleared independently of the source.
+    #[test]
+    fn test_set_fragment_description_clear() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+            {"ERFRAG_ID": 4, "ERFRAG_CODE": "TEST", "ERFRAG_DESC": "TEST",
+             "ERFRAG_SOURCE": "NAME", "ERFRAG_DEPENDS": null}
+        ]}}"#;
+
+        let params = SetFragmentParams {
+            source: FieldUpdate::Leave,
+            description: FieldUpdate::Clear,
+        };
+        let modified = set_fragment(config, "TEST", params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let frag = &value["G2_CONFIG"]["CFG_ERFRAG"][0];
+        assert_eq!(frag["ERFRAG_DESC"], Value::Null);
+        // Source untouched (Leave).
+        assert_eq!(frag["ERFRAG_SOURCE"], json!("NAME"));
     }
 }

--- a/src/fragments.rs
+++ b/src/fragments.rs
@@ -243,23 +243,20 @@ pub fn add_fragment(config_json: &str, fragment_config: &Value) -> Result<(Strin
 
     let config_data: Value = serde_json::from_str(config_json)?;
 
-    // Get next ID
-    let next_id = if let Some(g2_config) = config_data.get("G2_CONFIG") {
-        if let Some(array) = g2_config.get("CFG_ERFRAG").and_then(|v| v.as_array()) {
-            array
-                .iter()
-                .filter_map(|item| item.get("ERFRAG_ID").and_then(|v| v.as_i64()))
-                .max()
-                .unwrap_or(0)
-                + 1
-        } else {
-            1
-        }
-    } else {
-        return Err(SzConfigError::InvalidConfig(
-            "G2_CONFIG not found".to_string(),
-        ));
-    };
+    // Caller-supplied ERFRAG_ID (#37/D19): previously the add path computed
+    // max+1 unconditionally and *ignored* any ERFRAG_ID present in the input
+    // Value. Now an explicit ERFRAG_ID (> 0) is honoured — rejected with
+    // AlreadyExists if taken — while None/absent/non-positive auto-assigns the
+    // next id (unseeded max+1, floor 1, preserving the historical numbering).
+    let desired_id = fragment_config.get("ERFRAG_ID").and_then(|v| v.as_i64());
+    let empty: Vec<Value> = Vec::new();
+    let erfrag_array = config_data
+        .get("G2_CONFIG")
+        .ok_or_else(|| SzConfigError::InvalidConfig("G2_CONFIG not found".to_string()))?
+        .get("CFG_ERFRAG")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+    let next_id = helpers::get_desired_or_next_id(erfrag_array, "ERFRAG_ID", desired_id, 1)?;
 
     // Build a complete row via ErfragRow so every CFG_ERFRAG key is present
     // (optional fields serialize as null).
@@ -536,6 +533,45 @@ mod tests {
         assert_eq!(frag["ERFRAG_SOURCE"], json!("NAME+DOB"));
         // No FRAGMENT[...] references -> no dependencies -> null (present).
         assert_eq!(frag["ERFRAG_DEPENDS"], Value::Null);
+    }
+
+    /// #37/D19: a caller-supplied ERFRAG_ID is now honoured (previously ignored),
+    /// and a taken id is rejected.
+    #[test]
+    fn test_add_fragment_caller_supplied_id() {
+        let config = r#"{"G2_CONFIG": {"CFG_ERFRAG": [
+            {"ERFRAG_ID": 3, "ERFRAG_CODE": "EXISTING", "ERFRAG_SOURCE": "NAME"}
+        ]}}"#;
+
+        // Honour an explicit id rather than computing max+1 (=4).
+        let frag_config = json!({
+            "ERFRAG_CODE": "CUSTOM_FRAG",
+            "ERFRAG_SOURCE": "NAME+DOB",
+            "ERFRAG_ID": 50
+        });
+        let (modified, id) = add_fragment(config, &frag_config).unwrap();
+        assert_eq!(id, 50);
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let frag = value["G2_CONFIG"]["CFG_ERFRAG"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(frag["ERFRAG_ID"], json!(50));
+
+        // A taken id is rejected.
+        let frag_config = json!({
+            "ERFRAG_CODE": "ANOTHER",
+            "ERFRAG_SOURCE": "NAME",
+            "ERFRAG_ID": 3
+        });
+        let err = add_fragment(config, &frag_config).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+
+        // Absent id still auto-assigns max+1.
+        let frag_config = json!({"ERFRAG_CODE": "AUTO", "ERFRAG_SOURCE": "NAME"});
+        let (_m, id) = add_fragment(config, &frag_config).unwrap();
+        assert_eq!(id, 4);
     }
 
     /// #33: get_fragment / list_fragments null-preserve ERFRAG_SOURCE and

--- a/src/fragments.rs
+++ b/src/fragments.rs
@@ -351,7 +351,7 @@ pub fn get_fragment(config_json: &str, code_or_id: &str) -> Result<Value> {
     // null-preserving (stored null stays null, stored "" stays "", absent ->
     // null) via helpers::field_or_null rather than coerced to "".
     Ok(json!({
-        "id": item.get("ERFRAG_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+        "id": helpers::field_or_null(&item, "ERFRAG_ID"),
         "fragment": item.get("ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
         "source": helpers::field_or_null(&item, "ERFRAG_SOURCE"),
         "depends": helpers::field_or_null(&item, "ERFRAG_DEPENDS")
@@ -388,7 +388,7 @@ pub fn list_fragments(config_json: &str) -> Result<Vec<Value>> {
                 .map(|item| {
                     // ERFRAG_SOURCE and ERFRAG_DEPENDS null-preserved (see get_fragment).
                     json!({
-                        "id": item.get("ERFRAG_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                        "id": helpers::field_or_null(item, "ERFRAG_ID"),
                         "fragment": item.get("ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
                         "source": helpers::field_or_null(item, "ERFRAG_SOURCE"),
                         "depends": helpers::field_or_null(item, "ERFRAG_DEPENDS")

--- a/src/functions/comparison.rs
+++ b/src/functions/comparison.rs
@@ -360,7 +360,7 @@ pub fn list_comparison_functions(config_json: &str) -> Result<Vec<Value>, SzConf
                 // Field order: id, function, description, connectStr, anonSupport,
                 // language.
                 json!({
-                    "id": item.get("CFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                    "id": field_or_null(item, "CFUNC_ID"),
                     "function": item.get("CFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
                     "description": field_or_null(item, "CFUNC_DESC"),
                     "connectStr": field_or_null(item, "CONNECT_STR"),

--- a/src/functions/comparison.rs
+++ b/src/functions/comparison.rs
@@ -177,6 +177,141 @@ pub fn delete_comparison_function(
     Ok((modified_json, function))
 }
 
+/// Reverse-resolve a feature code from an `FTYPE_ID` (`0` -> `"all"`).
+fn ftype_code_for_id(config: &Value, ftype_id: i64) -> Option<String> {
+    if ftype_id == 0 {
+        return Some("all".to_string());
+    }
+    config
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_FTYPE"))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|f| f.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ftype_id))
+                .and_then(|f| f.get("FTYPE_CODE"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+}
+
+/// Delete a comparison function and everything that depends on it (cascade).
+///
+/// Composes the existing piece-wise deletes in the Python order:
+/// `CFG_CFBOM` (rows for the function's calls) → `CFG_CFCALL` → `CFG_CFRTN` →
+/// `CFG_CFUNC`. The `CFG_CFRTN` step reuses the Wave-2 three-key
+/// [`delete_comparison_threshold`](crate::thresholds::delete_comparison_threshold)
+/// for each well-formed return row, then sweeps any orphan/null rows that remain
+/// for the function so no dependent rows are left behind.
+///
+/// Unlike [`delete_comparison_function`] (which removes only the `CFG_CFUNC`
+/// row), this leaves the configuration with no dangling references to the
+/// deleted function.
+///
+/// # Arguments
+/// * `config_json` - The configuration JSON string
+/// * `cfunc_code` - Function code to delete
+///
+/// # Returns
+/// Result with modified JSON string and the deleted function record
+///
+/// # Errors
+/// Returns error if the function is not found or JSON is invalid
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::functions::comparison::delete_comparison_function_cascade;
+///
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_CFUNC": [{"CFUNC_ID": 1, "CFUNC_CODE": "CMP_X"}],
+///     "CFG_CFCALL": [],
+///     "CFG_CFBOM": [],
+///     "CFG_CFRTN": [],
+///     "CFG_FTYPE": []
+/// }}"#;
+/// let (updated, _removed) = delete_comparison_function_cascade(config, "CMP_X")?;
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn delete_comparison_function_cascade(
+    config_json: &str,
+    cfunc_code: &str,
+) -> Result<(String, Value), SzConfigError> {
+    let cfunc_code = cfunc_code.to_uppercase();
+
+    let function = find_in_config_array(config_json, "CFG_CFUNC", "CFUNC_CODE", &cfunc_code)?
+        .ok_or_else(|| {
+            SzConfigError::not_found(format!("Comparison function not found: {cfunc_code}"))
+        })?;
+    let cfunc_id = function
+        .get("CFUNC_ID")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| SzConfigError::MissingField("CFUNC_ID".to_string()))?;
+
+    // Steps 1 & 2: remove CFG_CFBOM (by the CFCALL_IDs bound to this function),
+    // then CFG_CFCALL.
+    let mut config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    let cfcall_ids: Vec<i64> = config["G2_CONFIG"]["CFG_CFCALL"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|r| r["CFUNC_ID"].as_i64() == Some(cfunc_id))
+                .filter_map(|r| r["CFCALL_ID"].as_i64())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(cfbom) = config["G2_CONFIG"]["CFG_CFBOM"].as_array_mut() {
+        cfbom.retain(|r| match r["CFCALL_ID"].as_i64() {
+            Some(id) => !cfcall_ids.contains(&id),
+            None => true,
+        });
+    }
+    if let Some(cfcall) = config["G2_CONFIG"]["CFG_CFCALL"].as_array_mut() {
+        cfcall.retain(|r| r["CFUNC_ID"].as_i64() != Some(cfunc_id));
+    }
+    let mut cur =
+        serde_json::to_string(&config).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    // Step 3: CFG_CFRTN. Reuse the Wave-2 three-key delete for well-formed rows.
+    let snapshot: Value =
+        serde_json::from_str(&cur).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+    let cfrtn_rows: Vec<Value> = snapshot["G2_CONFIG"]["CFG_CFRTN"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|r| r["CFUNC_ID"].as_i64() == Some(cfunc_id))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut seen: std::collections::HashSet<(i64, String)> = std::collections::HashSet::new();
+    for row in &cfrtn_rows {
+        if let (Some(fid), Some(rt)) = (row["FTYPE_ID"].as_i64(), row["CFUNC_RTNVAL"].as_str())
+            && let Some(code) = ftype_code_for_id(&snapshot, fid)
+            && seen.insert((fid, rt.to_uppercase()))
+        {
+            cur = crate::thresholds::delete_comparison_threshold(&cur, &cfunc_code, &code, rt)?;
+        }
+    }
+
+    // Sweep any remaining CFG_CFRTN rows for this function (orphan FTYPE_ID or
+    // null CFUNC_RTNVAL rows the three-key delete cannot address).
+    let mut swept: Value =
+        serde_json::from_str(&cur).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+    if let Some(arr) = swept["G2_CONFIG"]["CFG_CFRTN"].as_array_mut() {
+        arr.retain(|r| r["CFUNC_ID"].as_i64() != Some(cfunc_id));
+    }
+    cur = serde_json::to_string(&swept).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    // Step 4: CFG_CFUNC itself.
+    let (final_json, _) = delete_comparison_function(&cur, &cfunc_code)?;
+
+    Ok((final_json, function))
+}
+
 /// Get a comparison function by code
 ///
 /// # Arguments
@@ -485,6 +620,74 @@ mod tests {
             .last()
             .unwrap();
         assert_eq!(row["CONNECT_STR"], json!("g2X"));
+    }
+
+    /// #38.4: the cascade empties every dependent table (CFBOM, CFCALL, CFRTN)
+    /// for the function and then the function row, leaving no orphans.
+    #[test]
+    fn test_delete_comparison_function_cascade_empties_all() {
+        let config = json!({
+            "G2_CONFIG": {
+                "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+                "CFG_CFUNC": [
+                    {"CFUNC_ID": 1, "CFUNC_CODE": "CMP_X"},
+                    {"CFUNC_ID": 2, "CFUNC_CODE": "CMP_KEEP"}
+                ],
+                "CFG_CFCALL": [
+                    {"CFCALL_ID": 10, "FTYPE_ID": 3, "CFUNC_ID": 1},
+                    {"CFCALL_ID": 11, "FTYPE_ID": 3, "CFUNC_ID": 2}
+                ],
+                "CFG_CFBOM": [
+                    {"CFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 5, "EXEC_ORDER": 1},
+                    {"CFCALL_ID": 11, "FTYPE_ID": 3, "FELEM_ID": 5, "EXEC_ORDER": 1}
+                ],
+                "CFG_CFRTN": [
+                    {"CFRTN_ID": 100, "CFUNC_ID": 1, "FTYPE_ID": 3, "CFUNC_RTNVAL": "SAME"},
+                    {"CFRTN_ID": 101, "CFUNC_ID": 1, "FTYPE_ID": 0, "CFUNC_RTNVAL": "CLOSE"},
+                    {"CFRTN_ID": 102, "CFUNC_ID": 1, "FTYPE_ID": 999, "CFUNC_RTNVAL": null},
+                    {"CFRTN_ID": 103, "CFUNC_ID": 2, "FTYPE_ID": 3, "CFUNC_RTNVAL": "SAME"}
+                ]
+            }
+        })
+        .to_string();
+
+        let (modified, removed) = delete_comparison_function_cascade(&config, "cmp_x").unwrap();
+        assert_eq!(removed["CFUNC_CODE"], "CMP_X");
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &v["G2_CONFIG"];
+
+        // Function CMP_X gone, CMP_KEEP retained.
+        let cfuncs = g2["CFG_CFUNC"].as_array().unwrap();
+        assert_eq!(cfuncs.len(), 1);
+        assert_eq!(cfuncs[0]["CFUNC_CODE"], "CMP_KEEP");
+
+        // No CFCALL / CFBOM / CFRTN rows reference CFUNC_ID 1 or CFCALL_ID 10.
+        assert!(
+            g2["CFG_CFCALL"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|r| r["CFUNC_ID"] != 1)
+        );
+        assert!(
+            g2["CFG_CFBOM"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|r| r["CFCALL_ID"] != 10)
+        );
+        assert!(
+            g2["CFG_CFRTN"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|r| r["CFUNC_ID"] != 1)
+        );
+
+        // The unrelated function's rows survive.
+        assert_eq!(g2["CFG_CFCALL"].as_array().unwrap().len(), 1);
+        assert_eq!(g2["CFG_CFBOM"].as_array().unwrap().len(), 1);
+        assert_eq!(g2["CFG_CFRTN"].as_array().unwrap().len(), 1);
     }
 
     /// connect_str tri-state on the set path: Leave keeps, Clear nulls, Set writes.

--- a/src/functions/comparison.rs
+++ b/src/functions/comparison.rs
@@ -6,7 +6,8 @@
 
 use crate::error::SzConfigError;
 use crate::helpers::{
-    add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
+    FieldUpdate, add_to_config_array, delete_from_config_array, field_or_null,
+    find_in_config_array, get_next_id,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -28,7 +29,7 @@ struct CfuncRow {
     #[serde(rename = "CFUNC_CODE")]
     cfunc_code: String,
     #[serde(rename = "CONNECT_STR")]
-    connect_str: String,
+    connect_str: Option<String>,
     #[serde(rename = "ANON_SUPPORT")]
     anon_support: String,
     #[serde(rename = "CFUNC_DESC")]
@@ -42,9 +43,13 @@ struct CfuncRow {
 // ============================================================================
 
 /// Parameters for adding a comparison function
+///
+/// `connect_str` is tri-valued to mirror the Python tool: `None` (or an absent
+/// `connectStr` key) stores JSON `null`, `Some("")` stores an empty string, and
+/// `Some(x)` stores `x`.
 #[derive(Debug, Clone, Default)]
 pub struct AddComparisonFunctionParams<'a> {
-    pub connect_str: &'a str,
+    pub connect_str: Option<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
     pub anon_support: Option<&'a str>,
@@ -55,10 +60,8 @@ impl<'a> TryFrom<&'a Value> for AddComparisonFunctionParams<'a> {
 
     fn try_from(json: &'a Value) -> Result<Self, SzConfigError> {
         Ok(Self {
-            connect_str: json
-                .get("connectStr")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| SzConfigError::MissingField("connectStr".to_string()))?,
+            // Absent or explicit-null connectStr -> None (stored as JSON null).
+            connect_str: json.get("connectStr").and_then(|v| v.as_str()),
             description: json.get("description").and_then(|v| v.as_str()),
             language: json.get("language").and_then(|v| v.as_str()),
             anon_support: json.get("anonSupport").and_then(|v| v.as_str()),
@@ -67,9 +70,12 @@ impl<'a> TryFrom<&'a Value> for AddComparisonFunctionParams<'a> {
 }
 
 /// Parameters for setting a comparison function
+///
+/// `connect_str` is a tri-state [`FieldUpdate`]: `Leave` keeps the stored value,
+/// `Clear` writes JSON `null`, and `Set(x)` writes `x` (including `Set("")`).
 #[derive(Debug, Clone, Default)]
 pub struct SetComparisonFunctionParams<'a> {
-    pub connect_str: Option<&'a str>,
+    pub connect_str: FieldUpdate<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
     pub anon_support: Option<&'a str>,
@@ -80,7 +86,8 @@ pub struct SetComparisonFunctionParams<'a> {
 /// # Arguments
 /// * `config_json` - The configuration JSON string
 /// * `cfunc_code` - Function code (will be uppercased)
-/// * `params` - Function parameters (connect_str required, others optional)
+/// * `params` - Function parameters (all optional; a `None` `connect_str` stores
+///   JSON `null`)
 ///
 /// # Returns
 /// Result with modified JSON string and the new function record
@@ -127,7 +134,7 @@ pub fn add_comparison_function(
     let row = CfuncRow {
         cfunc_id,
         cfunc_code,
-        connect_str: params.connect_str.to_string(),
+        connect_str: params.connect_str.map(str::to_string),
         anon_support: anon_support.to_string(),
         cfunc_desc: params.description.map(str::to_string),
         language: params.language.map(str::to_string),
@@ -213,12 +220,17 @@ pub fn list_comparison_functions(config_json: &str) -> Result<Vec<Value>, SzConf
         items
             .iter()
             .map(|item| {
+                // Stored-nullable columns are projected null-preserving; the
+                // previously-missing `description` (CFUNC_DESC) is now emitted.
+                // Field order: id, function, description, connectStr, anonSupport,
+                // language.
                 json!({
                     "id": item.get("CFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
                     "function": item.get("CFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                    "connectStr": item.get("CONNECT_STR").and_then(|v| v.as_str()).unwrap_or(""),
-                    "language": item.get("LANGUAGE").and_then(|v| v.as_str()).unwrap_or(""),
-                    "anonSupport": item.get("ANON_SUPPORT").and_then(|v| v.as_str()).unwrap_or("")
+                    "description": field_or_null(item, "CFUNC_DESC"),
+                    "connectStr": field_or_null(item, "CONNECT_STR"),
+                    "anonSupport": field_or_null(item, "ANON_SUPPORT"),
+                    "language": field_or_null(item, "LANGUAGE")
                 })
             })
             .collect()
@@ -257,8 +269,14 @@ pub fn set_comparison_function(
     // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
-        if let Some(conn) = params.connect_str {
-            obj.insert("CONNECT_STR".to_string(), json!(conn));
+        match params.connect_str {
+            FieldUpdate::Leave => {}
+            FieldUpdate::Clear => {
+                obj.insert("CONNECT_STR".to_string(), Value::Null);
+            }
+            FieldUpdate::Set(conn) => {
+                obj.insert("CONNECT_STR".to_string(), json!(conn));
+            }
         }
         if let Some(desc) = params.description {
             obj.insert("CFUNC_DESC".to_string(), json!(desc));
@@ -306,7 +324,7 @@ mod tests {
             &config,
             "custom_cmp",
             AddComparisonFunctionParams {
-                connect_str: "g2CustomCmp",
+                connect_str: Some("g2CustomCmp"),
                 description: Some("Custom compare"),
                 language: Some("en"),
                 anon_support: Some("Yes"),
@@ -328,6 +346,48 @@ mod tests {
         assert_eq!(items[0]["function"], "CMP_NAME");
     }
 
+    /// #33: the list carries `description` (from CFUNC_DESC) in the exact key
+    /// order id, function, description, connectStr, anonSupport, language; and
+    /// stored-nullable columns are null-preserved (stored null -> null, stored ""
+    /// -> "", absent -> null).
+    #[test]
+    fn test_list_comparison_functions_description_and_order() {
+        let config = json!({
+            "G2_CONFIG": {"CFG_CFUNC": [{
+                "CFUNC_ID": 1,
+                "CFUNC_CODE": "CMP_NAME",
+                "CFUNC_DESC": "Compare names",
+                "CONNECT_STR": "",
+                "ANON_SUPPORT": null
+                // LANGUAGE absent -> null
+            }]}
+        })
+        .to_string();
+
+        let items = list_comparison_functions(&config).unwrap();
+        let keys: Vec<&str> = items[0]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                "id",
+                "function",
+                "description",
+                "connectStr",
+                "anonSupport",
+                "language"
+            ]
+        );
+        assert_eq!(items[0]["description"], json!("Compare names"));
+        assert_eq!(items[0]["connectStr"], json!("")); // stored "" preserved
+        assert_eq!(items[0]["anonSupport"], Value::Null); // stored null preserved
+        assert_eq!(items[0]["language"], Value::Null); // absent -> null
+    }
+
     /// add_comparison_function must write a complete CFG_CFUNC row even when the
     /// caller omits optionals — they become null, never dropped. ANON_SUPPORT
     /// defaults to "No".
@@ -338,7 +398,7 @@ mod tests {
             &config,
             "custom_cmp",
             AddComparisonFunctionParams {
-                connect_str: "g2CustomCmp",
+                connect_str: Some("g2CustomCmp"),
                 description: None,
                 language: None,
                 anon_support: None,
@@ -365,5 +425,118 @@ mod tests {
         assert_eq!(obj["CFUNC_DESC"], Value::Null);
         assert_eq!(obj["LANGUAGE"], Value::Null);
         assert_eq!(record["ANON_SUPPORT"], json!("No"));
+    }
+
+    /// connect_str tri-value on the add path: None -> null, Some("") -> "",
+    /// Some(x) -> x, with every key still emitted.
+    #[test]
+    fn test_add_comparison_function_connect_str_tri_value() {
+        // None -> stored JSON null.
+        let (m_none, _) = add_comparison_function(
+            &get_test_config(),
+            "cmp_none",
+            AddComparisonFunctionParams {
+                connect_str: None,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_none).unwrap();
+        let row = v["G2_CONFIG"]["CFG_CFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        // Some("") -> stored empty string (distinct from null).
+        let (m_empty, _) = add_comparison_function(
+            &get_test_config(),
+            "cmp_empty",
+            AddComparisonFunctionParams {
+                connect_str: Some(""),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_empty).unwrap();
+        let row = v["G2_CONFIG"]["CFG_CFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(row["CONNECT_STR"], json!(""));
+
+        // Some(x) -> stored x.
+        let (m_val, _) = add_comparison_function(
+            &get_test_config(),
+            "cmp_val",
+            AddComparisonFunctionParams {
+                connect_str: Some("g2X"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_val).unwrap();
+        let row = v["G2_CONFIG"]["CFG_CFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(row["CONNECT_STR"], json!("g2X"));
+    }
+
+    /// connect_str tri-state on the set path: Leave keeps, Clear nulls, Set writes.
+    #[test]
+    fn test_set_comparison_function_connect_str_tri_state() {
+        let base = get_test_config();
+
+        // Leave: existing CONNECT_STR ("g2CmpName") preserved.
+        let (m_leave, _) = set_comparison_function(
+            &base,
+            "CMP_NAME",
+            SetComparisonFunctionParams {
+                connect_str: FieldUpdate::Leave,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_leave).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_CFUNC"][0]["CONNECT_STR"],
+            json!("g2CmpName")
+        );
+
+        // Clear: CONNECT_STR -> null (key still present).
+        let (m_clear, _) = set_comparison_function(
+            &base,
+            "CMP_NAME",
+            SetComparisonFunctionParams {
+                connect_str: FieldUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_clear).unwrap();
+        let row = &v["G2_CONFIG"]["CFG_CFUNC"][0];
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        // Set: CONNECT_STR replaced.
+        let (m_set, _) = set_comparison_function(
+            &base,
+            "CMP_NAME",
+            SetComparisonFunctionParams {
+                connect_str: FieldUpdate::Set("g2New"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_set).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_CFUNC"][0]["CONNECT_STR"],
+            json!("g2New")
+        );
     }
 }

--- a/src/functions/distinct.rs
+++ b/src/functions/distinct.rs
@@ -5,7 +5,8 @@
 
 use crate::error::SzConfigError;
 use crate::helpers::{
-    add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
+    FieldUpdate, add_to_config_array, delete_from_config_array, field_or_null,
+    find_in_config_array, get_next_id,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -29,7 +30,7 @@ struct DfuncRow {
     #[serde(rename = "DFUNC_DESC")]
     dfunc_desc: Option<String>,
     #[serde(rename = "CONNECT_STR")]
-    connect_str: String,
+    connect_str: Option<String>,
     #[serde(rename = "ANON_SUPPORT")]
     anon_support: String,
     #[serde(rename = "LANGUAGE")]
@@ -41,9 +42,13 @@ struct DfuncRow {
 // ============================================================================
 
 /// Parameters for adding a distinct function
+///
+/// `connect_str` is tri-valued to mirror the Python tool: `None` (or an absent
+/// `connectStr` key) stores JSON `null`, `Some("")` stores an empty string, and
+/// `Some(x)` stores `x`. A blank `connect_str` is accepted (Python parity).
 #[derive(Debug, Clone, Default)]
 pub struct AddDistinctFunctionParams<'a> {
-    pub connect_str: &'a str,
+    pub connect_str: Option<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
     pub anon_support: Option<&'a str>,
@@ -54,10 +59,8 @@ impl<'a> TryFrom<&'a Value> for AddDistinctFunctionParams<'a> {
 
     fn try_from(json: &'a Value) -> Result<Self, SzConfigError> {
         Ok(Self {
-            connect_str: json
-                .get("connectStr")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| SzConfigError::MissingField("connectStr".to_string()))?,
+            // Absent or explicit-null connectStr -> None (stored as JSON null).
+            connect_str: json.get("connectStr").and_then(|v| v.as_str()),
             description: json.get("description").and_then(|v| v.as_str()),
             language: json.get("language").and_then(|v| v.as_str()),
             anon_support: json.get("anonSupport").and_then(|v| v.as_str()),
@@ -66,9 +69,12 @@ impl<'a> TryFrom<&'a Value> for AddDistinctFunctionParams<'a> {
 }
 
 /// Parameters for setting a distinct function
+///
+/// `connect_str` is a tri-state [`FieldUpdate`]: `Leave` keeps the stored value,
+/// `Clear` writes JSON `null`, and `Set(x)` writes `x` (including `Set("")`).
 #[derive(Debug, Clone, Default)]
 pub struct SetDistinctFunctionParams<'a> {
-    pub connect_str: Option<&'a str>,
+    pub connect_str: FieldUpdate<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
     pub anon_support: Option<&'a str>,
@@ -79,7 +85,8 @@ pub struct SetDistinctFunctionParams<'a> {
 /// # Arguments
 /// * `config_json` - The configuration JSON string
 /// * `dfunc_code` - Function code (will be uppercased)
-/// * `params` - Function parameters (connect_str required, others optional)
+/// * `params` - Function parameters (all optional; a `None` `connect_str` stores
+///   JSON `null`, and a blank `connect_str` is accepted)
 ///
 /// # Returns
 /// Result with modified JSON string and the new function record
@@ -98,13 +105,6 @@ pub fn add_distinct_function(
         return Err(SzConfigError::validation(format!(
             "Distinct function already exists: {dfunc_code}"
         )));
-    }
-
-    // Validate blank CONNECTSTR (Python parity)
-    if params.connect_str.trim().is_empty() {
-        return Err(SzConfigError::validation(
-            "CONNECTSTR cannot be blank".to_string(),
-        ));
     }
 
     // Validate ANON_SUPPORT domain (["Yes", "No"], default "No"), mirroring
@@ -135,7 +135,7 @@ pub fn add_distinct_function(
         dfunc_id,
         dfunc_code,
         dfunc_desc: params.description.map(str::to_string),
-        connect_str: params.connect_str.to_string(),
+        connect_str: params.connect_str.map(str::to_string),
         anon_support: anon_support.to_string(),
         language: params.language.map(str::to_string),
     };
@@ -217,12 +217,14 @@ pub fn list_distinct_functions(config_json: &str) -> Result<Vec<Value>, SzConfig
         items
             .iter()
             .map(|item| {
+                // Stored-nullable columns (and the id, per D10) are projected
+                // null-preserving via field_or_null rather than coerced.
                 json!({
-                    "id": item.get("DFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                    "id": field_or_null(item, "DFUNC_ID"),
                     "function": item.get("DFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                    "connectStr": item.get("CONNECT_STR").and_then(|v| v.as_str()).unwrap_or(""),
-                    "anonSupport": item.get("ANON_SUPPORT").and_then(|v| v.as_str()).unwrap_or(""),
-                    "language": item.get("LANGUAGE").and_then(|v| v.as_str()).unwrap_or("")
+                    "connectStr": field_or_null(item, "CONNECT_STR"),
+                    "anonSupport": field_or_null(item, "ANON_SUPPORT"),
+                    "language": field_or_null(item, "LANGUAGE")
                 })
             })
             .collect()
@@ -261,8 +263,14 @@ pub fn set_distinct_function(
     // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
-        if let Some(conn) = params.connect_str {
-            obj.insert("CONNECT_STR".to_string(), json!(conn));
+        match params.connect_str {
+            FieldUpdate::Leave => {}
+            FieldUpdate::Clear => {
+                obj.insert("CONNECT_STR".to_string(), Value::Null);
+            }
+            FieldUpdate::Set(conn) => {
+                obj.insert("CONNECT_STR".to_string(), json!(conn));
+            }
         }
         if let Some(desc) = params.description {
             obj.insert("DFUNC_DESC".to_string(), json!(desc));
@@ -309,7 +317,7 @@ mod tests {
             &config,
             "custom_dist",
             AddDistinctFunctionParams {
-                connect_str: "g2CustomDist",
+                connect_str: Some("g2CustomDist"),
                 description: Some("Custom distinct"),
                 language: Some("en"),
                 anon_support: Some("Yes"),
@@ -342,7 +350,7 @@ mod tests {
             &config,
             "custom_dist",
             AddDistinctFunctionParams {
-                connect_str: "g2CustomDist",
+                connect_str: Some("g2CustomDist"),
                 description: None,
                 language: None,
                 anon_support: None,
@@ -370,5 +378,117 @@ mod tests {
         assert_eq!(obj["LANGUAGE"], Value::Null);
         assert_eq!(record["DFUNC_DESC"], Value::Null);
         assert_eq!(record["ANON_SUPPORT"], json!("No"));
+    }
+
+    /// A blank connect_str is now accepted (the "CONNECTSTR cannot be blank"
+    /// rejection was removed for Python parity) and stored as an empty string.
+    #[test]
+    fn test_add_distinct_function_accepts_blank_connect_str() {
+        let (modified, _record) = add_distinct_function(
+            &get_test_config(),
+            "custom_blank",
+            AddDistinctFunctionParams {
+                connect_str: Some(""),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let row = v["G2_CONFIG"]["CFG_DFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(row["CONNECT_STR"], json!(""));
+    }
+
+    /// connect_str tri-value on the add path: None -> null, Some("") -> "",
+    /// Some(x) -> x.
+    #[test]
+    fn test_add_distinct_function_connect_str_tri_value() {
+        let (m_none, _) = add_distinct_function(
+            &get_test_config(),
+            "d_none",
+            AddDistinctFunctionParams {
+                connect_str: None,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_none).unwrap();
+        let row = v["G2_CONFIG"]["CFG_DFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        let (m_val, _) = add_distinct_function(
+            &get_test_config(),
+            "d_val",
+            AddDistinctFunctionParams {
+                connect_str: Some("g2X"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_val).unwrap();
+        let row = v["G2_CONFIG"]["CFG_DFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(row["CONNECT_STR"], json!("g2X"));
+    }
+
+    /// connect_str tri-state on the set path: Leave keeps, Clear nulls, Set writes.
+    #[test]
+    fn test_set_distinct_function_connect_str_tri_state() {
+        let base = get_test_config();
+
+        let (m_leave, _) = set_distinct_function(
+            &base,
+            "DIST_NAME",
+            SetDistinctFunctionParams {
+                connect_str: FieldUpdate::Leave,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_leave).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_DFUNC"][0]["CONNECT_STR"],
+            json!("g2DistName")
+        );
+
+        let (m_clear, _) = set_distinct_function(
+            &base,
+            "DIST_NAME",
+            SetDistinctFunctionParams {
+                connect_str: FieldUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_clear).unwrap();
+        let row = &v["G2_CONFIG"]["CFG_DFUNC"][0];
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        let (m_set, _) = set_distinct_function(
+            &base,
+            "DIST_NAME",
+            SetDistinctFunctionParams {
+                connect_str: FieldUpdate::Set("g2New"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_set).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_DFUNC"][0]["CONNECT_STR"],
+            json!("g2New")
+        );
     }
 }

--- a/src/functions/expression.rs
+++ b/src/functions/expression.rs
@@ -154,6 +154,80 @@ pub fn delete_expression_function(
     Ok((modified_json, function))
 }
 
+/// Delete an expression function and everything that depends on it (cascade).
+///
+/// Composes the piece-wise deletes in the Python order: `CFG_EFBOM` (rows for
+/// the function's calls) → `CFG_EFCALL` → `CFG_EFUNC`. Unlike
+/// [`delete_expression_function`] (which removes only the `CFG_EFUNC` row), this
+/// leaves no dangling references to the deleted function.
+///
+/// # Arguments
+/// * `config_json` - The configuration JSON string
+/// * `efunc_code` - Function code to delete
+///
+/// # Returns
+/// Result with modified JSON string and the deleted function record
+///
+/// # Errors
+/// Returns error if the function is not found or JSON is invalid
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::functions::expression::delete_expression_function_cascade;
+///
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_EFUNC": [{"EFUNC_ID": 1, "EFUNC_CODE": "EXP_X"}],
+///     "CFG_EFCALL": [],
+///     "CFG_EFBOM": []
+/// }}"#;
+/// let (updated, _removed) = delete_expression_function_cascade(config, "EXP_X")?;
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn delete_expression_function_cascade(
+    config_json: &str,
+    efunc_code: &str,
+) -> Result<(String, Value), SzConfigError> {
+    let efunc_code = efunc_code.to_uppercase();
+
+    let function = find_in_config_array(config_json, "CFG_EFUNC", "EFUNC_CODE", &efunc_code)?
+        .ok_or_else(|| {
+            SzConfigError::not_found(format!("Expression function not found: {efunc_code}"))
+        })?;
+    let efunc_id = function
+        .get("EFUNC_ID")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| SzConfigError::MissingField("EFUNC_ID".to_string()))?;
+
+    let mut config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    let efcall_ids: Vec<i64> = config["G2_CONFIG"]["CFG_EFCALL"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|r| r["EFUNC_ID"].as_i64() == Some(efunc_id))
+                .filter_map(|r| r["EFCALL_ID"].as_i64())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(efbom) = config["G2_CONFIG"]["CFG_EFBOM"].as_array_mut() {
+        efbom.retain(|r| match r["EFCALL_ID"].as_i64() {
+            Some(id) => !efcall_ids.contains(&id),
+            None => true,
+        });
+    }
+    if let Some(efcall) = config["G2_CONFIG"]["CFG_EFCALL"].as_array_mut() {
+        efcall.retain(|r| r["EFUNC_ID"].as_i64() != Some(efunc_id));
+    }
+    let cur =
+        serde_json::to_string(&config).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    let (final_json, _) = delete_expression_function(&cur, &efunc_code)?;
+
+    Ok((final_json, function))
+}
+
 /// Get an expression function by code
 ///
 /// # Arguments
@@ -438,5 +512,51 @@ mod tests {
             v["G2_CONFIG"]["CFG_EFUNC"][0]["CONNECT_STR"],
             json!("g2New")
         );
+    }
+
+    /// #38.4: the cascade empties CFG_EFBOM and CFG_EFCALL for the function and
+    /// then removes the function, leaving no orphans.
+    #[test]
+    fn test_delete_expression_function_cascade_empties_all() {
+        let config = json!({
+            "G2_CONFIG": {
+                "CFG_EFUNC": [
+                    {"EFUNC_ID": 1, "EFUNC_CODE": "EXP_X"},
+                    {"EFUNC_ID": 2, "EFUNC_CODE": "EXP_KEEP"}
+                ],
+                "CFG_EFCALL": [
+                    {"EFCALL_ID": 10, "FTYPE_ID": 3, "EFUNC_ID": 1},
+                    {"EFCALL_ID": 11, "FTYPE_ID": 3, "EFUNC_ID": 2}
+                ],
+                "CFG_EFBOM": [
+                    {"EFCALL_ID": 10, "FTYPE_ID": 3, "FELEM_ID": 5, "EXEC_ORDER": 1},
+                    {"EFCALL_ID": 11, "FTYPE_ID": 3, "FELEM_ID": 5, "EXEC_ORDER": 1}
+                ]
+            }
+        })
+        .to_string();
+
+        let (modified, removed) = delete_expression_function_cascade(&config, "exp_x").unwrap();
+        assert_eq!(removed["EFUNC_CODE"], "EXP_X");
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &v["G2_CONFIG"];
+
+        assert_eq!(g2["CFG_EFUNC"].as_array().unwrap().len(), 1);
+        assert!(
+            g2["CFG_EFCALL"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|r| r["EFUNC_ID"] != 1)
+        );
+        assert!(
+            g2["CFG_EFBOM"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|r| r["EFCALL_ID"] != 10)
+        );
+        assert_eq!(g2["CFG_EFCALL"].as_array().unwrap().len(), 1);
+        assert_eq!(g2["CFG_EFBOM"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/functions/expression.rs
+++ b/src/functions/expression.rs
@@ -274,7 +274,7 @@ pub fn list_expression_functions(config_json: &str) -> Result<Vec<Value>, SzConf
                 // connectStr and language are stored-nullable; project them
                 // null-preserving via field_or_null rather than coercing to "".
                 json!({
-                    "id": item.get("EFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                    "id": field_or_null(item, "EFUNC_ID"),
                     "function": item.get("EFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
                     "connectStr": field_or_null(item, "CONNECT_STR"),
                     "language": field_or_null(item, "LANGUAGE")

--- a/src/functions/expression.rs
+++ b/src/functions/expression.rs
@@ -5,7 +5,8 @@
 
 use crate::error::SzConfigError;
 use crate::helpers::{
-    add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
+    FieldUpdate, add_to_config_array, delete_from_config_array, field_or_null,
+    find_in_config_array, get_next_id,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -27,7 +28,7 @@ struct EfuncRow {
     #[serde(rename = "EFUNC_CODE")]
     efunc_code: String,
     #[serde(rename = "CONNECT_STR")]
-    connect_str: String,
+    connect_str: Option<String>,
     #[serde(rename = "EFUNC_DESC")]
     efunc_desc: Option<String>,
     #[serde(rename = "LANGUAGE")]
@@ -39,9 +40,13 @@ struct EfuncRow {
 // ============================================================================
 
 /// Parameters for adding an expression function
+///
+/// `connect_str` is tri-valued to mirror the Python tool: `None` (or an absent
+/// `connectStr` key) stores JSON `null`, `Some("")` stores an empty string, and
+/// `Some(x)` stores `x`.
 #[derive(Debug, Clone, Default)]
 pub struct AddExpressionFunctionParams<'a> {
-    pub connect_str: &'a str,
+    pub connect_str: Option<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
 }
@@ -51,10 +56,8 @@ impl<'a> TryFrom<&'a Value> for AddExpressionFunctionParams<'a> {
 
     fn try_from(json: &'a Value) -> Result<Self, SzConfigError> {
         Ok(Self {
-            connect_str: json
-                .get("connectStr")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| SzConfigError::MissingField("connectStr".to_string()))?,
+            // Absent or explicit-null connectStr -> None (stored as JSON null).
+            connect_str: json.get("connectStr").and_then(|v| v.as_str()),
             description: json.get("description").and_then(|v| v.as_str()),
             language: json.get("language").and_then(|v| v.as_str()),
         })
@@ -62,9 +65,12 @@ impl<'a> TryFrom<&'a Value> for AddExpressionFunctionParams<'a> {
 }
 
 /// Parameters for setting an expression function
+///
+/// `connect_str` is a tri-state [`FieldUpdate`]: `Leave` keeps the stored value,
+/// `Clear` writes JSON `null`, and `Set(x)` writes `x` (including `Set("")`).
 #[derive(Debug, Clone, Default)]
 pub struct SetExpressionFunctionParams<'a> {
-    pub connect_str: Option<&'a str>,
+    pub connect_str: FieldUpdate<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
 }
@@ -74,7 +80,8 @@ pub struct SetExpressionFunctionParams<'a> {
 /// # Arguments
 /// * `config_json` - The configuration JSON string
 /// * `efunc_code` - Function code (will be uppercased)
-/// * `params` - Function parameters (connect_str required, others optional)
+/// * `params` - Function parameters (all optional; a `None` `connect_str` stores
+///   JSON `null`)
 ///
 /// # Returns
 /// Result with modified JSON string and the new function record
@@ -105,7 +112,7 @@ pub fn add_expression_function(
     let row = EfuncRow {
         efunc_id,
         efunc_code,
-        connect_str: params.connect_str.to_string(),
+        connect_str: params.connect_str.map(str::to_string),
         efunc_desc: params.description.map(str::to_string),
         language: params.language.map(str::to_string),
     };
@@ -190,11 +197,13 @@ pub fn list_expression_functions(config_json: &str) -> Result<Vec<Value>, SzConf
         items
             .iter()
             .map(|item| {
+                // connectStr and language are stored-nullable; project them
+                // null-preserving via field_or_null rather than coercing to "".
                 json!({
                     "id": item.get("EFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
                     "function": item.get("EFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                    "connectStr": item.get("CONNECT_STR").and_then(|v| v.as_str()).unwrap_or(""),
-                    "language": item.get("LANGUAGE").and_then(|v| v.as_str()).unwrap_or("")
+                    "connectStr": field_or_null(item, "CONNECT_STR"),
+                    "language": field_or_null(item, "LANGUAGE")
                 })
             })
             .collect()
@@ -233,8 +242,14 @@ pub fn set_expression_function(
     // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
-        if let Some(conn) = params.connect_str {
-            obj.insert("CONNECT_STR".to_string(), json!(conn));
+        match params.connect_str {
+            FieldUpdate::Leave => {}
+            FieldUpdate::Clear => {
+                obj.insert("CONNECT_STR".to_string(), Value::Null);
+            }
+            FieldUpdate::Set(conn) => {
+                obj.insert("CONNECT_STR".to_string(), json!(conn));
+            }
         }
         if let Some(desc) = params.description {
             obj.insert("EFUNC_DESC".to_string(), json!(desc));
@@ -278,7 +293,7 @@ mod tests {
             &config,
             "custom_expr",
             AddExpressionFunctionParams {
-                connect_str: "g2CustomExpr",
+                connect_str: Some("g2CustomExpr"),
                 description: Some("Custom expression"),
                 language: Some("en"),
             },
@@ -308,7 +323,7 @@ mod tests {
             &config,
             "custom_expr",
             AddExpressionFunctionParams {
-                connect_str: "g2CustomExpr",
+                connect_str: Some("g2CustomExpr"),
                 description: None,
                 language: None,
             },
@@ -333,5 +348,95 @@ mod tests {
         assert_eq!(obj["LANGUAGE"], Value::Null);
         // Returned record mirrors the written row.
         assert_eq!(record["EFUNC_DESC"], Value::Null);
+    }
+
+    /// connect_str tri-value on the add path: None -> null, Some("") -> "",
+    /// Some(x) -> x.
+    #[test]
+    fn test_add_expression_function_connect_str_tri_value() {
+        let (m_none, _) = add_expression_function(
+            &get_test_config(),
+            "e_none",
+            AddExpressionFunctionParams {
+                connect_str: None,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_none).unwrap();
+        let row = v["G2_CONFIG"]["CFG_EFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        let (m_empty, _) = add_expression_function(
+            &get_test_config(),
+            "e_empty",
+            AddExpressionFunctionParams {
+                connect_str: Some(""),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_empty).unwrap();
+        let row = v["G2_CONFIG"]["CFG_EFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(row["CONNECT_STR"], json!(""));
+    }
+
+    /// connect_str tri-state on the set path: Leave keeps, Clear nulls, Set writes.
+    #[test]
+    fn test_set_expression_function_connect_str_tri_state() {
+        let base = get_test_config();
+
+        let (m_leave, _) = set_expression_function(
+            &base,
+            "EXPR_FEAT",
+            SetExpressionFunctionParams {
+                connect_str: FieldUpdate::Leave,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_leave).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_EFUNC"][0]["CONNECT_STR"],
+            json!("g2ExprFeat")
+        );
+
+        let (m_clear, _) = set_expression_function(
+            &base,
+            "EXPR_FEAT",
+            SetExpressionFunctionParams {
+                connect_str: FieldUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_clear).unwrap();
+        let row = &v["G2_CONFIG"]["CFG_EFUNC"][0];
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        let (m_set, _) = set_expression_function(
+            &base,
+            "EXPR_FEAT",
+            SetExpressionFunctionParams {
+                connect_str: FieldUpdate::Set("g2New"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_set).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_EFUNC"][0]["CONNECT_STR"],
+            json!("g2New")
+        );
     }
 }

--- a/src/functions/standardize.rs
+++ b/src/functions/standardize.rs
@@ -5,7 +5,8 @@
 
 use crate::error::SzConfigError;
 use crate::helpers::{
-    add_to_config_array, delete_from_config_array, find_in_config_array, get_next_id,
+    FieldUpdate, add_to_config_array, delete_from_config_array, field_or_null,
+    find_in_config_array, get_next_id,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -27,7 +28,7 @@ struct SfuncRow {
     #[serde(rename = "SFUNC_CODE")]
     sfunc_code: String,
     #[serde(rename = "CONNECT_STR")]
-    connect_str: String,
+    connect_str: Option<String>,
     #[serde(rename = "SFUNC_DESC")]
     sfunc_desc: Option<String>,
     #[serde(rename = "LANGUAGE")]
@@ -39,9 +40,13 @@ struct SfuncRow {
 // ============================================================================
 
 /// Parameters for adding a standardize function
+///
+/// `connect_str` is tri-valued to mirror the Python tool: `None` (or an absent
+/// `connectStr` key) stores JSON `null`, `Some("")` stores an empty string, and
+/// `Some(x)` stores `x`.
 #[derive(Debug, Clone, Default)]
 pub struct AddStandardizeFunctionParams<'a> {
-    pub connect_str: &'a str,
+    pub connect_str: Option<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
 }
@@ -51,10 +56,8 @@ impl<'a> TryFrom<&'a Value> for AddStandardizeFunctionParams<'a> {
 
     fn try_from(json: &'a Value) -> Result<Self, SzConfigError> {
         Ok(Self {
-            connect_str: json
-                .get("connectStr")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| SzConfigError::MissingField("connectStr".to_string()))?,
+            // Absent or explicit-null connectStr -> None (stored as JSON null).
+            connect_str: json.get("connectStr").and_then(|v| v.as_str()),
             description: json.get("description").and_then(|v| v.as_str()),
             language: json.get("language").and_then(|v| v.as_str()),
         })
@@ -62,9 +65,12 @@ impl<'a> TryFrom<&'a Value> for AddStandardizeFunctionParams<'a> {
 }
 
 /// Parameters for setting a standardize function
+///
+/// `connect_str` is a tri-state [`FieldUpdate`]: `Leave` keeps the stored value,
+/// `Clear` writes JSON `null`, and `Set(x)` writes `x` (including `Set("")`).
 #[derive(Debug, Clone, Default)]
 pub struct SetStandardizeFunctionParams<'a> {
-    pub connect_str: Option<&'a str>,
+    pub connect_str: FieldUpdate<&'a str>,
     pub description: Option<&'a str>,
     pub language: Option<&'a str>,
 }
@@ -74,7 +80,8 @@ pub struct SetStandardizeFunctionParams<'a> {
 /// # Arguments
 /// * `config_json` - The configuration JSON string
 /// * `sfunc_code` - Function code (will be uppercased)
-/// * `params` - Function parameters (connect_str required, others optional)
+/// * `params` - Function parameters (all optional; a `None` `connect_str` stores
+///   JSON `null`)
 ///
 /// # Returns
 /// Result with modified JSON string and the new function record
@@ -105,7 +112,7 @@ pub fn add_standardize_function(
     let row = SfuncRow {
         sfunc_id,
         sfunc_code,
-        connect_str: params.connect_str.to_string(),
+        connect_str: params.connect_str.map(str::to_string),
         sfunc_desc: params.description.map(str::to_string),
         language: params.language.map(str::to_string),
     };
@@ -190,11 +197,13 @@ pub fn list_standardize_functions(config_json: &str) -> Result<Vec<Value>, SzCon
         items
             .iter()
             .map(|item| {
+                // connectStr and language are stored-nullable; project them
+                // null-preserving via field_or_null rather than coercing to "".
                 json!({
                     "id": item.get("SFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
                     "function": item.get("SFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                    "connectStr": item.get("CONNECT_STR").and_then(|v| v.as_str()).unwrap_or(""),
-                    "language": item.get("LANGUAGE").and_then(|v| v.as_str()).unwrap_or("")
+                    "connectStr": field_or_null(item, "CONNECT_STR"),
+                    "language": field_or_null(item, "LANGUAGE")
                 })
             })
             .collect()
@@ -233,8 +242,14 @@ pub fn set_standardize_function(
     // In-place update of a complete existing row; all keys preserved.
     // Update fields if provided
     if let Some(obj) = function.as_object_mut() {
-        if let Some(conn) = params.connect_str {
-            obj.insert("CONNECT_STR".to_string(), json!(conn));
+        match params.connect_str {
+            FieldUpdate::Leave => {}
+            FieldUpdate::Clear => {
+                obj.insert("CONNECT_STR".to_string(), Value::Null);
+            }
+            FieldUpdate::Set(conn) => {
+                obj.insert("CONNECT_STR".to_string(), json!(conn));
+            }
         }
         if let Some(desc) = params.description {
             obj.insert("SFUNC_DESC".to_string(), json!(desc));
@@ -278,7 +293,7 @@ mod tests {
             &config,
             "custom_parse",
             AddStandardizeFunctionParams {
-                connect_str: "g2CustomParse",
+                connect_str: Some("g2CustomParse"),
                 description: Some("Custom parser"),
                 language: Some("en"),
             },
@@ -326,7 +341,7 @@ mod tests {
             &config,
             "custom_parse",
             AddStandardizeFunctionParams {
-                connect_str: "g2CustomParse",
+                connect_str: Some("g2CustomParse"),
                 description: None,
                 language: None,
             },
@@ -350,5 +365,95 @@ mod tests {
         assert_eq!(obj["SFUNC_DESC"], Value::Null);
         assert_eq!(obj["LANGUAGE"], Value::Null);
         assert_eq!(record["SFUNC_DESC"], Value::Null);
+    }
+
+    /// connect_str tri-value on the add path: None -> null, Some("") -> "",
+    /// Some(x) -> x.
+    #[test]
+    fn test_add_standardize_function_connect_str_tri_value() {
+        let (m_none, _) = add_standardize_function(
+            &get_test_config(),
+            "s_none",
+            AddStandardizeFunctionParams {
+                connect_str: None,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_none).unwrap();
+        let row = v["G2_CONFIG"]["CFG_SFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        let (m_empty, _) = add_standardize_function(
+            &get_test_config(),
+            "s_empty",
+            AddStandardizeFunctionParams {
+                connect_str: Some(""),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_empty).unwrap();
+        let row = v["G2_CONFIG"]["CFG_SFUNC"]
+            .as_array()
+            .unwrap()
+            .last()
+            .unwrap();
+        assert_eq!(row["CONNECT_STR"], json!(""));
+    }
+
+    /// connect_str tri-state on the set path: Leave keeps, Clear nulls, Set writes.
+    #[test]
+    fn test_set_standardize_function_connect_str_tri_state() {
+        let base = get_test_config();
+
+        let (m_leave, _) = set_standardize_function(
+            &base,
+            "PARSE_NAME",
+            SetStandardizeFunctionParams {
+                connect_str: FieldUpdate::Leave,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_leave).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_SFUNC"][0]["CONNECT_STR"],
+            json!("g2ParseName")
+        );
+
+        let (m_clear, _) = set_standardize_function(
+            &base,
+            "PARSE_NAME",
+            SetStandardizeFunctionParams {
+                connect_str: FieldUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_clear).unwrap();
+        let row = &v["G2_CONFIG"]["CFG_SFUNC"][0];
+        assert!(row.as_object().unwrap().contains_key("CONNECT_STR"));
+        assert_eq!(row["CONNECT_STR"], Value::Null);
+
+        let (m_set, _) = set_standardize_function(
+            &base,
+            "PARSE_NAME",
+            SetStandardizeFunctionParams {
+                connect_str: FieldUpdate::Set("g2New"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&m_set).unwrap();
+        assert_eq!(
+            v["G2_CONFIG"]["CFG_SFUNC"][0]["CONNECT_STR"],
+            json!("g2New")
+        );
     }
 }

--- a/src/functions/standardize.rs
+++ b/src/functions/standardize.rs
@@ -257,7 +257,7 @@ pub fn list_standardize_functions(config_json: &str) -> Result<Vec<Value>, SzCon
                 // connectStr and language are stored-nullable; project them
                 // null-preserving via field_or_null rather than coercing to "".
                 json!({
-                    "id": item.get("SFUNC_ID").and_then(|v| v.as_i64()).unwrap_or(0),
+                    "id": field_or_null(item, "SFUNC_ID"),
                     "function": item.get("SFUNC_CODE").and_then(|v| v.as_str()).unwrap_or(""),
                     "connectStr": field_or_null(item, "CONNECT_STR"),
                     "language": field_or_null(item, "LANGUAGE")

--- a/src/functions/standardize.rs
+++ b/src/functions/standardize.rs
@@ -154,6 +154,63 @@ pub fn delete_standardize_function(
     Ok((modified_json, function))
 }
 
+/// Delete a standardize function and everything that depends on it (cascade).
+///
+/// Composes the piece-wise deletes in the Python order: `CFG_SFCALL` →
+/// `CFG_SFUNC`. Unlike [`delete_standardize_function`] (which removes only the
+/// `CFG_SFUNC` row), this leaves no dangling `CFG_SFCALL` rows referencing the
+/// deleted function.
+///
+/// # Arguments
+/// * `config_json` - The configuration JSON string
+/// * `sfunc_code` - Function code to delete
+///
+/// # Returns
+/// Result with modified JSON string and the deleted function record
+///
+/// # Errors
+/// Returns error if the function is not found or JSON is invalid
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::functions::standardize::delete_standardize_function_cascade;
+///
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_SFUNC": [{"SFUNC_ID": 1, "SFUNC_CODE": "STD_X"}],
+///     "CFG_SFCALL": []
+/// }}"#;
+/// let (updated, _removed) = delete_standardize_function_cascade(config, "STD_X")?;
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn delete_standardize_function_cascade(
+    config_json: &str,
+    sfunc_code: &str,
+) -> Result<(String, Value), SzConfigError> {
+    let sfunc_code = sfunc_code.to_uppercase();
+
+    let function = find_in_config_array(config_json, "CFG_SFUNC", "SFUNC_CODE", &sfunc_code)?
+        .ok_or_else(|| {
+            SzConfigError::not_found(format!("Standardize function not found: {sfunc_code}"))
+        })?;
+    let sfunc_id = function
+        .get("SFUNC_ID")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| SzConfigError::MissingField("SFUNC_ID".to_string()))?;
+
+    let mut config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    if let Some(sfcall) = config["G2_CONFIG"]["CFG_SFCALL"].as_array_mut() {
+        sfcall.retain(|r| r["SFUNC_ID"].as_i64() != Some(sfunc_id));
+    }
+    let cur =
+        serde_json::to_string(&config).map_err(|e| SzConfigError::json_parse(e.to_string()))?;
+
+    let (final_json, _) = delete_standardize_function(&cur, &sfunc_code)?;
+
+    Ok((final_json, function))
+}
+
 /// Get a standardize function by code
 ///
 /// # Arguments
@@ -455,5 +512,39 @@ mod tests {
             v["G2_CONFIG"]["CFG_SFUNC"][0]["CONNECT_STR"],
             json!("g2New")
         );
+    }
+
+    /// #38.4: the cascade empties CFG_SFCALL for the function and then removes
+    /// the function, leaving no orphans.
+    #[test]
+    fn test_delete_standardize_function_cascade_empties_all() {
+        let config = json!({
+            "G2_CONFIG": {
+                "CFG_SFUNC": [
+                    {"SFUNC_ID": 1, "SFUNC_CODE": "STD_X"},
+                    {"SFUNC_ID": 2, "SFUNC_CODE": "STD_KEEP"}
+                ],
+                "CFG_SFCALL": [
+                    {"SFCALL_ID": 10, "FTYPE_ID": 3, "SFUNC_ID": 1},
+                    {"SFCALL_ID": 11, "FTYPE_ID": 3, "SFUNC_ID": 2}
+                ]
+            }
+        })
+        .to_string();
+
+        let (modified, removed) = delete_standardize_function_cascade(&config, "std_x").unwrap();
+        assert_eq!(removed["SFUNC_CODE"], "STD_X");
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        let g2 = &v["G2_CONFIG"];
+
+        assert_eq!(g2["CFG_SFUNC"].as_array().unwrap().len(), 1);
+        assert!(
+            g2["CFG_SFCALL"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|r| r["SFUNC_ID"] != 1)
+        );
+        assert_eq!(g2["CFG_SFCALL"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -10,6 +10,80 @@ pub(crate) fn field_as_string(item: &Value, key: &str) -> Option<String> {
     item.get(key).and_then(|v| v.as_str()).map(String::from)
 }
 
+/// Project a config-row field as an owned JSON value, null-preserving.
+///
+/// Returns the field's value cloned when the key is present (including an
+/// explicit JSON `null`), and `Value::Null` when the key is absent. This is the
+/// read-side projection used by list/get builders that must emit `null` for a
+/// stored-null or missing field rather than coercing it to `""` or `0`.
+// Consumed by the null-projection work in Wave 3 (rules/functions/fragments
+// list builders); kept behind `allow(dead_code)` until then.
+#[allow(dead_code)]
+pub(crate) fn field_or_null(item: &Value, key: &str) -> Value {
+    item.get(key).cloned().unwrap_or(Value::Null)
+}
+
+/// Tri-state update for an optional field: leave, clear, or set.
+///
+/// This distinguishes the three intents a partial update can express, which a
+/// plain `Option<T>` cannot:
+///
+/// - [`FieldUpdate::Leave`] — do not touch the field; keep whatever exists.
+/// - [`FieldUpdate::Clear`] — remove the field's value (store `null`).
+/// - [`FieldUpdate::Set`] — replace the field's value.
+///
+/// The default is [`FieldUpdate::Leave`], so a field omitted from an update
+/// builder carries its existing value forward untouched.
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::helpers::FieldUpdate;
+///
+/// // Leave keeps the existing value.
+/// assert_eq!(FieldUpdate::Leave.apply(Some("old")), Some("old"));
+/// // Clear drops it.
+/// assert_eq!(FieldUpdate::<&str>::Clear.apply(Some("old")), None);
+/// // Set overrides it.
+/// assert_eq!(FieldUpdate::Set("new").apply(Some("old")), Some("new"));
+/// // The default is Leave.
+/// assert_eq!(FieldUpdate::<&str>::default(), FieldUpdate::Leave);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum FieldUpdate<T> {
+    /// Do not modify the field; keep the existing value.
+    #[default]
+    Leave,
+    /// Clear the field (resolve to `None` / stored `null`).
+    Clear,
+    /// Set the field to the given value.
+    Set(T),
+}
+
+impl<T> FieldUpdate<T> {
+    /// Resolve this update against the current value of the field.
+    ///
+    /// - [`FieldUpdate::Leave`] returns `existing` unchanged.
+    /// - [`FieldUpdate::Clear`] returns `None`.
+    /// - [`FieldUpdate::Set`] returns `Some(value)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sz_configtool_lib::helpers::FieldUpdate;
+    ///
+    /// let update: FieldUpdate<i64> = FieldUpdate::Set(5);
+    /// assert_eq!(update.apply(Some(1)), Some(5));
+    /// ```
+    pub fn apply(self, existing: Option<T>) -> Option<T> {
+        match self {
+            FieldUpdate::Leave => existing,
+            FieldUpdate::Clear => None,
+            FieldUpdate::Set(value) => Some(value),
+        }
+    }
+}
+
 /// Get the next available ID for a config array
 ///
 /// Finds the maximum value of the specified ID field and returns max + 1
@@ -695,4 +769,240 @@ pub(crate) fn lookup_gplan_code(config_json: &str, gplan_id: i64) -> Result<Stri
                 .map(|s| s.to_string())
         })
         .ok_or_else(|| SzConfigError::NotFound(format!("Generic plan ID: {gplan_id}")))
+}
+
+// ============================================================================
+// By-feature call-id resolvers
+// ============================================================================
+//
+// A call row (CFG_?CALL) binds a function to a feature via FTYPE_ID. These
+// resolvers find the call *id* for a given feature by scanning the relevant
+// call section for rows whose FTYPE_ID matches.
+//
+// Multiplicity policy (see decision D22): all four resolvers require an
+// unambiguous result.
+//   * 0 matching rows  -> NotFound
+//   * exactly 1 row    -> that row's call id
+//   * 2+ matching rows -> InvalidInput (ambiguous; the caller must address the
+//                         call by id instead)
+// Comparison (CFCALL) and distinct (DFCALL) calls are expected to be 0-or-1
+// per feature, so ambiguity there indicates malformed config. Standardize
+// (SFCALL) and expression (EFCALL) calls *can* legitimately be many-per-feature,
+// so the ambiguity error is the safety net that prevents silently picking the
+// wrong call.
+
+/// Resolve the single call id for a feature within one call section.
+///
+/// Scans `config["G2_CONFIG"][section]` for rows whose `FTYPE_ID` equals
+/// `ftype_id` and returns the value of `id_field` when exactly one such row
+/// exists. `label` names the call family for error messages.
+fn resolve_call_id_for_feature(
+    config: &Value,
+    section: &str,
+    id_field: &str,
+    ftype_id: i64,
+    label: &str,
+) -> Result<i64> {
+    let empty: Vec<Value> = Vec::new();
+    let rows = config
+        .get("G2_CONFIG")
+        .and_then(|g| g.get(section))
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+
+    let matches: Vec<i64> = rows
+        .iter()
+        .filter(|row| row.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ftype_id))
+        .filter_map(|row| row.get(id_field).and_then(|v| v.as_i64()))
+        .collect();
+
+    match matches.as_slice() {
+        [] => Err(SzConfigError::NotFound(format!(
+            "No {label} call found for feature id {ftype_id}"
+        ))),
+        [id] => Ok(*id),
+        many => Err(SzConfigError::InvalidInput(format!(
+            "Ambiguous {label} call for feature id {ftype_id}: {} calls match; address the call by id instead",
+            many.len()
+        ))),
+    }
+}
+
+/// Resolve the comparison call id (`CFCALL_ID`) bound to a feature.
+///
+/// See the module policy: returns `NotFound` when the feature has no comparison
+/// call and `InvalidInput` when more than one matches.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::helpers::resolve_cfcall_id_for_feature;
+///
+/// let config = json!({"G2_CONFIG": {"CFG_CFCALL": [
+///     {"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}
+/// ]}});
+/// assert_eq!(resolve_cfcall_id_for_feature(&config, 3).unwrap(), 7);
+/// assert!(resolve_cfcall_id_for_feature(&config, 99).is_err());
+/// ```
+pub fn resolve_cfcall_id_for_feature(config: &Value, ftype_id: i64) -> Result<i64> {
+    resolve_call_id_for_feature(config, "CFG_CFCALL", "CFCALL_ID", ftype_id, "comparison")
+}
+
+/// Resolve the distinct call id (`DFCALL_ID`) bound to a feature.
+///
+/// See the module policy: returns `NotFound` when the feature has no distinct
+/// call and `InvalidInput` when more than one matches.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::helpers::resolve_dfcall_id_for_feature;
+///
+/// let config = json!({"G2_CONFIG": {"CFG_DFCALL": [
+///     {"DFCALL_ID": 11, "FTYPE_ID": 3, "DFUNC_ID": 1}
+/// ]}});
+/// assert_eq!(resolve_dfcall_id_for_feature(&config, 3).unwrap(), 11);
+/// ```
+pub fn resolve_dfcall_id_for_feature(config: &Value, ftype_id: i64) -> Result<i64> {
+    resolve_call_id_for_feature(config, "CFG_DFCALL", "DFCALL_ID", ftype_id, "distinct")
+}
+
+/// Resolve the standardize call id (`SFCALL_ID`) bound to a feature.
+///
+/// Standardize calls can legitimately be many-per-feature; this returns
+/// `InvalidInput` when more than one matches (address by id instead) and
+/// `NotFound` when none do.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::helpers::resolve_sfcall_id_for_feature;
+///
+/// let config = json!({"G2_CONFIG": {"CFG_SFCALL": [
+///     {"SFCALL_ID": 5, "FTYPE_ID": 3, "SFUNC_ID": 1}
+/// ]}});
+/// assert_eq!(resolve_sfcall_id_for_feature(&config, 3).unwrap(), 5);
+/// ```
+pub fn resolve_sfcall_id_for_feature(config: &Value, ftype_id: i64) -> Result<i64> {
+    resolve_call_id_for_feature(config, "CFG_SFCALL", "SFCALL_ID", ftype_id, "standardize")
+}
+
+/// Resolve the expression call id (`EFCALL_ID`) bound to a feature.
+///
+/// Expression calls can legitimately be many-per-feature; this returns
+/// `InvalidInput` when more than one matches (address by id instead) and
+/// `NotFound` when none do.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::helpers::resolve_efcall_id_for_feature;
+///
+/// let config = json!({"G2_CONFIG": {"CFG_EFCALL": [
+///     {"EFCALL_ID": 9, "FTYPE_ID": 3, "EFUNC_ID": 1}
+/// ]}});
+/// assert_eq!(resolve_efcall_id_for_feature(&config, 3).unwrap(), 9);
+/// ```
+pub fn resolve_efcall_id_for_feature(config: &Value, ftype_id: i64) -> Result<i64> {
+    resolve_call_id_for_feature(config, "CFG_EFCALL", "EFCALL_ID", ftype_id, "expression")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_field_or_null_present_empty_null_absent() {
+        let item = json!({"a": "value", "b": "", "c": null});
+        // Present, non-empty string -> cloned value.
+        assert_eq!(field_or_null(&item, "a"), json!("value"));
+        // Present, empty string -> preserved as "".
+        assert_eq!(field_or_null(&item, "b"), json!(""));
+        // Present, explicit null -> null.
+        assert_eq!(field_or_null(&item, "c"), Value::Null);
+        // Absent key -> null.
+        assert_eq!(field_or_null(&item, "missing"), Value::Null);
+    }
+
+    #[test]
+    fn test_field_or_null_non_string_values() {
+        let item = json!({"n": 42, "arr": [1, 2]});
+        assert_eq!(field_or_null(&item, "n"), json!(42));
+        assert_eq!(field_or_null(&item, "arr"), json!([1, 2]));
+    }
+
+    #[test]
+    fn test_field_update_apply() {
+        assert_eq!(FieldUpdate::Leave.apply(Some(1)), Some(1));
+        assert_eq!(FieldUpdate::Leave.apply(None::<i64>), None);
+        assert_eq!(FieldUpdate::<i64>::Clear.apply(Some(1)), None);
+        assert_eq!(FieldUpdate::<i64>::Clear.apply(None), None);
+        assert_eq!(FieldUpdate::Set(9).apply(Some(1)), Some(9));
+        assert_eq!(FieldUpdate::Set(9).apply(None), Some(9));
+    }
+
+    #[test]
+    fn test_field_update_default_is_leave() {
+        let d: FieldUpdate<String> = FieldUpdate::default();
+        assert_eq!(d, FieldUpdate::Leave);
+    }
+
+    fn resolver_config() -> Value {
+        json!({"G2_CONFIG": {
+            "CFG_CFCALL": [
+                {"CFCALL_ID": 100, "FTYPE_ID": 1, "CFUNC_ID": 1},
+                {"CFCALL_ID": 101, "FTYPE_ID": 2, "CFUNC_ID": 1}
+            ],
+            "CFG_DFCALL": [
+                {"DFCALL_ID": 200, "FTYPE_ID": 1, "DFUNC_ID": 1}
+            ],
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 300, "FTYPE_ID": 1, "SFUNC_ID": 1},
+                {"SFCALL_ID": 301, "FTYPE_ID": 1, "SFUNC_ID": 2}
+            ],
+            "CFG_EFCALL": [
+                {"EFCALL_ID": 400, "FTYPE_ID": 5, "EFUNC_ID": 1}
+            ]
+        }})
+    }
+
+    #[test]
+    fn test_resolvers_single_match() {
+        let cfg = resolver_config();
+        assert_eq!(resolve_cfcall_id_for_feature(&cfg, 1).unwrap(), 100);
+        assert_eq!(resolve_cfcall_id_for_feature(&cfg, 2).unwrap(), 101);
+        assert_eq!(resolve_dfcall_id_for_feature(&cfg, 1).unwrap(), 200);
+        assert_eq!(resolve_efcall_id_for_feature(&cfg, 5).unwrap(), 400);
+    }
+
+    #[test]
+    fn test_resolvers_zero_match_not_found() {
+        let cfg = resolver_config();
+        let err = resolve_cfcall_id_for_feature(&cfg, 999).unwrap_err();
+        assert_eq!(err.kind(), SzConfigError::not_found("").kind());
+        assert!(resolve_dfcall_id_for_feature(&cfg, 999).is_err());
+        assert!(resolve_sfcall_id_for_feature(&cfg, 999).is_err());
+        assert!(resolve_efcall_id_for_feature(&cfg, 999).is_err());
+    }
+
+    #[test]
+    fn test_resolvers_ambiguous_many_match() {
+        let cfg = resolver_config();
+        // Feature 1 has two standardize calls -> ambiguous.
+        let err = resolve_sfcall_id_for_feature(&cfg, 1).unwrap_err();
+        assert_eq!(err.kind(), SzConfigError::validation("").kind());
+        assert!(err.to_string().contains("Ambiguous"));
+    }
+
+    #[test]
+    fn test_resolvers_missing_section_is_not_found() {
+        // Absent section behaves like zero matches.
+        let cfg = json!({"G2_CONFIG": {}});
+        assert!(resolve_cfcall_id_for_feature(&cfg, 1).is_err());
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,11 +16,51 @@ pub(crate) fn field_as_string(item: &Value, key: &str) -> Option<String> {
 /// explicit JSON `null`), and `Value::Null` when the key is absent. This is the
 /// read-side projection used by list/get builders that must emit `null` for a
 /// stored-null or missing field rather than coercing it to `""` or `0`.
-// Consumed by the null-projection work in Wave 3 (rules/functions/fragments
-// list builders); kept behind `allow(dead_code)` until then.
-#[allow(dead_code)]
 pub(crate) fn field_or_null(item: &Value, key: &str) -> Value {
     item.get(key).cloned().unwrap_or(Value::Null)
+}
+
+/// Parse a tri-state string [`FieldUpdate`] from a JSON object.
+///
+/// Scans `keys` in order and acts on the first key that is present on `json`:
+/// an explicit JSON `null` maps to [`FieldUpdate::Clear`] and a JSON string maps
+/// to [`FieldUpdate::Set`]. A key that is absent everywhere (or present only with
+/// a non-string, non-null value) leaves the field untouched
+/// ([`FieldUpdate::Leave`]). This encodes the JSON write contract where an
+/// omitted key means "leave", an explicit `null` means "clear", and a value
+/// means "set".
+pub(crate) fn field_update_str<'a>(json: &'a Value, keys: &[&str]) -> FieldUpdate<&'a str> {
+    for key in keys {
+        if let Some(v) = json.get(*key) {
+            if v.is_null() {
+                return FieldUpdate::Clear;
+            }
+            if let Some(s) = v.as_str() {
+                return FieldUpdate::Set(s);
+            }
+        }
+    }
+    FieldUpdate::Leave
+}
+
+/// Parse a tri-state integer [`FieldUpdate`] from a JSON object.
+///
+/// The integer analogue of [`field_update_str`]: an explicit JSON `null` maps to
+/// [`FieldUpdate::Clear`], a JSON integer maps to [`FieldUpdate::Set`], and an
+/// absent key (or present non-integer, non-null value) leaves the field
+/// untouched ([`FieldUpdate::Leave`]).
+pub(crate) fn field_update_i64(json: &Value, keys: &[&str]) -> FieldUpdate<i64> {
+    for key in keys {
+        if let Some(v) = json.get(*key) {
+            if v.is_null() {
+                return FieldUpdate::Clear;
+            }
+            if let Some(n) = v.as_i64() {
+                return FieldUpdate::Set(n);
+            }
+        }
+    }
+    FieldUpdate::Leave
 }
 
 /// Tri-state update for an optional field: leave, clear, or set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,14 @@ pub mod thresholds;
 // Advanced operations modules
 pub mod command_processor;
 pub mod config_sections;
+pub mod export;
 pub mod fragments;
 pub mod generic_plans;
 pub mod hashes;
 pub mod rules;
 pub mod settings;
 pub mod system_params;
+pub mod validation;
 pub mod versioning;
 
 // Function and call management modules
@@ -110,7 +112,8 @@ pub use attributes::ATTRIBUTE_CLASSES;
 pub use behavior_domain::{
     BEHAVIOR_CODES, behavior_position, compute_behavior, parse_behavior_code,
 };
-pub use behavior_overrides::delete_behavior_override;
+pub use behavior_overrides::{delete_behavior_override, list_behavior_overrides_resolved};
+pub use export::render_config;
 pub use filter::{FilterSubstrate, matches_filter, to_json_dumps_string, to_python_repr_string};
 pub use helpers::FieldUpdate;
 pub use helpers::{
@@ -118,6 +121,7 @@ pub use helpers::{
     resolve_sfcall_id_for_feature,
 };
 pub use settings::set_setting;
+pub use validation::validate_config;
 
 // C FFI module
 pub mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ pub mod helpers;
 // Shared crate-internal row structs (one per CFG_* section).
 pub(crate) mod config_rows;
 
+// Shared domain/substrate modules
+pub mod behavior_domain;
+pub mod filter;
+
 // Core entity modules
 pub mod attributes;
 pub mod behavior_overrides;
@@ -96,7 +100,20 @@ pub mod calls;
 pub mod functions;
 
 // Re-export commonly used types
-pub use error::{Result, SzConfigError};
+pub use error::{Result, SzConfigError, SzErrorKind};
+
+// Re-export shared domain items so consumers can use them without the
+// fully-qualified module path.
+pub use attributes::ATTRIBUTE_CLASSES;
+pub use behavior_domain::{
+    BEHAVIOR_CODES, behavior_position, compute_behavior, parse_behavior_code,
+};
+pub use filter::{FilterSubstrate, matches_filter, to_json_dumps_string, to_python_repr_string};
+pub use helpers::FieldUpdate;
+pub use helpers::{
+    resolve_cfcall_id_for_feature, resolve_dfcall_id_for_feature, resolve_efcall_id_for_feature,
+    resolve_sfcall_id_for_feature,
+};
 
 // C FFI module
 pub mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@
 //!             default_value: None,
 //!             internal: None,
 //!             required: None,
+//!             id: None,
 //!         },
 //!     )?;
 //!
@@ -92,6 +93,7 @@ pub mod fragments;
 pub mod generic_plans;
 pub mod hashes;
 pub mod rules;
+pub mod settings;
 pub mod system_params;
 pub mod versioning;
 
@@ -108,12 +110,14 @@ pub use attributes::ATTRIBUTE_CLASSES;
 pub use behavior_domain::{
     BEHAVIOR_CODES, behavior_position, compute_behavior, parse_behavior_code,
 };
+pub use behavior_overrides::delete_behavior_override;
 pub use filter::{FilterSubstrate, matches_filter, to_json_dumps_string, to_python_repr_string};
 pub use helpers::FieldUpdate;
 pub use helpers::{
     resolve_cfcall_id_for_feature, resolve_dfcall_id_for_feature, resolve_efcall_id_for_feature,
     resolve_sfcall_id_for_feature,
 };
+pub use settings::set_setting;
 
 // C FFI module
 pub mod ffi;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -448,9 +448,14 @@ pub fn get_rule(config_json: &str, code_or_id: &str) -> Result<Value> {
 ///
 /// * `config_json` - Configuration JSON string
 ///
+/// The rows are sorted inside the SDK by `ERRULE_ID` ascending. That is an
+/// **assumed** default order: the exact Python sort key for `listRules` could not
+/// be verified in-repo, so this is the documented SDK convention (a one-line
+/// change if Python later proves to sort differently).
+///
 /// # Returns
 ///
-/// Returns a vector of rule objects in Python sz_configtool format
+/// Returns a vector of rule objects in Python sz_configtool format, sorted by id
 ///
 /// # Example
 ///
@@ -499,6 +504,13 @@ pub fn list_rules(config_json: &str) -> Result<Vec<Value>> {
     } else {
         Vec::new()
     };
+
+    // SDK-owned default sort. NOTE: the exact Python sort order for listRules is
+    // unverified (Python is not in-repo); the assumed order is ERRULE_ID
+    // ascending. If Python turns out to sort by (tier, id) or similar this is a
+    // one-line change. rows carrying a null/absent id sort first (id 0).
+    let mut items = items;
+    items.sort_by_key(|item| item.get("id").and_then(|v| v.as_i64()).unwrap_or(0));
 
     Ok(items)
 }
@@ -1134,5 +1146,21 @@ mod tests {
         // id 100 is already taken by EXISTING.
         let err = add_rule(cfg, 100, &rule).unwrap_err();
         assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_list_rules_default_sort_by_id() {
+        // Stored order deliberately out of ERRULE_ID order.
+        let config = r#"{"G2_CONFIG": {"CFG_ERRULE": [
+            {"ERRULE_ID": 30, "ERRULE_CODE": "C", "RESOLVE": "No"},
+            {"ERRULE_ID": 10, "ERRULE_CODE": "A", "RESOLVE": "No"},
+            {"ERRULE_ID": 20, "ERRULE_CODE": "B", "RESOLVE": "No"}
+        ]}}"#;
+
+        let rules = list_rules(config).unwrap();
+        // SDK-owned default sort: ERRULE_ID ascending.
+        assert_eq!(rules[0]["id"], json!(10));
+        assert_eq!(rules[1]["id"], json!(20));
+        assert_eq!(rules[2]["id"], json!(30));
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -4,7 +4,7 @@
 //! Rules define matching and relationship logic based on fragments.
 
 use crate::error::{Result, SzConfigError};
-use crate::helpers;
+use crate::helpers::{self, FieldUpdate};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -228,16 +228,22 @@ pub(crate) fn validate_rule_row(
 // Parameter Structs
 // ============================================================================
 
-/// Parameters for setting (updating) a rule
+/// Parameters for setting (updating) a rule.
+///
+/// `resolve`, `relate` and `rtype_id` are plain `Option`s (a `None` leaves the
+/// stored value untouched). `fragment`, `disqualifier` and `tier` are tri-state
+/// [`FieldUpdate`]s so an update can distinguish "leave unchanged" from
+/// "clear to null": `Leave` carries the stored value forward, `Clear` writes
+/// JSON `null`, and `Set` writes the new value.
 #[derive(Debug, Clone)]
 pub struct SetRuleParams<'a> {
     pub code: &'a str,
     pub resolve: Option<&'a str>,
     pub relate: Option<&'a str>,
     pub rtype_id: Option<i64>,
-    pub fragment: Option<&'a str>,
-    pub disqualifier: Option<&'a str>,
-    pub tier: Option<i64>,
+    pub fragment: FieldUpdate<&'a str>,
+    pub disqualifier: FieldUpdate<&'a str>,
+    pub tier: FieldUpdate<i64>,
 }
 
 impl<'a> TryFrom<&'a Value> for SetRuleParams<'a> {
@@ -264,18 +270,11 @@ impl<'a> TryFrom<&'a Value> for SetRuleParams<'a> {
                 .get("rtypeId")
                 .and_then(|v| v.as_i64())
                 .or_else(|| json.get("RTYPE_ID").and_then(|v| v.as_i64())),
-            fragment: json
-                .get("fragment")
-                .and_then(|v| v.as_str())
-                .or_else(|| json.get("FRAGMENT").and_then(|v| v.as_str())),
-            disqualifier: json
-                .get("disqualifier")
-                .and_then(|v| v.as_str())
-                .or_else(|| json.get("DISQUALIFIER").and_then(|v| v.as_str())),
-            tier: json
-                .get("tier")
-                .and_then(|v| v.as_i64())
-                .or_else(|| json.get("TIER").and_then(|v| v.as_i64())),
+            // Tri-state: an absent key -> Leave, an explicit JSON null -> Clear,
+            // a value -> Set.
+            fragment: helpers::field_update_str(json, &["fragment", "FRAGMENT"]),
+            disqualifier: helpers::field_update_str(json, &["disqualifier", "DISQUALIFIER"]),
+            tier: helpers::field_update_i64(json, &["tier", "TIER"]),
         })
     }
 }
@@ -419,22 +418,26 @@ pub fn get_rule(config_json: &str, code_or_id: &str) -> Result<Value> {
         )));
     };
 
-    // Transform to lowercase format (matching list_rules for consistency)
-    let resolve = item.get("RESOLVE").and_then(|v| v.as_str()).unwrap_or("");
-    let tier = if resolve == "Yes" {
-        item.get("ERRULE_TIER").and_then(|v| v.as_i64())
+    // Transform to lowercase format (matching list_rules for consistency).
+    // Stored-nullable columns are projected null-preserving (stored null stays
+    // null, stored "" stays "", absent -> null) via helpers::field_or_null. The
+    // computed `tier` keeps its business rule: it is the stored ERRULE_TIER only
+    // when RESOLVE == "Yes", otherwise null.
+    let resolve_is_yes = item.get("RESOLVE").and_then(|v| v.as_str()) == Some("Yes");
+    let tier = if resolve_is_yes {
+        helpers::field_or_null(&item, "ERRULE_TIER")
     } else {
-        None
+        Value::Null
     };
 
     Ok(json!({
-        "id": item.get("ERRULE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
-        "rule": item.get("ERRULE_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-        "resolve": resolve,
-        "relate": item.get("RELATE").and_then(|v| v.as_str()).unwrap_or(""),
-        "rtype_id": item.get("RTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
-        "fragment": item.get("QUAL_ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-        "disqualifier": item.get("DISQ_ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
+        "id": helpers::field_or_null(&item, "ERRULE_ID"),
+        "rule": helpers::field_or_null(&item, "ERRULE_CODE"),
+        "resolve": helpers::field_or_null(&item, "RESOLVE"),
+        "relate": helpers::field_or_null(&item, "RELATE"),
+        "rtype_id": helpers::field_or_null(&item, "RTYPE_ID"),
+        "fragment": helpers::field_or_null(&item, "QUAL_ERFRAG_CODE"),
+        "disqualifier": helpers::field_or_null(&item, "DISQ_ERFRAG_CODE"),
         "tier": tier
     }))
 }
@@ -467,21 +470,25 @@ pub fn list_rules(config_json: &str) -> Result<Vec<Value>> {
             array
                 .iter()
                 .map(|item| {
-                    let resolve = item.get("RESOLVE").and_then(|v| v.as_str()).unwrap_or("");
-                    let tier = if resolve == "Yes" {
-                        item.get("ERRULE_TIER").and_then(|v| v.as_i64())
+                    // Null-preserving projection for every stored column; the
+                    // computed `tier` keeps its business rule (stored ERRULE_TIER
+                    // only when RESOLVE == "Yes", otherwise null).
+                    let resolve_is_yes =
+                        item.get("RESOLVE").and_then(|v| v.as_str()) == Some("Yes");
+                    let tier = if resolve_is_yes {
+                        helpers::field_or_null(item, "ERRULE_TIER")
                     } else {
-                        None
+                        Value::Null
                     };
 
                     json!({
-                        "id": item.get("ERRULE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "rule": item.get("ERRULE_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                        "resolve": resolve,
-                        "relate": item.get("RELATE").and_then(|v| v.as_str()).unwrap_or(""),
-                        "rtype_id": item.get("RTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "fragment": item.get("QUAL_ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
-                        "disqualifier": item.get("DISQ_ERFRAG_CODE").and_then(|v| v.as_str()).unwrap_or(""),
+                        "id": helpers::field_or_null(item, "ERRULE_ID"),
+                        "rule": helpers::field_or_null(item, "ERRULE_CODE"),
+                        "resolve": helpers::field_or_null(item, "RESOLVE"),
+                        "relate": helpers::field_or_null(item, "RELATE"),
+                        "rtype_id": helpers::field_or_null(item, "RTYPE_ID"),
+                        "fragment": helpers::field_or_null(item, "QUAL_ERFRAG_CODE"),
+                        "disqualifier": helpers::field_or_null(item, "DISQ_ERFRAG_CODE"),
                         "tier": tier
                     })
                 })
@@ -513,15 +520,17 @@ pub fn list_rules(config_json: &str) -> Result<Vec<Value>> {
 /// ```
 /// use sz_configtool_lib::rules;
 ///
+/// use sz_configtool_lib::helpers::FieldUpdate;
+///
 /// let config = r#"{"G2_CONFIG": {"CFG_ERRULE": [{"ERRULE_ID": 1, "ERRULE_CODE": "TEST", "RESOLVE": "No"}], "CFG_ERFRAG": []}}"#;
 /// let params = rules::SetRuleParams {
 ///     code: "TEST",
 ///     resolve: Some("Yes"),
 ///     relate: Some("No"),
 ///     rtype_id: None,
-///     fragment: None,
-///     disqualifier: None,
-///     tier: None,
+///     fragment: FieldUpdate::Leave,
+///     disqualifier: FieldUpdate::Leave,
+///     tier: FieldUpdate::Leave,
 /// };
 /// let modified = rules::set_rule(config, params).unwrap();
 /// ```
@@ -535,12 +544,16 @@ pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
         helpers::find_in_config_array(config_json, "CFG_ERRULE", "ERRULE_CODE", &code)?
             .ok_or_else(|| SzConfigError::NotFound(format!("Rule not found: {code}")))?;
 
-    // Validate ONLY the fragment/disqualifier being changed. A code carried over
-    // unchanged from the existing rule is never re-validated, preserving the
+    // Validate ONLY the fragment/disqualifier being Set. A code carried over
+    // unchanged (Leave) or cleared (Clear) is never validated, preserving the
     // historical set_rule contract (do not newly reject previously-accepted
     // input). add_rule, by contrast, validates every code on the new row.
-    validate_fragment_code(&config_data, params.fragment, "Fragment")?;
-    validate_fragment_code(&config_data, params.disqualifier, "Disqualifier")?;
+    if let FieldUpdate::Set(frag) = params.fragment {
+        validate_fragment_code(&config_data, Some(frag), "Fragment")?;
+    }
+    if let FieldUpdate::Set(disq) = params.disqualifier {
+        validate_fragment_code(&config_data, Some(disq), "Disqualifier")?;
+    }
 
     // Extract ERRULE_ID from existing rule to preserve it
     let errule_id = existing_rule
@@ -571,17 +584,23 @@ pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
             .rtype_id
             .or_else(|| existing_rule.get("RTYPE_ID").and_then(|v| v.as_i64()))
             .unwrap_or(1),
-        qual_erfrag_code: params
-            .fragment
-            .map(str::to_uppercase)
-            .or_else(|| helpers::field_as_string(&existing_rule, "QUAL_ERFRAG_CODE")),
-        disq_erfrag_code: params
-            .disqualifier
-            .map(str::to_uppercase)
-            .or_else(|| helpers::field_as_string(&existing_rule, "DISQ_ERFRAG_CODE")),
-        errule_tier: params
-            .tier
-            .or_else(|| existing_rule.get("ERRULE_TIER").and_then(|v| v.as_i64())),
+        // Tri-state: Leave carries the stored value forward, Clear writes null,
+        // Set writes the (upper-cased) new code.
+        qual_erfrag_code: match params.fragment {
+            FieldUpdate::Leave => helpers::field_as_string(&existing_rule, "QUAL_ERFRAG_CODE"),
+            FieldUpdate::Clear => None,
+            FieldUpdate::Set(frag) => Some(frag.to_uppercase()),
+        },
+        disq_erfrag_code: match params.disqualifier {
+            FieldUpdate::Leave => helpers::field_as_string(&existing_rule, "DISQ_ERFRAG_CODE"),
+            FieldUpdate::Clear => None,
+            FieldUpdate::Set(disq) => Some(disq.to_uppercase()),
+        },
+        errule_tier: match params.tier {
+            FieldUpdate::Leave => existing_rule.get("ERRULE_TIER").and_then(|v| v.as_i64()),
+            FieldUpdate::Clear => None,
+            FieldUpdate::Set(tier) => Some(tier),
+        },
     };
 
     // Enforce/normalise the non-fragment invariants (is_new=false skips the
@@ -620,9 +639,9 @@ mod tests {
             resolve: Some("No"),
             relate: None,
             rtype_id: None,
-            fragment: None,
-            disqualifier: None,
-            tier: None,
+            fragment: FieldUpdate::Leave,
+            disqualifier: FieldUpdate::Leave,
+            tier: FieldUpdate::Leave,
         };
 
         let modified = set_rule(config, params).unwrap();
@@ -666,9 +685,9 @@ mod tests {
             resolve: Some("Yes"),
             relate: None,
             rtype_id: None,
-            fragment: None,
-            disqualifier: None,
-            tier: None,
+            fragment: FieldUpdate::Leave,
+            disqualifier: FieldUpdate::Leave,
+            tier: FieldUpdate::Leave,
         };
 
         let modified = set_rule(config, params).unwrap();
@@ -725,6 +744,51 @@ mod tests {
         assert_eq!(obj["QUAL_ERFRAG_CODE"], Value::Null);
         assert_eq!(obj["DISQ_ERFRAG_CODE"], Value::Null);
         assert_eq!(obj["ERRULE_TIER"], Value::Null);
+    }
+
+    // ------------------------------------------------------------------
+    // #33 null-preserving read projection
+    // ------------------------------------------------------------------
+
+    /// list_rules / get_rule must render a stored null as JSON null (not ""), a
+    /// stored "" as "", and an absent column as null; the computed `tier` keeps
+    /// its business rule (present only when RESOLVE == "Yes").
+    #[test]
+    fn test_list_rules_null_preserving_projection() {
+        // Row 1: RESOLVE=Yes, DISQ null, QUAL "" (empty), tier present.
+        // Row 2: RELATE=Yes, tier present but must be suppressed (RESOLVE != Yes).
+        // Row 3: QUAL_ERFRAG_CODE absent entirely -> projects as null.
+        let config = r#"{"G2_CONFIG": {"CFG_ERRULE": [
+            {"ERRULE_ID": 1, "ERRULE_CODE": "A", "RESOLVE": "Yes", "RELATE": "No",
+             "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "", "DISQ_ERFRAG_CODE": null,
+             "ERRULE_TIER": 10},
+            {"ERRULE_ID": 2, "ERRULE_CODE": "B", "RESOLVE": "No", "RELATE": "Yes",
+             "RTYPE_ID": 2, "QUAL_ERFRAG_CODE": "Q", "DISQ_ERFRAG_CODE": "D",
+             "ERRULE_TIER": 20},
+            {"ERRULE_ID": 3, "ERRULE_CODE": "C", "RESOLVE": "No", "RELATE": "No",
+             "RTYPE_ID": 1, "DISQ_ERFRAG_CODE": null}
+        ]}}"#;
+
+        let rules = list_rules(config).unwrap();
+
+        // Row 1: stored null stays null, stored "" stays "", tier computed.
+        assert_eq!(rules[0]["disqualifier"], Value::Null);
+        assert_eq!(rules[0]["fragment"], json!(""));
+        assert_eq!(rules[0]["tier"], json!(10));
+
+        // Row 2: RESOLVE != "Yes" -> tier suppressed to null despite stored 20.
+        assert_eq!(rules[1]["tier"], Value::Null);
+        assert_eq!(rules[1]["fragment"], json!("Q"));
+
+        // Row 3: absent QUAL_ERFRAG_CODE -> null (present as a key).
+        assert!(rules[2].as_object().unwrap().contains_key("fragment"));
+        assert_eq!(rules[2]["fragment"], Value::Null);
+
+        // get_rule agrees with list_rules for row 1.
+        let one = get_rule(config, "A").unwrap();
+        assert_eq!(one["disqualifier"], Value::Null);
+        assert_eq!(one["fragment"], json!(""));
+        assert_eq!(one["tier"], json!(10));
     }
 
     // ------------------------------------------------------------------
@@ -960,9 +1024,9 @@ mod tests {
             resolve: None,
             relate: None,
             rtype_id: None,
-            fragment: Some("GHOST"),
-            disqualifier: None,
-            tier: None,
+            fragment: FieldUpdate::Set("GHOST"),
+            disqualifier: FieldUpdate::Leave,
+            tier: FieldUpdate::Leave,
         };
         let set_err = set_rule(cfg, set_params).unwrap_err();
 
@@ -992,9 +1056,9 @@ mod tests {
             resolve: Some("No"),
             relate: None,
             rtype_id: None,
-            fragment: None,
-            disqualifier: None,
-            tier: None,
+            fragment: FieldUpdate::Leave,
+            disqualifier: FieldUpdate::Leave,
+            tier: FieldUpdate::Leave,
         };
         let modified = set_rule(config, params).unwrap();
         let value: Value = serde_json::from_str(&modified).unwrap();
@@ -1021,6 +1085,46 @@ mod tests {
         let rule2 = json!({"ERRULE_CODE": "R2", "RESOLVE": "No", "RELATE": "No"});
         let (_m2, id2) = add_rule(&modified, 2000, &rule2).unwrap();
         assert_eq!(id2, 2000);
+    }
+
+    /// Tri-state on set_rule: Clear writes an explicit null, Set writes a value
+    /// (validating existence), and Leave preserves the stored value.
+    #[test]
+    fn test_set_rule_disqualifier_tri_state() {
+        let cfg = add_rule_config();
+
+        // Clear: existing disqualifier (null already) stays null; and clearing a
+        // populated fragment writes null.
+        let clear_params = SetRuleParams {
+            code: "EXISTING",
+            resolve: None,
+            relate: None,
+            rtype_id: None,
+            fragment: FieldUpdate::Clear,
+            disqualifier: FieldUpdate::Leave,
+            tier: FieldUpdate::Leave,
+        };
+        let modified = set_rule(cfg, clear_params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let rule = &value["G2_CONFIG"]["CFG_ERRULE"][0];
+        assert_eq!(rule["QUAL_ERFRAG_CODE"], Value::Null);
+
+        // Set: point the disqualifier at an existing fragment.
+        let set_params = SetRuleParams {
+            code: "EXISTING",
+            resolve: None,
+            relate: None,
+            rtype_id: None,
+            fragment: FieldUpdate::Leave,
+            disqualifier: FieldUpdate::Set("frag_b"),
+            tier: FieldUpdate::Leave,
+        };
+        let modified = set_rule(cfg, set_params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let rule = &value["G2_CONFIG"]["CFG_ERRULE"][0];
+        assert_eq!(rule["DISQ_ERFRAG_CODE"], json!("FRAG_B"));
+        // The carried-over fragment (Leave) is untouched.
+        assert_eq!(rule["QUAL_ERFRAG_CODE"], json!("FRAG_A"));
     }
 
     #[test]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -448,10 +448,9 @@ pub fn get_rule(config_json: &str, code_or_id: &str) -> Result<Value> {
 ///
 /// * `config_json` - Configuration JSON string
 ///
-/// The rows are sorted inside the SDK by `ERRULE_ID` ascending. That is an
-/// **assumed** default order: the exact Python sort key for `listRules` could not
-/// be verified in-repo, so this is the documented SDK convention (a one-line
-/// change if Python later proves to sort differently).
+/// The rows are sorted inside the SDK by `ERRULE_ID` ascending. This matches the
+/// Python `sz_configtool` reference (`/opt/senzing/er/bin/sz_configtool`, 4.4.0),
+/// whose `do_listRules` sorts with `key=lambda k: k["ERRULE_ID"]`.
 ///
 /// # Returns
 ///

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 /// The Senzing engine's config loader requires every key to be present (a
 /// missing key yields SENZ9117), so partial rows must never be written.
 #[derive(Debug, Clone, Serialize)]
-struct ErruleRow {
+pub(crate) struct ErruleRow {
     #[serde(rename = "ERRULE_ID")]
     errule_id: i64,
     #[serde(rename = "ERRULE_CODE")]
@@ -64,6 +64,138 @@ impl ErruleRow {
             errule_tier: cfg.get("ERRULE_TIER").and_then(|v| v.as_i64()),
         }
     }
+}
+
+/// Check whether a fragment code exists in `CFG_ERFRAG` (case-insensitive).
+// Consumed by `validate_rule_row`, which is wired into `add_rule`/`set_rule` in
+// Wave 2c; kept behind `allow(dead_code)` until then.
+#[allow(dead_code)]
+fn fragment_code_exists(config: &Value, frag_upper: &str) -> bool {
+    config
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_ERFRAG"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter().any(|item| {
+                item.get("ERFRAG_CODE")
+                    .and_then(|v| v.as_str())
+                    .map(|c| c.eq_ignore_ascii_case(frag_upper))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Validate and normalise a proposed `CFG_ERRULE` row against the config.
+///
+/// This is the single, shared rule validator so that `add_rule` and `set_rule`
+/// enforce exactly the same invariants and cannot drift apart. It performs, in
+/// order:
+///
+/// 1. **Duplicate-code check** (only when `is_new`): rejects a rule whose
+///    `ERRULE_CODE` already exists.
+/// 2. **Fragment / disqualifier existence**: any non-empty `QUAL_ERFRAG_CODE`
+///    or `DISQ_ERFRAG_CODE` must name an existing `CFG_ERFRAG` row.
+/// 3. **RESOLVE / RELATE domain**: each must be `Yes`/`No` (case-insensitive);
+///    the returned row is normalised to title-case.
+/// 4. **Mutual exclusivity**: a rule may not both resolve and relate.
+/// 5. **RTYPE_ID coherence**: `RESOLVE=Yes` auto-corrects `RTYPE_ID` to `1`;
+///    `RELATE=Yes` requires `RTYPE_ID` in `[2, 3, 4]`.
+///
+/// On success it returns a normalised copy of the row (title-cased
+/// RESOLVE/RELATE and any auto-corrected RTYPE_ID). It never mutates the config.
+///
+/// The error messages match the historical `set_rule` wording so the two entry
+/// points remain behaviourally identical once both delegate here.
+// Created in Wave 1; `add_rule`/`set_rule` are wired to call it in Wave 2c.
+#[allow(dead_code)]
+pub(crate) fn validate_rule_row(
+    config: &Value,
+    row: &ErruleRow,
+    is_new: bool,
+) -> Result<ErruleRow> {
+    let mut out = row.clone();
+
+    // 1. Duplicate ERRULE_CODE (adds only; an update targets an existing code).
+    if is_new
+        && config
+            .get("G2_CONFIG")
+            .and_then(|g| g.get("CFG_ERRULE"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter().any(|item| {
+                    item.get("ERRULE_CODE")
+                        .and_then(|v| v.as_str())
+                        .map(|c| c.eq_ignore_ascii_case(&out.errule_code))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    {
+        return Err(SzConfigError::AlreadyExists(format!(
+            "Rule '{}' already exists",
+            out.errule_code
+        )));
+    }
+
+    // 2. Fragment / disqualifier existence (skip null / empty).
+    if let Some(frag) = out.qual_erfrag_code.as_deref()
+        && !frag.is_empty()
+    {
+        let frag_upper = frag.to_uppercase();
+        if !fragment_code_exists(config, &frag_upper) {
+            return Err(SzConfigError::NotFound(format!(
+                "Fragment '{frag_upper}' not found"
+            )));
+        }
+    }
+    if let Some(disq) = out.disq_erfrag_code.as_deref()
+        && !disq.is_empty()
+    {
+        let disq_upper = disq.to_uppercase();
+        if !fragment_code_exists(config, &disq_upper) {
+            return Err(SzConfigError::NotFound(format!(
+                "Fragment '{disq_upper}' not found"
+            )));
+        }
+    }
+
+    // 3. RESOLVE domain + normalise.
+    let resolve_upper = out.resolve.to_uppercase();
+    if resolve_upper != "YES" && resolve_upper != "NO" {
+        return Err(SzConfigError::InvalidInput(
+            "resolve value must be in [\"Yes\", \"No\"]".to_string(),
+        ));
+    }
+    out.resolve = if resolve_upper == "YES" { "Yes" } else { "No" }.to_string();
+
+    // 3. RELATE domain + normalise.
+    let relate_upper = out.relate.to_uppercase();
+    if relate_upper != "YES" && relate_upper != "NO" {
+        return Err(SzConfigError::InvalidInput(
+            "relate value must be in [\"Yes\", \"No\"]".to_string(),
+        ));
+    }
+    out.relate = if relate_upper == "YES" { "Yes" } else { "No" }.to_string();
+
+    // 4. Mutual exclusivity.
+    if out.resolve == "Yes" && out.relate == "Yes" {
+        return Err(SzConfigError::InvalidInput(
+            "A rule must either resolve or relate, please set the other to No".to_string(),
+        ));
+    }
+
+    // 5. RTYPE_ID coherence / auto-correct.
+    if out.resolve == "Yes" && out.rtype_id != 1 {
+        out.rtype_id = 1;
+    }
+    if out.relate == "Yes" && ![2, 3, 4].contains(&out.rtype_id) {
+        return Err(SzConfigError::InvalidInput(
+            "Relationship type (RTYPE_ID) must be set to either 2=Possible match or 3=Possibly related".to_string(),
+        ));
+    }
+
+    Ok(out)
 }
 
 // ============================================================================
@@ -598,5 +730,142 @@ mod tests {
         assert_eq!(obj["QUAL_ERFRAG_CODE"], Value::Null);
         assert_eq!(obj["DISQ_ERFRAG_CODE"], Value::Null);
         assert_eq!(obj["ERRULE_TIER"], Value::Null);
+    }
+
+    // ------------------------------------------------------------------
+    // validate_rule_row (shared validator, created in Wave 1)
+    // ------------------------------------------------------------------
+
+    fn validator_config() -> Value {
+        serde_json::from_str(
+            r#"{"G2_CONFIG": {
+                "CFG_ERRULE": [
+                    {"ERRULE_ID": 100, "ERRULE_CODE": "EXISTING", "RESOLVE": "Yes",
+                     "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "FRAG_A",
+                     "DISQ_ERFRAG_CODE": null, "ERRULE_TIER": 10}
+                ],
+                "CFG_ERFRAG": [
+                    {"ERFRAG_ID": 1, "ERFRAG_CODE": "FRAG_A"},
+                    {"ERFRAG_ID": 2, "ERFRAG_CODE": "FRAG_B"}
+                ]
+            }}"#,
+        )
+        .unwrap()
+    }
+
+    fn base_row() -> ErruleRow {
+        ErruleRow {
+            errule_id: 1000,
+            errule_code: "NEW_RULE".to_string(),
+            resolve: "No".to_string(),
+            relate: "No".to_string(),
+            rtype_id: 1,
+            qual_erfrag_code: None,
+            disq_erfrag_code: None,
+            errule_tier: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_rule_row_accepts_valid_new() {
+        let cfg = validator_config();
+        let out = validate_rule_row(&cfg, &base_row(), true).unwrap();
+        assert_eq!(out.resolve, "No");
+        assert_eq!(out.relate, "No");
+    }
+
+    #[test]
+    fn test_validate_rule_row_rejects_duplicate_code_when_new() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.errule_code = "existing".to_string(); // case-insensitive clash
+        let err = validate_rule_row(&cfg, &row, true).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_validate_rule_row_allows_existing_code_when_not_new() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.errule_code = "EXISTING".to_string();
+        // is_new = false -> dup check skipped.
+        assert!(validate_rule_row(&cfg, &row, false).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rule_row_bad_fragment() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.qual_erfrag_code = Some("NOPE".to_string());
+        let err = validate_rule_row(&cfg, &row, true).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+        assert!(err.to_string().contains("Fragment 'NOPE' not found"));
+    }
+
+    #[test]
+    fn test_validate_rule_row_bad_disqualifier() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.disq_erfrag_code = Some("NOPE".to_string());
+        let err = validate_rule_row(&cfg, &row, true).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_validate_rule_row_existing_fragment_ok() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.qual_erfrag_code = Some("frag_b".to_string()); // case-insensitive
+        assert!(validate_rule_row(&cfg, &row, true).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rule_row_resolve_domain() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.resolve = "maybe".to_string();
+        let err = validate_rule_row(&cfg, &row, true).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_validate_rule_row_relate_domain() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.relate = "perhaps".to_string();
+        assert!(validate_rule_row(&cfg, &row, true).is_err());
+    }
+
+    #[test]
+    fn test_validate_rule_row_mutual_exclusivity() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.resolve = "Yes".to_string();
+        row.relate = "Yes".to_string();
+        let err = validate_rule_row(&cfg, &row, true).unwrap_err();
+        assert!(err.to_string().contains("either resolve or relate"));
+    }
+
+    #[test]
+    fn test_validate_rule_row_resolve_autocorrects_rtype() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.resolve = "yes".to_string();
+        row.rtype_id = 3; // incoherent with RESOLVE=Yes
+        let out = validate_rule_row(&cfg, &row, true).unwrap();
+        assert_eq!(out.resolve, "Yes"); // normalised
+        assert_eq!(out.rtype_id, 1); // auto-corrected
+    }
+
+    #[test]
+    fn test_validate_rule_row_relate_requires_valid_rtype() {
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.relate = "Yes".to_string();
+        row.rtype_id = 1; // invalid for RELATE
+        assert!(validate_rule_row(&cfg, &row, true).is_err());
+
+        row.rtype_id = 2; // valid
+        assert!(validate_rule_row(&cfg, &row, true).is_ok());
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -67,9 +67,6 @@ impl ErruleRow {
 }
 
 /// Check whether a fragment code exists in `CFG_ERFRAG` (case-insensitive).
-// Consumed by `validate_rule_row`, which is wired into `add_rule`/`set_rule` in
-// Wave 2c; kept behind `allow(dead_code)` until then.
-#[allow(dead_code)]
 fn fragment_code_exists(config: &Value, frag_upper: &str) -> bool {
     config
         .get("G2_CONFIG")
@@ -86,34 +83,47 @@ fn fragment_code_exists(config: &Value, frag_upper: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Validate and normalise a proposed `CFG_ERRULE` row against the config.
+/// Validate that a single fragment/disqualifier code names an existing
+/// `CFG_ERFRAG` row. `None` and empty codes are accepted (nothing to check).
 ///
-/// This is the single, shared rule validator so that `add_rule` and `set_rule`
-/// enforce exactly the same invariants and cannot drift apart. It performs, in
+/// `label` distinguishes the message (`"Fragment"` vs `"Disqualifier"`). The
+/// message uses double quotes for Python parity (D13).
+///
+/// This is the single-code building block so callers can validate *only* the
+/// codes they are changing (as `set_rule` does), while `validate_rule_row`
+/// composes it to validate every code present on a new row.
+fn validate_fragment_code(config: &Value, code: Option<&str>, label: &str) -> Result<()> {
+    if let Some(c) = code
+        && !c.is_empty()
+    {
+        let upper = c.to_uppercase();
+        if !fragment_code_exists(config, &upper) {
+            return Err(SzConfigError::NotFound(format!(
+                "{label} \"{upper}\" not found"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate and normalise the non-fragment invariants of a proposed rule row.
+///
+/// This is the shared core that both `add_rule` and `set_rule` delegate to so
+/// their RESOLVE/RELATE/RTYPE_ID handling can never drift. It performs, in
 /// order:
 ///
-/// 1. **Duplicate-code check** (only when `is_new`): rejects a rule whose
-///    `ERRULE_CODE` already exists.
-/// 2. **Fragment / disqualifier existence**: any non-empty `QUAL_ERFRAG_CODE`
-///    or `DISQ_ERFRAG_CODE` must name an existing `CFG_ERFRAG` row.
-/// 3. **RESOLVE / RELATE domain**: each must be `Yes`/`No` (case-insensitive);
+/// 1. **Duplicate-code check** (only when `is_new`).
+/// 2. **RESOLVE / RELATE domain** — each must be `Yes`/`No` (case-insensitive);
 ///    the returned row is normalised to title-case.
-/// 4. **Mutual exclusivity**: a rule may not both resolve and relate.
-/// 5. **RTYPE_ID coherence**: `RESOLVE=Yes` auto-corrects `RTYPE_ID` to `1`;
+/// 3. **Mutual exclusivity** — a rule may not both resolve and relate.
+/// 4. **RTYPE_ID coherence** — `RESOLVE=Yes` auto-corrects `RTYPE_ID` to `1`;
 ///    `RELATE=Yes` requires `RTYPE_ID` in `[2, 3, 4]`.
 ///
-/// On success it returns a normalised copy of the row (title-cased
-/// RESOLVE/RELATE and any auto-corrected RTYPE_ID). It never mutates the config.
-///
-/// The error messages match the historical `set_rule` wording so the two entry
-/// points remain behaviourally identical once both delegate here.
-// Created in Wave 1; `add_rule`/`set_rule` are wired to call it in Wave 2c.
-#[allow(dead_code)]
-pub(crate) fn validate_rule_row(
-    config: &Value,
-    row: &ErruleRow,
-    is_new: bool,
-) -> Result<ErruleRow> {
+/// Fragment/disqualifier *existence* is intentionally NOT checked here: `add_rule`
+/// validates every code on the new row via [`validate_rule_row`], while `set_rule`
+/// validates only the codes it is changing via [`validate_fragment_code`], never
+/// re-validating a code carried over unchanged.
+fn validate_rule_row_core(config: &Value, row: &ErruleRow, is_new: bool) -> Result<ErruleRow> {
     let mut out = row.clone();
 
     // 1. Duplicate ERRULE_CODE (adds only; an update targets an existing code).
@@ -138,29 +148,7 @@ pub(crate) fn validate_rule_row(
         )));
     }
 
-    // 2. Fragment / disqualifier existence (skip null / empty).
-    if let Some(frag) = out.qual_erfrag_code.as_deref()
-        && !frag.is_empty()
-    {
-        let frag_upper = frag.to_uppercase();
-        if !fragment_code_exists(config, &frag_upper) {
-            return Err(SzConfigError::NotFound(format!(
-                "Fragment '{frag_upper}' not found"
-            )));
-        }
-    }
-    if let Some(disq) = out.disq_erfrag_code.as_deref()
-        && !disq.is_empty()
-    {
-        let disq_upper = disq.to_uppercase();
-        if !fragment_code_exists(config, &disq_upper) {
-            return Err(SzConfigError::NotFound(format!(
-                "Fragment '{disq_upper}' not found"
-            )));
-        }
-    }
-
-    // 3. RESOLVE domain + normalise.
+    // 2. RESOLVE domain + normalise.
     let resolve_upper = out.resolve.to_uppercase();
     if resolve_upper != "YES" && resolve_upper != "NO" {
         return Err(SzConfigError::InvalidInput(
@@ -169,7 +157,7 @@ pub(crate) fn validate_rule_row(
     }
     out.resolve = if resolve_upper == "YES" { "Yes" } else { "No" }.to_string();
 
-    // 3. RELATE domain + normalise.
+    // 2. RELATE domain + normalise.
     let relate_upper = out.relate.to_uppercase();
     if relate_upper != "YES" && relate_upper != "NO" {
         return Err(SzConfigError::InvalidInput(
@@ -178,24 +166,62 @@ pub(crate) fn validate_rule_row(
     }
     out.relate = if relate_upper == "YES" { "Yes" } else { "No" }.to_string();
 
-    // 4. Mutual exclusivity.
+    // 3. Mutual exclusivity.
     if out.resolve == "Yes" && out.relate == "Yes" {
         return Err(SzConfigError::InvalidInput(
             "A rule must either resolve or relate, please set the other to No".to_string(),
         ));
     }
 
-    // 5. RTYPE_ID coherence / auto-correct.
+    // 4. RTYPE_ID coherence / auto-correct.
     if out.resolve == "Yes" && out.rtype_id != 1 {
         out.rtype_id = 1;
     }
     if out.relate == "Yes" && ![2, 3, 4].contains(&out.rtype_id) {
         return Err(SzConfigError::InvalidInput(
-            "Relationship type (RTYPE_ID) must be set to either 2=Possible match or 3=Possibly related".to_string(),
+            "Relationship type (RTYPE_ID) must be 2 (Possible match), 3 (Possibly related), or 4"
+                .to_string(),
         ));
     }
 
     Ok(out)
+}
+
+/// Validate and normalise a proposed `CFG_ERRULE` row against the config.
+///
+/// This is the single, shared rule validator so that `add_rule` and `set_rule`
+/// enforce exactly the same invariants and cannot drift apart. It performs, in
+/// order:
+///
+/// 1. **Duplicate-code check** (only when `is_new`): rejects a rule whose
+///    `ERRULE_CODE` already exists.
+/// 2. **Fragment / disqualifier existence**: any non-empty `QUAL_ERFRAG_CODE`
+///    or `DISQ_ERFRAG_CODE` must name an existing `CFG_ERFRAG` row.
+/// 3. **RESOLVE / RELATE domain**: each must be `Yes`/`No` (case-insensitive);
+///    the returned row is normalised to title-case.
+/// 4. **Mutual exclusivity**: a rule may not both resolve and relate.
+/// 5. **RTYPE_ID coherence**: `RESOLVE=Yes` auto-corrects `RTYPE_ID` to `1`;
+///    `RELATE=Yes` requires `RTYPE_ID` in `[2, 3, 4]`.
+///
+/// On success it returns a normalised copy of the row (title-cased
+/// RESOLVE/RELATE and any auto-corrected RTYPE_ID). It never mutates the config.
+///
+/// This validates the existence of **every** fragment/disqualifier code present
+/// on the row, so it is the entry point used by `add_rule` (which validates the
+/// whole new row). `set_rule` instead validates only the codes it is changing
+/// via [`validate_fragment_code`] and composes [`validate_rule_row_core`] for the
+/// remaining invariants, so a code carried over unchanged is never re-validated.
+pub(crate) fn validate_rule_row(
+    config: &Value,
+    row: &ErruleRow,
+    is_new: bool,
+) -> Result<ErruleRow> {
+    // Fragment / disqualifier existence for every code on the row.
+    validate_fragment_code(config, row.qual_erfrag_code.as_deref(), "Fragment")?;
+    validate_fragment_code(config, row.disq_erfrag_code.as_deref(), "Disqualifier")?;
+
+    // Remaining invariants (dup code, domains, exclusivity, RTYPE_ID coherence).
+    validate_rule_row_core(config, row, is_new)
 }
 
 // ============================================================================
@@ -259,11 +285,20 @@ impl<'a> TryFrom<&'a Value> for SetRuleParams<'a> {
 /// # Arguments
 ///
 /// * `config_json` - Configuration JSON string
+/// * `id` - Desired `ERRULE_ID`: `0` (or any non-positive value) auto-assigns
+///   the next available id (seeded at 1000 for user rules); a positive value is
+///   honoured, or rejected with `AlreadyExists` if already taken.
 /// * `rule_config` - JSON configuration for the rule (must include ERRULE_CODE)
 ///
 /// # Returns
 ///
-/// Returns `(modified_config, new_rule_id)` tuple on success
+/// Returns `(modified_config, new_rule_id)` on success, where `new_rule_id` is
+/// the id actually assigned.
+///
+/// The proposed row is run through the shared rule validator, so `add_rule`
+/// rejects a duplicate code, an unknown fragment/disqualifier, an invalid
+/// RESOLVE/RELATE value, a rule that both resolves and relates, and an
+/// incoherent RTYPE_ID — exactly as `set_rule` does.
 ///
 /// # Example
 ///
@@ -278,7 +313,7 @@ impl<'a> TryFrom<&'a Value> for SetRuleParams<'a> {
 ///     "RELATE": "No",
 ///     "RTYPE_ID": 1
 /// });
-/// // ID parameter is required (0 for auto-assign, >0 for specific ID)
+/// // Pass 0 to auto-assign the next id, or a positive value for a specific id.
 /// let (_modified, _rule_id) = rules::add_rule(config, 0, &rule_config).unwrap();
 /// ```
 pub fn add_rule(config_json: &str, id: i64, rule_config: &Value) -> Result<(String, i64)> {
@@ -287,30 +322,34 @@ pub fn add_rule(config_json: &str, id: i64, rule_config: &Value) -> Result<(Stri
         .and_then(|v| v.as_str())
         .ok_or_else(|| SzConfigError::MissingField("ERRULE_CODE".to_string()))?;
 
-    // Validate ID not already taken
     let config_data: Value = serde_json::from_str(config_json)?;
-    if let Some(errule_array) = config_data
+
+    // Resolve the ERRULE_ID: id 0 (or non-positive) auto-assigns the next id
+    // (seeded at 1000 for user-created rules, matching the other add_* paths);
+    // a specific positive id is honoured, or rejected if already taken.
+    let empty: Vec<Value> = Vec::new();
+    let errule_array = config_data
         .get("G2_CONFIG")
         .and_then(|g| g.get("CFG_ERRULE"))
         .and_then(|v| v.as_array())
-        && errule_array
-            .iter()
-            .any(|item| item.get("ERRULE_ID").and_then(|v| v.as_i64()) == Some(id))
-    {
-        return Err(SzConfigError::AlreadyExists(
-            "The specified ID is already taken".to_string(),
-        ));
-    }
+        .unwrap_or(&empty);
+    let desired = if id > 0 { Some(id) } else { None };
+    let assigned_id = helpers::get_desired_or_next_id(errule_array, "ERRULE_ID", desired, 1000)?;
 
     // Build a complete row via ErruleRow so every CFG_ERRULE key is present
     // (optional fields serialize as null) regardless of what the caller passed.
-    let row = ErruleRow::from_config(id, code.to_uppercase(), rule_config);
-    let new_item = serde_json::to_value(&row)?;
+    let row = ErruleRow::from_config(assigned_id, code.to_uppercase(), rule_config);
+
+    // Validate the whole new row through the shared validator (dup code,
+    // fragment/disqualifier existence, RESOLVE/RELATE domain + exclusivity,
+    // RTYPE_ID coherence). Returns the normalised row.
+    let validated = validate_rule_row(&config_data, &row, true)?;
+    let new_item = serde_json::to_value(&validated)?;
 
     // Add to config
     let modified_json = helpers::add_to_config_array(config_json, "CFG_ERRULE", new_item)?;
 
-    Ok((modified_json, id))
+    Ok((modified_json, assigned_id))
 }
 
 /// Delete a rule from the configuration
@@ -489,80 +528,19 @@ pub fn list_rules(config_json: &str) -> Result<Vec<Value>> {
 pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
     let code = params.code.to_uppercase();
 
+    let config_data: Value = serde_json::from_str(config_json)?;
+
     // Get existing rule to validate and merge updates
     let existing_rule =
         helpers::find_in_config_array(config_json, "CFG_ERRULE", "ERRULE_CODE", &code)?
             .ok_or_else(|| SzConfigError::NotFound(format!("Rule not found: {code}")))?;
 
-    // Validate NEW fragment if being updated (line 4683-4686)
-    if let Some(frag) = params.fragment {
-        let frag_upper = frag.to_uppercase();
-        helpers::find_in_config_array(config_json, "CFG_ERFRAG", "ERFRAG_CODE", &frag_upper)?
-            .ok_or_else(|| SzConfigError::NotFound(format!("Fragment '{frag_upper}' not found")))?;
-    }
-
-    // Validate NEW disqualifier if being updated (line 4688-4692)
-    if let Some(disq) = params.disqualifier {
-        let disq_upper = disq.to_uppercase();
-        helpers::find_in_config_array(config_json, "CFG_ERFRAG", "ERFRAG_CODE", &disq_upper)?
-            .ok_or_else(|| SzConfigError::NotFound(format!("Fragment '{disq_upper}' not found")))?;
-    }
-
-    // Determine final RESOLVE value (from params or existing)
-    let resolve_value = params
-        .resolve
-        .or_else(|| existing_rule.get("RESOLVE").and_then(|v| v.as_str()))
-        .unwrap_or("No");
-
-    // CHECK 3: RESOLVE domain validation (line 4694-4697)
-    let resolve_upper = resolve_value.to_uppercase();
-    if resolve_upper != "YES" && resolve_upper != "NO" {
-        return Err(SzConfigError::InvalidInput(
-            "resolve value must be in [\"Yes\", \"No\"]".to_string(),
-        ));
-    }
-    let final_resolve = if resolve_upper == "YES" { "Yes" } else { "No" };
-
-    // Determine final RELATE value (from params or existing)
-    let relate_value = params
-        .relate
-        .or_else(|| existing_rule.get("RELATE").and_then(|v| v.as_str()))
-        .unwrap_or("No");
-
-    // CHECK 4: RELATE domain validation (line 4699-4702)
-    let relate_upper = relate_value.to_uppercase();
-    if relate_upper != "YES" && relate_upper != "NO" {
-        return Err(SzConfigError::InvalidInput(
-            "relate value must be in [\"Yes\", \"No\"]".to_string(),
-        ));
-    }
-    let final_relate = if relate_upper == "YES" { "Yes" } else { "No" };
-
-    // CHECK 5: Can't have both RESOLVE=Yes AND RELATE=Yes (line 4704-4709)
-    if final_resolve == "Yes" && final_relate == "Yes" {
-        return Err(SzConfigError::InvalidInput(
-            "A rule must either resolve or relate, please set the other to No".to_string(),
-        ));
-    }
-
-    // Determine final RTYPE_ID (from params or existing)
-    let mut final_rtype_id = params
-        .rtype_id
-        .or_else(|| existing_rule.get("RTYPE_ID").and_then(|v| v.as_i64()))
-        .unwrap_or(1);
-
-    // AUTO-CORRECT: RESOLVE=Yes forces RTYPE_ID to 1 (Python line 4722-4725)
-    // "just do it without making them wonder"
-    if final_resolve == "Yes" && final_rtype_id != 1 {
-        final_rtype_id = 1;
-    }
-
-    // CHECK 8: RELATE=Yes requires RTYPE_ID in [2, 3, 4] (line 4731-4736)
-    if final_relate == "Yes" && ![2, 3, 4].contains(&final_rtype_id) {
-        return Err(SzConfigError::InvalidInput(
-            "Relationship type (RTYPE_ID) must be set to either 2=Possible match or 3=Possibly related".to_string(),
-        ));
-    }
+    // Validate ONLY the fragment/disqualifier being changed. A code carried over
+    // unchanged from the existing rule is never re-validated, preserving the
+    // historical set_rule contract (do not newly reject previously-accepted
+    // input). add_rule, by contrast, validates every code on the new row.
+    validate_fragment_code(&config_data, params.fragment, "Fragment")?;
+    validate_fragment_code(&config_data, params.disqualifier, "Disqualifier")?;
 
     // Extract ERRULE_ID from existing rule to preserve it
     let errule_id = existing_rule
@@ -570,16 +548,29 @@ pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
-    // Build the complete row. Optional fields not supplied in `params` fall back
-    // to the existing value (which may itself be null). Because ErruleRow always
-    // serializes every key (None -> null), the resulting object can never be
-    // missing a key the engine config loader requires.
+    // Build the merged row from params (or the existing value where a field is
+    // not being updated). RESOLVE/RELATE domain, exclusivity and RTYPE_ID
+    // coherence are enforced and normalised by the shared validator core below,
+    // so add_rule and set_rule cannot drift on those rules. Because ErruleRow
+    // always serializes every key (None -> null), the resulting object can never
+    // be missing a key the engine config loader requires.
     let row = ErruleRow {
         errule_id,
         errule_code: code.clone(),
-        resolve: final_resolve.to_string(),
-        relate: final_relate.to_string(),
-        rtype_id: final_rtype_id,
+        resolve: params
+            .resolve
+            .or_else(|| existing_rule.get("RESOLVE").and_then(|v| v.as_str()))
+            .unwrap_or("No")
+            .to_string(),
+        relate: params
+            .relate
+            .or_else(|| existing_rule.get("RELATE").and_then(|v| v.as_str()))
+            .unwrap_or("No")
+            .to_string(),
+        rtype_id: params
+            .rtype_id
+            .or_else(|| existing_rule.get("RTYPE_ID").and_then(|v| v.as_i64()))
+            .unwrap_or(1),
         qual_erfrag_code: params
             .fragment
             .map(str::to_uppercase)
@@ -592,7 +583,11 @@ pub fn set_rule(config_json: &str, params: SetRuleParams) -> Result<String> {
             .tier
             .or_else(|| existing_rule.get("ERRULE_TIER").and_then(|v| v.as_i64())),
     };
-    let updated_item = serde_json::to_value(&row)?;
+
+    // Enforce/normalise the non-fragment invariants (is_new=false skips the
+    // duplicate-code check, since an update targets an existing code).
+    let validated = validate_rule_row_core(&config_data, &row, false)?;
+    let updated_item = serde_json::to_value(&validated)?;
 
     // Update the item in the config
     helpers::update_in_config_array(
@@ -799,7 +794,8 @@ mod tests {
         row.qual_erfrag_code = Some("NOPE".to_string());
         let err = validate_rule_row(&cfg, &row, true).unwrap_err();
         assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
-        assert!(err.to_string().contains("Fragment 'NOPE' not found"));
+        // Double-quoted wording (D13, Python parity).
+        assert!(err.to_string().contains("Fragment \"NOPE\" not found"));
     }
 
     #[test]
@@ -809,6 +805,8 @@ mod tests {
         row.disq_erfrag_code = Some("NOPE".to_string());
         let err = validate_rule_row(&cfg, &row, true).unwrap_err();
         assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+        // Disqualifier uses its own label, double-quoted.
+        assert!(err.to_string().contains("Disqualifier \"NOPE\" not found"));
     }
 
     #[test]
@@ -867,5 +865,170 @@ mod tests {
 
         row.rtype_id = 2; // valid
         assert!(validate_rule_row(&cfg, &row, true).is_ok());
+    }
+
+    #[test]
+    fn test_validate_rule_row_relate_accepts_rtype_4() {
+        // The RELATE domain is [2, 3, 4]; 4 must be accepted (reconciled wording).
+        let cfg = validator_config();
+        let mut row = base_row();
+        row.relate = "Yes".to_string();
+        row.rtype_id = 4;
+        assert!(validate_rule_row(&cfg, &row, true).is_ok());
+    }
+
+    // ------------------------------------------------------------------
+    // add_rule / set_rule wiring + parity (#39, Wave 2c)
+    // ------------------------------------------------------------------
+
+    fn add_rule_config() -> &'static str {
+        r#"{"G2_CONFIG": {
+            "CFG_ERRULE": [
+                {"ERRULE_ID": 100, "ERRULE_CODE": "EXISTING", "RESOLVE": "Yes",
+                 "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "FRAG_A",
+                 "DISQ_ERFRAG_CODE": null, "ERRULE_TIER": 10}
+            ],
+            "CFG_ERFRAG": [
+                {"ERFRAG_ID": 1, "ERFRAG_CODE": "FRAG_A"},
+                {"ERFRAG_ID": 2, "ERFRAG_CODE": "FRAG_B"}
+            ]
+        }}"#
+    }
+
+    #[test]
+    fn test_add_rule_rejects_duplicate_code() {
+        let cfg = add_rule_config();
+        let rule = json!({"ERRULE_CODE": "existing", "RESOLVE": "No", "RELATE": "No"});
+        let err = add_rule(cfg, 0, &rule).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn test_add_rule_rejects_bad_fragment() {
+        let cfg = add_rule_config();
+        let rule = json!({"ERRULE_CODE": "NEW", "RESOLVE": "No", "RELATE": "No",
+            "QUAL_ERFRAG_CODE": "NOPE"});
+        let err = add_rule(cfg, 0, &rule).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+        assert!(err.to_string().contains("Fragment \"NOPE\" not found"));
+    }
+
+    #[test]
+    fn test_add_rule_rejects_bad_disqualifier() {
+        let cfg = add_rule_config();
+        let rule = json!({"ERRULE_CODE": "NEW", "RESOLVE": "No", "RELATE": "No",
+            "DISQ_ERFRAG_CODE": "NOPE"});
+        let err = add_rule(cfg, 0, &rule).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+        assert!(err.to_string().contains("Disqualifier \"NOPE\" not found"));
+    }
+
+    #[test]
+    fn test_add_rule_rejects_resolve_and_relate_both_yes() {
+        let cfg = add_rule_config();
+        let rule = json!({"ERRULE_CODE": "NEW", "RESOLVE": "Yes", "RELATE": "Yes",
+            "RTYPE_ID": 2});
+        let err = add_rule(cfg, 0, &rule).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+        assert!(err.to_string().contains("either resolve or relate"));
+    }
+
+    #[test]
+    fn test_add_rule_rejects_incoherent_rtype_for_relate() {
+        let cfg = add_rule_config();
+        // RELATE=Yes with RTYPE_ID=1 is incoherent.
+        let rule = json!({"ERRULE_CODE": "NEW", "RESOLVE": "No", "RELATE": "Yes",
+            "RTYPE_ID": 1});
+        let err = add_rule(cfg, 0, &rule).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+    }
+
+    /// Drift guard: add_rule and set_rule must reject the same invalid row. Here
+    /// a bad *new* fragment is supplied to both entry points.
+    #[test]
+    fn test_add_and_set_rule_reject_same_invalid_row() {
+        let cfg = add_rule_config();
+
+        // add_rule: new rule naming a non-existent fragment.
+        let add_row = json!({"ERRULE_CODE": "NEW", "RESOLVE": "No", "RELATE": "No",
+            "QUAL_ERFRAG_CODE": "GHOST"});
+        let add_err = add_rule(cfg, 0, &add_row).unwrap_err();
+
+        // set_rule: existing rule updated to name the same non-existent fragment.
+        let set_params = SetRuleParams {
+            code: "EXISTING",
+            resolve: None,
+            relate: None,
+            rtype_id: None,
+            fragment: Some("GHOST"),
+            disqualifier: None,
+            tier: None,
+        };
+        let set_err = set_rule(cfg, set_params).unwrap_err();
+
+        assert_eq!(add_err.kind(), crate::error::SzErrorKind::NotFound);
+        assert_eq!(set_err.kind(), crate::error::SzErrorKind::NotFound);
+        assert_eq!(add_err.to_string(), set_err.to_string());
+    }
+
+    /// Regression: set_rule must NOT re-validate a fragment/disqualifier carried
+    /// over unchanged. Here the existing rule points at a fragment that has since
+    /// been removed from CFG_ERFRAG; a no-fragment update must still succeed.
+    #[test]
+    fn test_set_rule_does_not_revalidate_carried_over_fragment() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_ERRULE": [
+                {"ERRULE_ID": 100, "ERRULE_CODE": "ORPHAN", "RESOLVE": "Yes",
+                 "RELATE": "No", "RTYPE_ID": 1, "QUAL_ERFRAG_CODE": "GONE",
+                 "DISQ_ERFRAG_CODE": "ALSO_GONE", "ERRULE_TIER": 10}
+            ],
+            "CFG_ERFRAG": []
+        }}"#;
+
+        // Change only RESOLVE; fragment/disqualifier are carried over unchanged
+        // and must not be re-validated (they no longer exist).
+        let params = SetRuleParams {
+            code: "ORPHAN",
+            resolve: Some("No"),
+            relate: None,
+            rtype_id: None,
+            fragment: None,
+            disqualifier: None,
+            tier: None,
+        };
+        let modified = set_rule(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let rule = &value["G2_CONFIG"]["CFG_ERRULE"][0];
+        assert_eq!(rule["RESOLVE"], json!("No"));
+        assert_eq!(rule["QUAL_ERFRAG_CODE"], json!("GONE"));
+        assert_eq!(rule["DISQ_ERFRAG_CODE"], json!("ALSO_GONE"));
+    }
+
+    #[test]
+    fn test_add_rule_auto_assigns_id() {
+        // Empty rule table -> first user id seeds at 1000.
+        let config = r#"{"G2_CONFIG": {"CFG_ERRULE": []}}"#;
+        let rule = json!({"ERRULE_CODE": "R1", "RESOLVE": "No", "RELATE": "No"});
+        let (modified, id) = add_rule(config, 0, &rule).unwrap();
+        assert_eq!(id, 1000);
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(
+            value["G2_CONFIG"]["CFG_ERRULE"][0]["ERRULE_ID"],
+            json!(1000)
+        );
+
+        // A specific positive id is honoured.
+        let rule2 = json!({"ERRULE_CODE": "R2", "RESOLVE": "No", "RELATE": "No"});
+        let (_m2, id2) = add_rule(&modified, 2000, &rule2).unwrap();
+        assert_eq!(id2, 2000);
+    }
+
+    #[test]
+    fn test_add_rule_rejects_taken_id() {
+        let cfg = add_rule_config();
+        let rule = json!({"ERRULE_CODE": "NEW", "RESOLVE": "No", "RELATE": "No"});
+        // id 100 is already taken by EXISTING.
+        let err = add_rule(cfg, 100, &rule).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,104 @@
+//! Configuration settings operations.
+//!
+//! Manages the `G2_CONFIG.SETTINGS` object — a flat map of named settings keyed
+//! by an upper-cased setting name. This is distinct from the `CFG_*` array
+//! sections and is created lazily the first time a setting is written.
+
+use crate::error::{Result, SzConfigError};
+use serde_json::{Value, json};
+
+/// Set (create or overwrite) a named configuration setting.
+///
+/// The `SETTINGS` object under `G2_CONFIG` is created if absent. The `name` is
+/// upper-cased before use, and an existing setting of the same name is
+/// overwritten silently. No validation is applied to `value` — it is stored
+/// verbatim as a JSON string.
+///
+/// # Arguments
+/// * `config_json` - JSON configuration string
+/// * `name` - Setting name (upper-cased before storing)
+/// * `value` - Setting value (stored as a JSON string, unvalidated)
+///
+/// # Returns
+/// Modified configuration JSON string
+///
+/// # Errors
+/// - `JsonParse` if `config_json` is invalid
+/// - `MissingSection` if the top-level `G2_CONFIG` object is absent
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::settings::set_setting;
+///
+/// let config = r#"{"G2_CONFIG": {}}"#;
+/// let updated = set_setting(config, "my_setting", "42")?;
+/// assert!(updated.contains("MY_SETTING"));
+/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// ```
+pub fn set_setting(config_json: &str, name: &str, value: &str) -> Result<String> {
+    let mut config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let g2_config = config
+        .get_mut("G2_CONFIG")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| SzConfigError::MissingSection("G2_CONFIG".to_string()))?;
+
+    // Create SETTINGS as an object if absent (or if a non-object placeholder is
+    // present, replace it with a fresh object).
+    let settings_is_object = g2_config
+        .get("SETTINGS")
+        .map(|v| v.is_object())
+        .unwrap_or(false);
+    if !settings_is_object {
+        g2_config.insert("SETTINGS".to_string(), json!({}));
+    }
+
+    let settings = g2_config
+        .get_mut("SETTINGS")
+        .and_then(|v| v.as_object_mut())
+        .expect("SETTINGS object was just ensured");
+
+    settings.insert(name.to_uppercase(), json!(value));
+
+    serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_setting_creates_section() {
+        let config = r#"{"G2_CONFIG": {}}"#;
+        let modified = set_setting(config, "foo", "bar").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(value["G2_CONFIG"]["SETTINGS"]["FOO"], json!("bar"));
+    }
+
+    #[test]
+    fn test_set_setting_uppercases_name() {
+        let config = r#"{"G2_CONFIG": {"SETTINGS": {}}}"#;
+        let modified = set_setting(config, "MixedCase", "v").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(value["G2_CONFIG"]["SETTINGS"]["MIXEDCASE"], json!("v"));
+        assert!(value["G2_CONFIG"]["SETTINGS"].get("MixedCase").is_none());
+    }
+
+    #[test]
+    fn test_set_setting_overwrites_silently() {
+        let config = r#"{"G2_CONFIG": {"SETTINGS": {"FOO": "old"}}}"#;
+        let modified = set_setting(config, "foo", "new").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(value["G2_CONFIG"]["SETTINGS"]["FOO"], json!("new"));
+        // Exactly one entry — overwrite, not append.
+        assert_eq!(value["G2_CONFIG"]["SETTINGS"].as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_set_setting_missing_g2_config() {
+        let config = r#"{}"#;
+        let err = set_setting(config, "foo", "bar").unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::MissingSection);
+    }
+}

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -962,11 +962,35 @@ pub fn set_generic_threshold(
 
 /// List all generic thresholds with resolved names
 ///
+/// The rows are sorted inside the SDK by `(GPLAN_ID, behaviour-code position)` —
+/// the behaviour order coming from [`crate::behavior_domain::behavior_position`]
+/// — so callers never need to re-sort or reverse-map the plan code to its id. The
+/// projection carries `id` (the `GPLAN_ID`), previously absent.
+///
 /// # Arguments
 /// * `config_json` - JSON configuration string
 ///
 /// # Returns
-/// Vector of JSON Values with plan, behavior, feature, candidateCap, scoringCap, and sendToRedo fields
+/// Vector of JSON Values with id, plan, behavior, feature, candidateCap, scoringCap, and sendToRedo fields
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::thresholds::list_generic_thresholds;
+/// let config = r#"{"G2_CONFIG": {
+///     "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+///     "CFG_FTYPE": [],
+///     "CFG_GENERIC_THRESHOLD": [
+///         {"GPLAN_ID": 1, "BEHAVIOR": "F1", "FTYPE_ID": 0, "CANDIDATE_CAP": 10,
+///          "SCORING_CAP": -1, "SEND_TO_REDO": "Yes"},
+///         {"GPLAN_ID": 1, "BEHAVIOR": "NAME", "FTYPE_ID": 0, "CANDIDATE_CAP": 10,
+///          "SCORING_CAP": -1, "SEND_TO_REDO": "Yes"}
+///     ]
+/// }}"#;
+/// let rows = list_generic_thresholds(config).unwrap();
+/// // NAME sorts before F1 despite being stored second.
+/// assert_eq!(rows[0]["behavior"], "NAME");
+/// assert_eq!(rows[0]["id"], 1);
+/// ```
 pub fn list_generic_thresholds(config_json: &str) -> Result<Vec<Value>> {
     let config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
@@ -983,8 +1007,21 @@ pub fn list_generic_thresholds(config_json: &str) -> Result<Vec<Value>> {
         .as_array()
         .ok_or_else(|| SzConfigError::MissingSection("CFG_FTYPE".to_string()))?;
 
-    let result: Vec<Value> = gthresh_array
-        .iter()
+    // Sort the raw rows by (GPLAN_ID, behaviour-code position) before projection
+    // so the numeric sort key is never lost. The behaviour-code order comes from
+    // the SDK-owned canonical domain (behavior_domain::behavior_position); an
+    // unrecognised behaviour sorts last. sort_by_key is stable, so per-feature
+    // rows sharing a (plan, behaviour) keep their stored relative order.
+    let mut sorted: Vec<&Value> = gthresh_array.iter().collect();
+    sorted.sort_by_key(|item| {
+        let gplan_id = item["GPLAN_ID"].as_i64().unwrap_or(0);
+        let behavior = item["BEHAVIOR"].as_str().unwrap_or("");
+        let pos = crate::behavior_domain::behavior_position(behavior).unwrap_or(usize::MAX);
+        (gplan_id, pos)
+    });
+
+    let result: Vec<Value> = sorted
+        .into_iter()
         .map(|item| {
             let gplan_id = item["GPLAN_ID"].as_i64().unwrap_or(0);
             let ftype_id = item["FTYPE_ID"].as_i64().unwrap_or(0);
@@ -1009,7 +1046,11 @@ pub fn list_generic_thresholds(config_json: &str) -> Result<Vec<Value>> {
                     .to_string()
             };
 
+            // `id` carries the GPLAN_ID: generic-threshold rows have no single
+            // surrogate key, and the plan id is the numeric key callers need to
+            // sort/round-trip (previously reverse-mapped from `plan`).
             json!({
+                "id": gplan_id,
                 "plan": plan,
                 "behavior": item["BEHAVIOR"].as_str().unwrap_or(""),
                 "feature": feature,
@@ -1336,5 +1377,34 @@ mod tests {
         let err =
             delete_comparison_threshold(config, "GNR_COMP", "NAME", "CLOSE_SCORE").unwrap_err();
         assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_list_generic_thresholds_carries_id_and_sorts_by_behavior() {
+        // Stored order deliberately differs from (GPLAN_ID, behaviour-position):
+        // within plan 1, FF is stored before NAME/F1; plan 2 stored before plan 1.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [
+                {"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"},
+                {"GPLAN_ID": 2, "GPLAN_CODE": "SEARCH"}
+            ],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_GENERIC_THRESHOLD": [
+                {"GPLAN_ID": 2, "BEHAVIOR": "F1", "FTYPE_ID": 0, "CANDIDATE_CAP": 5, "SCORING_CAP": 5, "SEND_TO_REDO": "Yes"},
+                {"GPLAN_ID": 1, "BEHAVIOR": "FF", "FTYPE_ID": 0, "CANDIDATE_CAP": 20, "SCORING_CAP": 20, "SEND_TO_REDO": "No"},
+                {"GPLAN_ID": 1, "BEHAVIOR": "NAME", "FTYPE_ID": 0, "CANDIDATE_CAP": 10, "SCORING_CAP": -1, "SEND_TO_REDO": "Yes"},
+                {"GPLAN_ID": 1, "BEHAVIOR": "F1", "FTYPE_ID": 0, "CANDIDATE_CAP": 5, "SCORING_CAP": 5, "SEND_TO_REDO": "Yes"}
+            ]
+        }}"#;
+
+        let rows = list_generic_thresholds(config).unwrap();
+        // Plan 1 first (all its rows), each carrying id = GPLAN_ID, in behaviour
+        // order NAME < F1 < FF; then plan 2.
+        assert_eq!(rows[0]["id"], json!(1));
+        assert_eq!(rows[0]["behavior"], json!("NAME"));
+        assert_eq!(rows[1]["behavior"], json!("F1"));
+        assert_eq!(rows[2]["behavior"], json!("FF"));
+        assert_eq!(rows[3]["id"], json!(2));
+        assert_eq!(rows[3]["behavior"], json!("F1"));
     }
 }

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -251,6 +251,36 @@ impl<'a> TryFrom<&'a Value> for DeleteGenericThresholdParams<'a> {
     }
 }
 
+// ============================================================================
+// Shared local helpers
+// ============================================================================
+
+/// Resolve a feature code to its `FTYPE_ID`, treating `"all"` (case-insensitive)
+/// as the `0` sentinel that means "all features".
+///
+/// Used as a *lookup* key by the threshold add/set/delete paths.
+fn resolve_ftype_id_or_all(config_json: &str, feature: &str) -> Result<i64> {
+    if feature.eq_ignore_ascii_case("all") {
+        Ok(0)
+    } else {
+        helpers::lookup_feature_id(config_json, feature)
+    }
+}
+
+/// Canonicalise a `sendToRedo` value to the title-case form stored on disk.
+///
+/// Accepts `"Yes"`/`"No"` in any case and returns the canonical `"Yes"`/`"No"`.
+/// Any other value is rejected as invalid input.
+fn send_to_redo_canonical(value: &str) -> Result<&'static str> {
+    match value.to_uppercase().as_str() {
+        "YES" => Ok("Yes"),
+        "NO" => Ok("No"),
+        _ => Err(SzConfigError::InvalidInput(format!(
+            "Invalid sendToRedo value '{value}'. Must be 'Yes' or 'No'"
+        ))),
+    }
+}
+
 // ===== Comparison Thresholds (CFG_CFRTN) =====
 
 /// Add a new comparison threshold (CFG_CFRTN record)
@@ -461,53 +491,51 @@ pub(crate) fn delete_comparison_threshold_by_id(
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
 
+/// Delete a comparison threshold (CFG_CFRTN record)
+///
+/// Matches on the full three-key identity of a comparison threshold:
+/// `(CFUNC_ID, FTYPE_ID, CFUNC_RTNVAL)`. `cfunc_rtnval` is matched
+/// case-insensitively (mirroring [`set_comparison_threshold`]), and
+/// `ftype_code = "all"` resolves to the `FTYPE_ID` `0` sentinel.
+///
+/// # Arguments
+/// * `config_json` - JSON configuration string
+/// * `cfunc_code` - Comparison function code
+/// * `ftype_code` - Feature code, or `"all"` for the all-features (0) sentinel
+/// * `cfunc_rtnval` - Return value / score name (matched case-insensitively)
+///
+/// # Returns
+/// Modified configuration JSON string
 pub fn delete_comparison_threshold(
     config_json: &str,
     cfunc_code: &str,
     ftype_code: &str,
+    cfunc_rtnval: &str,
 ) -> Result<String> {
     let cfunc_id = helpers::lookup_cfunc_id(config_json, cfunc_code)?;
-    let ftype_id = helpers::lookup_feature_id(config_json, ftype_code)?;
-
-    // Find the CFRTN_ID for this combination
-    let config_lookup: Value =
-        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
-
-    let cfrtn_array = config_lookup["G2_CONFIG"]["CFG_CFRTN"]
-        .as_array()
-        .ok_or_else(|| SzConfigError::MissingSection("CFG_CFRTN".to_string()))?;
-
-    let cfrtn_id = cfrtn_array
-        .iter()
-        .find(|item| {
-            item["CFUNC_ID"].as_i64() == Some(cfunc_id)
-                && item["FTYPE_ID"].as_i64() == Some(ftype_id)
-        })
-        .and_then(|item| item["CFRTN_ID"].as_i64())
-        .ok_or_else(|| {
-            SzConfigError::NotFound(format!(
-                "Comparison threshold for cfunc='{cfunc_code}', ftype='{ftype_code}'"
-            ))
-        })?;
+    let ftype_id = resolve_ftype_id_or_all(config_json, ftype_code)?;
 
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    let mut found = false;
+    let cfrtn_array = config["G2_CONFIG"]["CFG_CFRTN"]
+        .as_array_mut()
+        .ok_or_else(|| SzConfigError::MissingSection("CFG_CFRTN".to_string()))?;
 
-    if let Some(cfrtn_array) = config["G2_CONFIG"]["CFG_CFRTN"].as_array_mut() {
-        cfrtn_array.retain(|item| {
-            let matches = item["CFRTN_ID"].as_i64() == Some(cfrtn_id);
-            if matches {
-                found = true;
-            }
-            !matches
-        });
-    }
+    let original_len = cfrtn_array.len();
+    cfrtn_array.retain(|item| {
+        let matches = item["CFUNC_ID"].as_i64() == Some(cfunc_id)
+            && item["FTYPE_ID"].as_i64() == Some(ftype_id)
+            && item["CFUNC_RTNVAL"]
+                .as_str()
+                .map(|s| s.eq_ignore_ascii_case(cfunc_rtnval))
+                .unwrap_or(false);
+        !matches
+    });
 
-    if !found {
+    if cfrtn_array.len() == original_len {
         return Err(SzConfigError::NotFound(format!(
-            "Comparison threshold: {cfrtn_id}"
+            "Comparison threshold for cfunc='{cfunc_code}', ftype='{ftype_code}', rtnval='{cfunc_rtnval}'"
         )));
     }
 
@@ -727,15 +755,10 @@ pub fn add_generic_threshold(
 
     let plan_upper = plan.to_uppercase();
     let behavior_upper = behavior.to_uppercase();
-    let redo_upper = send_to_redo.to_uppercase();
     let feature_upper = params.feature.unwrap_or("ALL").to_uppercase();
 
-    // Validate sendToRedo
-    if redo_upper != "YES" && redo_upper != "NO" {
-        return Err(SzConfigError::InvalidInput(format!(
-            "Invalid sendToRedo value '{send_to_redo}'. Must be 'Yes' or 'No'"
-        )));
-    }
+    // Validate sendToRedo and store the canonical title-case form ("Yes"/"No").
+    let redo_canonical = send_to_redo_canonical(send_to_redo)?;
 
     // Lookup plan ID
     let gplan_array = config["G2_CONFIG"]["CFG_GPLAN"]
@@ -786,7 +809,7 @@ pub fn add_generic_threshold(
         ftype_id,
         candidate_cap,
         scoring_cap,
-        send_to_redo: redo_upper,
+        send_to_redo: redo_canonical.to_string(),
     };
     let new_threshold = serde_json::to_value(&row)?;
 
@@ -885,6 +908,17 @@ pub fn set_generic_threshold(
 
     let gplan_id = helpers::lookup_gplan_id(config_json, plan)?;
 
+    // The feature selects WHICH per-feature row to edit; it is a lookup key,
+    // never a value to write. Defaults to the all-features (0) sentinel.
+    let ftype_id = resolve_ftype_id_or_all(config_json, params.feature.unwrap_or("ALL"))?;
+
+    // Canonicalise sendToRedo up front so an invalid value is rejected before
+    // any mutation (case-insensitive validation, title-case storage).
+    let redo_canonical = match params.send_to_redo {
+        Some(v) => Some(send_to_redo_canonical(v)?),
+        None => None,
+    };
+
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
@@ -894,33 +928,32 @@ pub fn set_generic_threshold(
         .as_array_mut()
         .ok_or_else(|| SzConfigError::MissingSection("CFG_GENERIC_THRESHOLD".to_string()))?;
 
+    // Match on the FULL triple (GPLAN_ID, BEHAVIOR, FTYPE_ID) so per-feature
+    // rows that share a (plan, behaviour) are distinguished by feature.
     let gthresh = gthresh_array
         .iter_mut()
         .find(|item| {
             item["GPLAN_ID"].as_i64() == Some(gplan_id)
                 && item["BEHAVIOR"].as_str() == Some(behavior_upper.as_str())
+                && item["FTYPE_ID"].as_i64() == Some(ftype_id)
         })
         .ok_or_else(|| {
             SzConfigError::NotFound(format!(
-                "Generic threshold not found: GPLAN_ID={gplan_id}, BEHAVIOR={behavior_upper}"
+                "Generic threshold not found: GPLAN_ID={gplan_id}, BEHAVIOR={behavior_upper}, FTYPE_ID={ftype_id}"
             ))
         })?;
 
     // In-place update of a complete existing row; all keys preserved.
-    // Update fields from params
+    // FTYPE_ID is a lookup key and must never be overwritten here.
     if let Some(dest_obj) = gthresh.as_object_mut() {
-        if let Some(feature_code) = params.feature {
-            let new_ftype_id = helpers::lookup_feature_id(config_json, feature_code)?;
-            dest_obj.insert("FTYPE_ID".to_string(), json!(new_ftype_id));
-        }
         if let Some(cap) = params.candidate_cap {
             dest_obj.insert("CANDIDATE_CAP".to_string(), json!(cap));
         }
         if let Some(cap) = params.scoring_cap {
             dest_obj.insert("SCORING_CAP".to_string(), json!(cap));
         }
-        if let Some(redo) = params.send_to_redo {
-            dest_obj.insert("SEND_TO_REDO".to_string(), json!(redo.to_uppercase()));
+        if let Some(redo) = redo_canonical {
+            dest_obj.insert("SEND_TO_REDO".to_string(), json!(redo));
         }
     }
 
@@ -1129,6 +1162,179 @@ mod tests {
         assert_eq!(row["FTYPE_ID"], json!(0));
         assert_eq!(row["CANDIDATE_CAP"], json!(10));
         assert_eq!(row["SCORING_CAP"], json!(20));
-        assert_eq!(row["SEND_TO_REDO"], json!("NO"));
+        // Canonical storage is title-case "No", not "NO".
+        assert_eq!(row["SEND_TO_REDO"], json!("No"));
+    }
+
+    #[test]
+    fn test_add_generic_threshold_send_to_redo_yes_title_case() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+            "CFG_GENERIC_THRESHOLD": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}]
+        }}"#;
+
+        // Lower-case input must be accepted and stored title-case.
+        let params = AddGenericThresholdParams::new("INGEST", "NAME", 20, 10, "yes");
+        let modified = add_generic_threshold(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let row = &value["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"][0];
+        assert_eq!(row["SEND_TO_REDO"], json!("Yes"));
+    }
+
+    #[test]
+    fn test_add_generic_threshold_rejects_unknown_send_to_redo() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+            "CFG_GENERIC_THRESHOLD": [],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}]
+        }}"#;
+
+        let params = AddGenericThresholdParams::new("INGEST", "NAME", 20, 10, "maybe");
+        let err = add_generic_threshold(config, params).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+    }
+
+    /// Rows sharing (GPLAN_ID, BEHAVIOR) but differing by FTYPE_ID must be
+    /// distinguished by the feature key; the matched row's FTYPE_ID must never
+    /// be overwritten.
+    #[test]
+    fn test_set_generic_threshold_edits_correct_per_feature_row() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_GENERIC_THRESHOLD": [
+                {"GPLAN_ID": 1, "BEHAVIOR": "FF", "FTYPE_ID": 0,
+                 "CANDIDATE_CAP": 10, "SCORING_CAP": 20, "SEND_TO_REDO": "No"},
+                {"GPLAN_ID": 1, "BEHAVIOR": "FF", "FTYPE_ID": 3,
+                 "CANDIDATE_CAP": 11, "SCORING_CAP": 21, "SEND_TO_REDO": "No"}
+            ]
+        }}"#;
+
+        let params = SetGenericThresholdParams {
+            plan: Some("INGEST"),
+            behavior: Some("FF"),
+            feature: Some("NAME"),
+            candidate_cap: Some(99),
+            scoring_cap: None,
+            send_to_redo: Some("yes"),
+        };
+        let modified = set_generic_threshold(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let rows = value["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+            .as_array()
+            .unwrap();
+
+        // The FTYPE_ID=0 row is untouched.
+        assert_eq!(rows[0]["CANDIDATE_CAP"], json!(10));
+        assert_eq!(rows[0]["SEND_TO_REDO"], json!("No"));
+        assert_eq!(rows[0]["FTYPE_ID"], json!(0));
+
+        // The NAME (FTYPE_ID=3) row is edited; FTYPE_ID preserved, redo canonical.
+        assert_eq!(rows[1]["FTYPE_ID"], json!(3));
+        assert_eq!(rows[1]["CANDIDATE_CAP"], json!(99));
+        assert_eq!(rows[1]["SCORING_CAP"], json!(21));
+        assert_eq!(rows[1]["SEND_TO_REDO"], json!("Yes"));
+    }
+
+    #[test]
+    fn test_set_generic_threshold_defaults_to_all_sentinel() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_GENERIC_THRESHOLD": [
+                {"GPLAN_ID": 1, "BEHAVIOR": "FF", "FTYPE_ID": 0,
+                 "CANDIDATE_CAP": 10, "SCORING_CAP": 20, "SEND_TO_REDO": "No"}
+            ]
+        }}"#;
+
+        // No feature supplied -> matches the FTYPE_ID=0 row.
+        let params = SetGenericThresholdParams {
+            plan: Some("INGEST"),
+            behavior: Some("FF"),
+            feature: None,
+            candidate_cap: Some(5),
+            scoring_cap: None,
+            send_to_redo: None,
+        };
+        let modified = set_generic_threshold(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let row = &value["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"][0];
+        assert_eq!(row["FTYPE_ID"], json!(0));
+        assert_eq!(row["CANDIDATE_CAP"], json!(5));
+    }
+
+    #[test]
+    fn test_set_generic_threshold_rejects_unknown_send_to_redo() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_GPLAN": [{"GPLAN_ID": 1, "GPLAN_CODE": "INGEST"}],
+            "CFG_FTYPE": [],
+            "CFG_GENERIC_THRESHOLD": [
+                {"GPLAN_ID": 1, "BEHAVIOR": "FF", "FTYPE_ID": 0,
+                 "CANDIDATE_CAP": 10, "SCORING_CAP": 20, "SEND_TO_REDO": "No"}
+            ]
+        }}"#;
+
+        let params = SetGenericThresholdParams {
+            plan: Some("INGEST"),
+            behavior: Some("FF"),
+            feature: None,
+            candidate_cap: None,
+            scoring_cap: None,
+            send_to_redo: Some("nope"),
+        };
+        let err = set_generic_threshold(config, params).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+    }
+
+    /// delete_comparison_threshold must match the full 3-key identity and leave
+    /// rows that differ in any key intact. "all" resolves to FTYPE_ID 0.
+    #[test]
+    fn test_delete_comparison_threshold_three_key_match() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_CFUNC": [{"CFUNC_ID": 5, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_CFRTN": [
+                {"CFRTN_ID": 1, "CFUNC_ID": 5, "FTYPE_ID": 3, "CFUNC_RTNVAL": "FULL_SCORE"},
+                {"CFRTN_ID": 2, "CFUNC_ID": 5, "FTYPE_ID": 3, "CFUNC_RTNVAL": "CLOSE_SCORE"},
+                {"CFRTN_ID": 3, "CFUNC_ID": 5, "FTYPE_ID": 0, "CFUNC_RTNVAL": "FULL_SCORE"}
+            ]
+        }}"#;
+
+        // Case-insensitive rtnval; only the exact 3-key row is removed.
+        let modified =
+            delete_comparison_threshold(config, "GNR_COMP", "NAME", "full_score").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let rows = value["G2_CONFIG"]["CFG_CFRTN"].as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        let ids: Vec<i64> = rows
+            .iter()
+            .map(|r| r["CFRTN_ID"].as_i64().unwrap())
+            .collect();
+        assert_eq!(ids, vec![2, 3]);
+
+        // "all" -> FTYPE_ID 0 sentinel.
+        let modified2 =
+            delete_comparison_threshold(&modified, "GNR_COMP", "all", "FULL_SCORE").unwrap();
+        let value2: Value = serde_json::from_str(&modified2).unwrap();
+        let rows2 = value2["G2_CONFIG"]["CFG_CFRTN"].as_array().unwrap();
+        assert_eq!(rows2.len(), 1);
+        assert_eq!(rows2[0]["CFRTN_ID"], json!(2));
+    }
+
+    #[test]
+    fn test_delete_comparison_threshold_not_found() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_CFUNC": [{"CFUNC_ID": 5, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_CFRTN": [
+                {"CFRTN_ID": 1, "CFUNC_ID": 5, "FTYPE_ID": 3, "CFUNC_RTNVAL": "FULL_SCORE"}
+            ]
+        }}"#;
+
+        // Right cfunc+ftype, wrong rtnval -> NotFound (3-key addressing).
+        let err =
+            delete_comparison_threshold(config, "GNR_COMP", "NAME", "CLOSE_SCORE").unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,172 @@
+//! Config-document structural validation.
+//!
+//! This module provides [`validate_config`], a single structural gate that
+//! callers (and, in future, the crate's own mutators) can rely on to decide
+//! whether a JSON document is a plausible Senzing config document *before*
+//! attempting section-by-section operations that would otherwise fail with
+//! ad-hoc per-section errors.
+//!
+//! The check is deliberately **structure-only** (see decision D31): it does not
+//! perform any cross-reference validation (foreign keys between sections, id
+//! uniqueness, behaviour-code validity, and so on). It answers one question —
+//! "is the top-level shape a config document?" — and nothing more.
+
+use crate::error::{Result, SzConfigError};
+use serde_json::Value;
+
+/// The recognised `CFG_*` config sections.
+///
+/// Each of these, **when present** in `G2_CONFIG`, must be a JSON array. Keys
+/// not in this list (for example `SETTINGS`, `SYS_OOM`, `CONFIG_BASE_VERSION`)
+/// are not `CFG_*` array sections and are left unchecked by [`validate_config`].
+///
+/// # Example
+///
+/// ```
+/// use sz_configtool_lib::validation::EXPECTED_SECTIONS;
+///
+/// assert!(EXPECTED_SECTIONS.contains(&"CFG_FTYPE"));
+/// assert!(EXPECTED_SECTIONS.contains(&"CFG_DSRC"));
+/// ```
+pub const EXPECTED_SECTIONS: &[&str] = &[
+    "CFG_ATTR",
+    "CFG_CFBOM",
+    "CFG_CFCALL",
+    "CFG_CFRTN",
+    "CFG_CFUNC",
+    "CFG_DFBOM",
+    "CFG_DFCALL",
+    "CFG_DFUNC",
+    "CFG_DSRC",
+    "CFG_DSRC_INTEREST",
+    "CFG_EFBOM",
+    "CFG_EFCALL",
+    "CFG_EFUNC",
+    "CFG_ERFRAG",
+    "CFG_ERRULE",
+    "CFG_FBOM",
+    "CFG_FBOVR",
+    "CFG_FCLASS",
+    "CFG_FELEM",
+    "CFG_FTYPE",
+    "CFG_GENERIC_THRESHOLD",
+    "CFG_GPLAN",
+    "CFG_RCLASS",
+    "CFG_RTYPE",
+    "CFG_SFCALL",
+    "CFG_SFUNC",
+    "CFG_SPROFILE",
+];
+
+/// Validate the top-level structure of a config document.
+///
+/// This is a **structure-only** gate (decision D31). It confirms, in order:
+///
+/// 1. `config_json` parses as JSON,
+/// 2. a top-level `G2_CONFIG` key is present and is a JSON object,
+/// 3. every recognised `CFG_*` section listed in [`EXPECTED_SECTIONS`], **if
+///    present**, is a JSON array.
+///
+/// It does **not** perform any deep or cross-reference validation: it never
+/// checks that required sections exist, that ids are unique, or that foreign
+/// keys between sections resolve. A document that passes `validate_config` is
+/// only guaranteed to have the right *shape* for the crate's navigators, not to
+/// be semantically complete.
+///
+/// # Arguments
+/// * `config_json` - Configuration JSON string
+///
+/// # Returns
+/// * `Ok(())` if the document is structurally a config document
+/// * `Err(SzConfigError::JsonParse)` if the input is not valid JSON
+/// * `Err(SzConfigError::MissingSection)` if `G2_CONFIG` is absent
+/// * `Err(SzConfigError::InvalidStructure)` if `G2_CONFIG` is not an object, or
+///   a present `CFG_*` section is not an array
+///
+/// # Example
+/// ```
+/// use sz_configtool_lib::validation::validate_config;
+///
+/// // Well-formed (empty but correctly shaped) document.
+/// assert!(validate_config(r#"{"G2_CONFIG":{"CFG_DSRC":[]}}"#).is_ok());
+///
+/// // G2_CONFIG is not an object.
+/// assert!(validate_config(r#"{"G2_CONFIG":42}"#).is_err());
+///
+/// // A CFG_* section is present but not an array.
+/// assert!(validate_config(r#"{"G2_CONFIG":{"CFG_DSRC":{}}}"#).is_err());
+/// ```
+pub fn validate_config(config_json: &str) -> Result<()> {
+    let config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let g2 = config
+        .get("G2_CONFIG")
+        .ok_or_else(|| SzConfigError::MissingSection("G2_CONFIG".to_string()))?;
+
+    let g2_obj = g2.as_object().ok_or_else(|| {
+        SzConfigError::InvalidStructure("G2_CONFIG must be a JSON object".to_string())
+    })?;
+
+    for section in EXPECTED_SECTIONS {
+        match g2_obj.get(*section) {
+            Some(value) if !value.is_array() => {
+                return Err(SzConfigError::InvalidStructure(format!(
+                    "Config section {section} must be a JSON array"
+                )));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_accepts_well_formed_config() {
+        let config = r#"{"G2_CONFIG":{"CFG_DSRC":[],"CFG_FTYPE":[{"FTYPE_ID":1}]}}"#;
+        assert!(validate_config(config).is_ok());
+    }
+
+    #[test]
+    fn test_accepts_config_with_non_cfg_scalars() {
+        // Non-CFG_* keys (SETTINGS, SYS_OOM, CONFIG_BASE_VERSION) are unchecked.
+        let config = r#"{"G2_CONFIG":{"CFG_DSRC":[],"CONFIG_BASE_VERSION":{"x":1},"SETTINGS":{}}}"#;
+        assert!(validate_config(config).is_ok());
+    }
+
+    #[test]
+    fn test_rejects_g2_config_not_object() {
+        let err = validate_config(r#"{"G2_CONFIG":42}"#).unwrap_err();
+        assert!(matches!(err, SzConfigError::InvalidStructure(_)));
+    }
+
+    #[test]
+    fn test_rejects_missing_g2_config() {
+        let err = validate_config(r#"{"SOMETHING_ELSE":{}}"#).unwrap_err();
+        assert!(matches!(err, SzConfigError::MissingSection(_)));
+    }
+
+    #[test]
+    fn test_rejects_non_array_cfg_section() {
+        let err = validate_config(r#"{"G2_CONFIG":{"CFG_DSRC":{}}}"#).unwrap_err();
+        assert!(matches!(err, SzConfigError::InvalidStructure(_)));
+        assert!(err.to_string().contains("CFG_DSRC"));
+    }
+
+    #[test]
+    fn test_rejects_invalid_json() {
+        let err = validate_config("{not json").unwrap_err();
+        assert!(matches!(err, SzConfigError::JsonParse(_)));
+    }
+
+    #[test]
+    fn test_accepts_stock_template() {
+        let config = include_str!("../tests/fixtures/g2config_template.json");
+        assert!(validate_config(config).is_ok());
+    }
+}

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -39,14 +39,20 @@ fn test_data_source_workflow() {
         datasources::get_data_source(&config, "TEST_SOURCE").expect("Failed to get data source");
     assert_eq!(source["DSRC_CODE"], "TEST_SOURCE");
 
-    // Attempt to delete data source - should fail due to system datasource protection (ID ≤ 2)
-    // TEST_SOURCE gets auto-assigned a low ID, triggering protection
-    let delete_result = datasources::delete_data_source(&config, "TEST_SOURCE");
+    // #37/D18: a fresh data source now seeds at DSRC_ID 1000 (was max+1), so it is
+    // well clear of the system range (<= 2) and IS deletable.
+    assert_eq!(source["DSRC_ID"], 1000);
+    let config = datasources::delete_data_source(&config, "TEST_SOURCE")
+        .expect("A user data source (id >= 1000) must be deletable");
+    let sources = datasources::list_data_sources(&config).expect("Failed to list data sources");
+    assert_eq!(sources.len(), 0);
 
-    // Should fail with protection error (system datasources cannot be deleted)
+    // A genuine system data source (DSRC_ID <= 2) is still protected.
+    let sys_config = r#"{"G2_CONFIG": {"CFG_DSRC": [{"DSRC_ID": 1, "DSRC_CODE": "TEST"}]}}"#;
+    let delete_result = datasources::delete_data_source(sys_config, "TEST");
     assert!(
         delete_result.is_err(),
-        "Should fail to delete system datasource"
+        "Should fail to delete a system datasource (id <= 2)"
     );
     let err_msg = delete_result.unwrap_err().to_string();
     assert!(
@@ -64,6 +70,7 @@ fn test_element_workflow() {
         code: "TEST_ELEM",
         description: Some("Test Element"),
         data_type: Some("string"),
+        id: None,
     };
 
     let config = elements::add_element(&config, add_params).expect("Failed to add element");

--- a/tests/roundtrip_completeness.rs
+++ b/tests/roundtrip_completeness.rs
@@ -11,6 +11,8 @@
 //! append, so a positional comparison of the "before" rows is exact.
 
 use serde_json::{Value, json};
+use sz_configtool_lib::fragments::SetFragmentParams;
+use sz_configtool_lib::helpers::FieldUpdate;
 use sz_configtool_lib::{fragments, rules};
 
 /// For every section array under `G2_CONFIG`, assert that each row present in
@@ -87,9 +89,9 @@ fn roundtrip_set_rule_drops_no_keys() {
         resolve: Some("No"),
         relate: None,
         rtype_id: None,
-        fragment: None,
-        disqualifier: None,
-        tier: None,
+        fragment: FieldUpdate::Leave,
+        disqualifier: FieldUpdate::Leave,
+        tier: FieldUpdate::Leave,
     };
     let modified = rules::set_rule(&config_str, params).unwrap();
     let after: Value = serde_json::from_str(&modified).unwrap();
@@ -111,8 +113,11 @@ fn roundtrip_set_fragment_drops_no_keys() {
 
     // Update only the description; ERFRAG_ID / ERFRAG_SOURCE / ERFRAG_DEPENDS
     // must be carried forward, not dropped by the full-row replace.
-    let update = json!({"ERFRAG_DESC": "Updated"});
-    let modified = fragments::set_fragment(&config_str, "SAME_A1", &update).unwrap();
+    let update = SetFragmentParams {
+        source: FieldUpdate::Leave,
+        description: FieldUpdate::Set("Updated"),
+    };
+    let modified = fragments::set_fragment(&config_str, "SAME_A1", update).unwrap();
     let after: Value = serde_json::from_str(&modified).unwrap();
 
     assert_no_keys_dropped(&before, &after);
@@ -160,9 +165,9 @@ fn roundtrip_real_config_fixture() {
                     resolve: None,
                     relate: None,
                     rtype_id: None,
-                    fragment: None,
-                    disqualifier: None,
-                    tier: None,
+                    fragment: FieldUpdate::Leave,
+                    disqualifier: FieldUpdate::Leave,
+                    tier: FieldUpdate::Leave,
                 };
                 config_str = rules::set_rule(&config_str, params)
                     .unwrap_or_else(|e| panic!("set_rule({code}) failed: {e}"));
@@ -174,8 +179,8 @@ fn roundtrip_real_config_fixture() {
     if let Some(frags) = before["G2_CONFIG"]["CFG_ERFRAG"].as_array() {
         for row in frags {
             if let Some(code) = row.get("ERFRAG_CODE").and_then(|v| v.as_str()) {
-                let empty = json!({});
-                config_str = fragments::set_fragment(&config_str, code, &empty)
+                let empty = SetFragmentParams::default();
+                config_str = fragments::set_fragment(&config_str, code, empty)
                     .unwrap_or_else(|e| panic!("set_fragment({code}) failed: {e}"));
             }
         }


### PR DESCRIPTION
Coordinated breaking release (**0.6.0**) resolving the SDK audit — issues **#32–#43** — delivered in six reviewed waves plus release prep. Every wave was implemented and then checked by two independent adversarial reviewers; zero blockers, zero rejections across the programme.

## Issues resolved
- **HIGH (correctness):** #32 threshold/config-section corruption, #33 null-preserving reads, #34 write-path null/tri-state, #35 `LOCKED_FEATURES`, #36 filter substrate
- **NORMAL (API/maintainability):** #37 caller ids, #38 missing mutators, #39 rule validation, #40 call-API redesign, #41 list sort/`elementList`, #42 typed error surface, #43 config domains/validator/export

## Highlights
- **Correctness:** `set_generic_threshold` no longer edits/corrupts the wrong row; reads preserve stored `null` vs `""`; `get_standardize_call`/`get_distinct_call` return the correct call by feature; `add_rule` validates via a validator shared with `set_rule`.
- **New API (additive):** `add_element_to_feature`/`delete_element_from_feature`, `settings::set_setting`, cascading `delete_*_function_cascade`, caller-supplied `id` on `Add*Params`, `calls::CallSelector` (id-or-code), `list_behavior_overrides_resolved`, `validate_config`, `render_config`, public behaviour/attribute-class domains, `SzErrorKind`/`reason_code()`.
- **Breaking:** see CHANGELOG. `delete_comparison_threshold` gains `cfunc_rtnval`; `add_config_section_field` returns `AddFieldCounts`; four `Add*FunctionParams.connect_str` → `Option<&str>` (+ row structs → `Option<String>`); tri-state `FieldUpdate<T>` on set-params; `get_*_call`/`delete_*_call_element` signatures; `Add*Params` gain `id`; DSRC/ATTR id seed → 1000.

## Parity verified against Python `sz_configtool` 4.4.0
- `list_rules` sorts by `ERRULE_ID` ascending (matches `do_listRules`).
- `BEHAVIOR_CODES` byte-identical to Python `valid_behavior_codes`.
- `LOCKED_FEATURES` protected set ratified by the maintainer.

## Quality gates (local)
- `cargo build --lib` + `--release` clean
- **323 test cases** (218 lib unit + integration + doc), 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --check` clean
- No dependency changes (`cargo deny` posture identical to 0.5.0)

## FFI
No existing C ABI signature changed; new wrappers are additive (the call-element delete redesign had no prior C wrapper). `include/libSzConfigTool.h` updated.

Full details in `CHANGELOG.md` under `[0.6.0]`.
