### PR TITLE
Release v0.6.2: disambiguate call-element delete by element feature (#40 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-08-24
+
+Patch: fixes a call-element delete regression found during the CLI's v0.6.x adoption, verified
+against the stock config and Python `sz_configtool` 4.4.0. Gates green: 329 test cases, clippy/fmt
+clean.
+
+### Fixed
+
+- **`delete_{comparison,expression,distinct}_call_element` can now disambiguate an element that
+  appears under multiple features in one call.** The v0.6.0 redesign (#40) derived `EXEC_ORDER` from
+  `(call, element)` alone, so when one call carried the same `FELEM_ID` under multiple `FTYPE_ID`s it
+  errored `Ambiguous …` instead of deleting the right row. The **stock config** ships exactly this
+  (`EFCALL_ID 97` / `TOKENIZED_NM` under both `GROUP_ASSOCIATION` and `EMPLOYER`), so
+  `deleteExpressionCallElement` was broken on shipped data. The three delete functions (and their FFI
+  wrappers) now take an optional **`element_feature`** which, when supplied, resolves the collision to
+  the feature-matched BOM row — mirroring Python's `(call_id, FTYPE_ID, FELEM_ID)` addressing. When
+  `(call, element)` is unambiguous the feature is optional (`None` / `NULL`).
+
+### Changed (API/FFI — additive optional parameter)
+
+- `delete_comparison_call_element`, `delete_expression_call_element`, `delete_distinct_call_element`
+  gain a trailing `element_feature: Option<&str>`.
+- The FFI wrappers `SzConfigTool_delete{Comparison,Distinct,Expression}CallElement` gain a trailing
+  **nullable** `element_feature` C-string argument (`include/libSzConfigTool.h` updated). Pass `NULL`
+  when unambiguous.
+- The `deleteComparisonCallElement` / `deleteDistinctCallElement` script commands accept an optional
+  `elementFeature` parameter.
+
 ## [0.6.1] - 2026-08-24
 
 Patch: rule-validation parity fixes found during the downstream CLI's adoption of v0.6.0,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -665,15 +665,22 @@ struct SzConfigTool_result SzConfigTool_getExpressionCallByFeature(const char *c
 // wrappers — so it does not break an existing ABI. Comparison/distinct address
 // the call by feature code (0-or-1 call per feature); expression addresses the
 // call by its EFCALL_ID because expression calls are many-per-feature.
+// element_feature is OPTIONAL (may be NULL): when one call carries the same
+// element under multiple element-features, pass the element's feature code to
+// disambiguate to the correct BOM row (matches Python). Pass NULL when the
+// (call, element) pair is unambiguous.
 struct SzConfigTool_result SzConfigTool_deleteComparisonCallElement(const char *config_json,
                                                                     const char *feature_code,
-                                                                    const char *element_code);
+                                                                    const char *element_code,
+                                                                    const char *element_feature);
 struct SzConfigTool_result SzConfigTool_deleteDistinctCallElement(const char *config_json,
                                                                   const char *feature_code,
-                                                                  const char *element_code);
+                                                                  const char *element_code,
+                                                                  const char *element_feature);
 struct SzConfigTool_result SzConfigTool_deleteExpressionCallElement(const char *config_json,
                                                                     int64_t efcall_id,
-                                                                    const char *element_code);
+                                                                    const char *element_code,
+                                                                    const char *element_feature);
 
 // Wave 6 additions (#42, #43): API-surface helpers. All additive.
 //

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -590,7 +590,7 @@ pub fn add_comparison_call_element(
 ///     "CFG_CFBOM": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}]
 /// }}"#;
 /// let out = delete_comparison_call_element(
-///     config, CallSelector::Feature("NAME"), "FIRST_NAME").unwrap();
+///     config, CallSelector::Feature("NAME"), "FIRST_NAME", None).unwrap();
 /// let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 /// assert!(v["G2_CONFIG"]["CFG_CFBOM"].as_array().unwrap().is_empty());
 /// ```
@@ -598,12 +598,19 @@ pub fn delete_comparison_call_element(
     config: &str,
     call: CallSelector,
     element_code: &str,
+    element_feature: Option<&str>,
 ) -> Result<String> {
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     let cfcall_id = resolve_call_id(config, &config_data, call, resolve_cfcall_id_for_feature)?;
     let felem_id = lookup_element_id(config, element_code)?;
+    // When the element appears under multiple features in this call, the
+    // element's feature disambiguates to the correct BOM row (Python parity).
+    let element_ftype_id = match element_feature {
+        Some(f) => Some(lookup_feature_id(config, f)?),
+        None => None,
+    };
 
     // Derive EXEC_ORDER from the located BOM row (also validates existence).
     let exec_order = derive_bom_exec_order(
@@ -612,6 +619,7 @@ pub fn delete_comparison_call_element(
         "CFCALL_ID",
         cfcall_id,
         felem_id,
+        element_ftype_id,
         "Comparison",
     )?;
 
@@ -802,9 +810,13 @@ mod tests {
     fn test_delete_comparison_call_element_derives_exec_order() {
         let config = populated_config();
         // No exec_order supplied; the SDK derives it and removes the right row.
-        let out =
-            delete_comparison_call_element(&config, CallSelector::Feature("NAME"), "FIRST_NAME")
-                .unwrap();
+        let out = delete_comparison_call_element(
+            &config,
+            CallSelector::Feature("NAME"),
+            "FIRST_NAME",
+            None,
+        )
+        .unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         let cfbom = v["G2_CONFIG"]["CFG_CFBOM"].as_array().unwrap();
         assert_eq!(cfbom.len(), 1);
@@ -814,10 +826,11 @@ mod tests {
     #[test]
     fn test_delete_comparison_call_element_not_found() {
         let config = populated_config();
-        let err = delete_comparison_call_element(&config, CallSelector::Id(7), "LAST_NAME");
+        let err = delete_comparison_call_element(&config, CallSelector::Id(7), "LAST_NAME", None);
         assert!(err.is_ok());
         // Element on a call that has no such BOM row -> NotFound.
-        let err = delete_comparison_call_element(&config, CallSelector::Id(999), "FIRST_NAME");
+        let err =
+            delete_comparison_call_element(&config, CallSelector::Id(999), "FIRST_NAME", None);
         assert_eq!(err.unwrap_err().kind(), crate::error::SzErrorKind::NotFound);
     }
 

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -548,7 +548,7 @@ pub fn add_distinct_call_element(
 ///     "CFG_DFBOM": [{"DFCALL_ID": 11, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}]
 /// }}"#;
 /// let out = delete_distinct_call_element(
-///     config, CallSelector::Id(11), "FIRST_NAME").unwrap();
+///     config, CallSelector::Id(11), "FIRST_NAME", None).unwrap();
 /// let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 /// assert!(v["G2_CONFIG"]["CFG_DFBOM"].as_array().unwrap().is_empty());
 /// ```
@@ -556,12 +556,19 @@ pub fn delete_distinct_call_element(
     config: &str,
     call: CallSelector,
     element_code: &str,
+    element_feature: Option<&str>,
 ) -> Result<String> {
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     let dfcall_id = resolve_call_id(config, &config_data, call, resolve_dfcall_id_for_feature)?;
     let felem_id = lookup_element_id(config, element_code)?;
+    // When the element appears under multiple features in this call, the
+    // element's feature disambiguates to the correct BOM row (Python parity).
+    let element_ftype_id = match element_feature {
+        Some(f) => Some(lookup_feature_id(config, f)?),
+        None => None,
+    };
 
     // Derive EXEC_ORDER from the located BOM row (also validates existence).
     let exec_order = derive_bom_exec_order(
@@ -570,6 +577,7 @@ pub fn delete_distinct_call_element(
         "DFCALL_ID",
         dfcall_id,
         felem_id,
+        element_ftype_id,
         "Distinct",
     )?;
 
@@ -712,7 +720,8 @@ mod tests {
     #[test]
     fn test_delete_distinct_call_element_derives_exec_order() {
         let config = populated_config();
-        let out = delete_distinct_call_element(&config, CallSelector::Id(11), "LAST_NAME").unwrap();
+        let out =
+            delete_distinct_call_element(&config, CallSelector::Id(11), "LAST_NAME", None).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         let dfbom = v["G2_CONFIG"]["CFG_DFBOM"].as_array().unwrap();
         assert_eq!(dfbom.len(), 1);

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -601,7 +601,7 @@ pub fn add_expression_call_element(
 ///     "CFG_EFBOM": [{"EFCALL_ID": 9, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "No"}]
 /// }}"#;
 /// let out = delete_expression_call_element(
-///     config, CallSelector::Id(9), "FIRST_NAME").unwrap();
+///     config, CallSelector::Id(9), "FIRST_NAME", None).unwrap();
 /// let v: serde_json::Value = serde_json::from_str(&out).unwrap();
 /// assert!(v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap().is_empty());
 /// ```
@@ -609,12 +609,19 @@ pub fn delete_expression_call_element(
     config: &str,
     call: CallSelector,
     element_code: &str,
+    element_feature: Option<&str>,
 ) -> Result<String> {
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     let efcall_id = resolve_call_id(config, &config_data, call, resolve_efcall_id_for_feature)?;
     let felem_id = lookup_element_id(config, element_code)?;
+    // When the element appears under multiple features in this call, the
+    // element's feature disambiguates to the correct BOM row (Python parity).
+    let element_ftype_id = match element_feature {
+        Some(f) => Some(lookup_feature_id(config, f)?),
+        None => None,
+    };
 
     // Derive EXEC_ORDER from the located BOM row (also validates existence).
     let exec_order = derive_bom_exec_order(
@@ -623,6 +630,7 @@ pub fn delete_expression_call_element(
         "EFCALL_ID",
         efcall_id,
         felem_id,
+        element_ftype_id,
         "Expression",
     )?;
 
@@ -782,8 +790,12 @@ mod tests {
     #[test]
     fn test_delete_expression_call_element_ambiguous_feature_errors() {
         let config = populated_config();
-        let err =
-            delete_expression_call_element(&config, CallSelector::Feature("NAME"), "FIRST_NAME");
+        let err = delete_expression_call_element(
+            &config,
+            CallSelector::Feature("NAME"),
+            "FIRST_NAME",
+            None,
+        );
         assert_eq!(
             err.unwrap_err().kind(),
             crate::error::SzErrorKind::InvalidInput
@@ -794,8 +806,8 @@ mod tests {
     fn test_delete_expression_call_element_by_id_derives_exec_order() {
         let config = populated_config();
         // Addressing the specific call by id disambiguates; exec_order derived.
-        let out =
-            delete_expression_call_element(&config, CallSelector::Id(9), "FIRST_NAME").unwrap();
+        let out = delete_expression_call_element(&config, CallSelector::Id(9), "FIRST_NAME", None)
+            .unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         let efbom = v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
         assert_eq!(efbom.len(), 1);
@@ -829,5 +841,59 @@ mod tests {
         assert_eq!(calls[1]["id"], json!(30));
         // elementList ordered by EXEC_ORDER despite reversed storage.
         assert_eq!(calls[0]["elementList"], json!(["FIRST_NAME", "LAST_NAME"]));
+    }
+
+    // Regression: one call can carry the same element under multiple features.
+    // The stock config ships exactly this (EFCALL_ID 97 / TOKENIZED_NM under both
+    // GROUP_ASSOCIATION and EMPLOYER). Without the element's feature the delete is
+    // ambiguous; with it, only the feature-matched BOM row is removed.
+    #[test]
+    fn test_delete_expression_call_element_disambiguates_by_feature() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FELEM": [{"FELEM_ID": 118, "FELEM_CODE": "TOKENIZED_NM"}],
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 57, "FTYPE_CODE": "GROUP_ASSOCIATION"},
+                {"FTYPE_ID": 59, "FTYPE_CODE": "EMPLOYER"}
+            ],
+            "CFG_EFCALL": [{"EFCALL_ID": 97}],
+            "CFG_EFBOM": [
+                {"EFCALL_ID": 97, "FTYPE_ID": 57, "FELEM_ID": 118, "EXEC_ORDER": 13},
+                {"EFCALL_ID": 97, "FTYPE_ID": 59, "FELEM_ID": 118, "EXEC_ORDER": 14}
+            ]
+        }}"#;
+
+        // Ambiguous without the element's feature -> InvalidInput (not a silent
+        // wrong-row delete).
+        let err =
+            delete_expression_call_element(config, CallSelector::Id(97), "TOKENIZED_NM", None)
+                .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+
+        // With GROUP_ASSOCIATION, only the FTYPE 57 / exec 13 row is removed.
+        let out = delete_expression_call_element(
+            config,
+            CallSelector::Id(97),
+            "TOKENIZED_NM",
+            Some("GROUP_ASSOCIATION"),
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let bom = v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
+        assert_eq!(bom.len(), 1, "exactly one row removed");
+        assert_eq!(bom[0]["FTYPE_ID"], json!(59), "EMPLOYER row remains");
+        assert_eq!(bom[0]["EXEC_ORDER"], json!(14));
+
+        // With EMPLOYER, the other row is removed instead.
+        let out2 = delete_expression_call_element(
+            config,
+            CallSelector::Id(97),
+            "TOKENIZED_NM",
+            Some("EMPLOYER"),
+        )
+        .unwrap();
+        let v2: Value = serde_json::from_str(&out2).unwrap();
+        let bom2 = v2["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
+        assert_eq!(bom2.len(), 1);
+        assert_eq!(bom2[0]["FTYPE_ID"], json!(57));
     }
 }

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -72,22 +72,28 @@ pub(crate) fn resolve_call_id(
     }
 }
 
-/// Derive the `EXEC_ORDER` of the single BOM row addressed by (call, element).
+/// Derive the `EXEC_ORDER` of the single BOM row addressed by
+/// (call, element[, element feature]).
 ///
 /// A BOM record (`CFG_CFBOM` / `CFG_DFBOM` / `CFG_EFBOM`) stores the *element's*
-/// feature id in its `FTYPE_ID`, not the call's, so `FTYPE_ID` is deliberately
-/// **not** part of the address here — the row is located by (call id, element
-/// id) alone. Returns the located row's `EXEC_ORDER`, so callers no longer need
-/// to supply it.
+/// feature id in its `FTYPE_ID` (not the call's). One call can carry the same
+/// element (`FELEM_ID`) under several element-features — the stock config does
+/// exactly this (e.g. `EFCALL_ID 97` / `TOKENIZED_NM` under both
+/// `GROUP_ASSOCIATION` and `EMPLOYER`). When `element_ftype_id` is supplied it is
+/// added to the match so that collision resolves to the feature-matched row,
+/// mirroring Python's `(call_id, FTYPE_ID, FELEM_ID)` addressing. When it is
+/// `None` the row is located by (call id, element id) alone.
 ///
-/// Errors with `NotFound` when no row matches and `InvalidInput` when more than
-/// one does (the element cannot be uniquely addressed without more information).
+/// Returns the located row's `EXEC_ORDER`. Errors with `NotFound` when no row
+/// matches and `InvalidInput` when more than one does (an ambiguous
+/// `(call, element)` — the caller should pass the element's feature).
 pub(crate) fn derive_bom_exec_order(
     root: &Value,
     section: &str,
     call_id_field: &str,
     call_id: i64,
     felem_id: i64,
+    element_ftype_id: Option<i64>,
     label: &str,
 ) -> Result<i64> {
     let empty: Vec<Value> = Vec::new();
@@ -102,6 +108,8 @@ pub(crate) fn derive_bom_exec_order(
         .filter(|r| {
             r.get(call_id_field).and_then(|v| v.as_i64()) == Some(call_id)
                 && r.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
+                && element_ftype_id
+                    .is_none_or(|ft| r.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ft))
         })
         .filter_map(|r| r.get("EXEC_ORDER").and_then(|v| v.as_i64()))
         .collect();
@@ -112,7 +120,7 @@ pub(crate) fn derive_bom_exec_order(
         ))),
         [order] => Ok(*order),
         many => Err(SzConfigError::InvalidInput(format!(
-            "Ambiguous {label} call element: element matches {} rows; cannot derive execution order",
+            "Ambiguous {label} call element: element matches {} rows across features; specify the element's feature to disambiguate",
             many.len()
         ))),
     }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -547,11 +547,15 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
             // derivation (#40); the tool is a thin pass-through of the codes.
             let feature = get_str_param(params, "feature")?;
             let element = get_str_param(params, "element")?;
+            // Optional: the element's feature disambiguates when one call carries
+            // the same element under multiple features (#40 follow-up).
+            let element_feature = params.get("elementFeature").and_then(|v| v.as_str());
 
             crate::calls::comparison::delete_comparison_call_element(
                 config,
                 crate::calls::CallSelector::Feature(feature),
                 element,
+                element_feature,
             )
         }
 
@@ -617,11 +621,15 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
             // derives the BOM exec_order internally (#40).
             let feature = get_str_param(params, "feature")?;
             let element = get_str_param(params, "element")?;
+            // Optional: the element's feature disambiguates when one call carries
+            // the same element under multiple features (#40 follow-up).
+            let element_feature = params.get("elementFeature").and_then(|v| v.as_str());
 
             crate::calls::distinct::delete_distinct_call_element(
                 config,
                 crate::calls::CallSelector::Feature(feature),
                 element,
+                element_feature,
             )
         }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -10039,14 +10039,30 @@ pub extern "C" fn SzConfigTool_deleteComparisonCallElement(
     config_json: *const c_char,
     feature_code: *const c_char,
     element_code: *const c_char,
+    element_feature: *const c_char,
 ) -> SzConfigTool_result {
     let config = ffi_required_str!(config_json, "config_json");
     let feature = ffi_required_str!(feature_code, "feature_code");
     let element = ffi_required_str!(element_code, "element_code");
+    let elem_feature = if element_feature.is_null() {
+        None
+    } else {
+        match unsafe { CStr::from_ptr(element_feature) }.to_str() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in element_feature: {e}"), -1);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -1,
+                };
+            }
+        }
+    };
     handle_result!(crate::calls::comparison::delete_comparison_call_element(
         config,
         crate::calls::CallSelector::Feature(feature),
-        element
+        element,
+        elem_feature,
     ))
 }
 
@@ -10061,14 +10077,30 @@ pub extern "C" fn SzConfigTool_deleteDistinctCallElement(
     config_json: *const c_char,
     feature_code: *const c_char,
     element_code: *const c_char,
+    element_feature: *const c_char,
 ) -> SzConfigTool_result {
     let config = ffi_required_str!(config_json, "config_json");
     let feature = ffi_required_str!(feature_code, "feature_code");
     let element = ffi_required_str!(element_code, "element_code");
+    let elem_feature = if element_feature.is_null() {
+        None
+    } else {
+        match unsafe { CStr::from_ptr(element_feature) }.to_str() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in element_feature: {e}"), -1);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -1,
+                };
+            }
+        }
+    };
     handle_result!(crate::calls::distinct::delete_distinct_call_element(
         config,
         crate::calls::CallSelector::Feature(feature),
-        element
+        element,
+        elem_feature,
     ))
 }
 
@@ -10084,13 +10116,29 @@ pub extern "C" fn SzConfigTool_deleteExpressionCallElement(
     config_json: *const c_char,
     efcall_id: i64,
     element_code: *const c_char,
+    element_feature: *const c_char,
 ) -> SzConfigTool_result {
     let config = ffi_required_str!(config_json, "config_json");
     let element = ffi_required_str!(element_code, "element_code");
+    let elem_feature = if element_feature.is_null() {
+        None
+    } else {
+        match unsafe { CStr::from_ptr(element_feature) }.to_str() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                set_error(format!("Invalid UTF-8 in element_feature: {e}"), -1);
+                return SzConfigTool_result {
+                    response: std::ptr::null_mut(),
+                    returnCode: -1,
+                };
+            }
+        }
+    };
     handle_result!(crate::calls::expression::delete_expression_call_element(
         config,
         crate::calls::CallSelector::Id(efcall_id),
-        element
+        element,
+        elem_feature,
     ))
 }
 
@@ -10301,6 +10349,7 @@ mod tests {
             config.as_ptr(),
             feature.as_ptr(),
             element.as_ptr(),
+            std::ptr::null(), // element_feature: not needed (unambiguous)
         ));
         let v: Value = serde_json::from_str(&modified).unwrap();
         let cfbom = v["G2_CONFIG"]["CFG_CFBOM"].as_array().unwrap();


### PR DESCRIPTION
Patch **v0.6.2** — fixes a call-element delete regression found during the CLI's v0.6.x adoption, **verified against the stock config and Python `sz_configtool` 4.4.0**, coordinated with the CLI session.

## The bug (regression from #40)
`delete_{comparison,expression,distinct}_call_element` derived `EXEC_ORDER` from `(call, element)` alone (`derive_bom_exec_order`). When one call carries the same `FELEM_ID` under multiple `FTYPE_ID`s, it errored `Ambiguous …` instead of deleting the right row. The **stock config** ships exactly this — `EFCALL_ID 97` / `TOKENIZED_NM` under `GROUP_ASSOCIATION` (exec 13) **and** `EMPLOYER` (exec 14) — so `deleteExpressionCallElement` was broken on shipped data. Introduced in v0.6.0 (#40) when the FTYPE disambiguator was dropped with the `exec_order` tuple.

## Fix
The three delete functions (+ their FFI wrappers + the `deleteComparison/DistinctCallElement` script commands) take an optional **`element_feature`**. When supplied it's added to the BOM match `(call_id, FTYPE_ID, FELEM_ID)`, resolving the collision to the feature-matched row — mirroring Python's `prepCallElement`. When `(call, element)` is unambiguous, the feature is optional (`None` / `NULL`).

## API / FFI (additive optional param)
- Rust: `delete_*_call_element(config, call, element_code, element_feature: Option<&str>)`.
- FFI: `SzConfigTool_delete{Comparison,Distinct,Expression}CallElement` gain a trailing **nullable** `element_feature` C-string (`include/libSzConfigTool.h` updated).

## Gates
329 test cases (added a regression test reproducing the stock `EFCALL_ID 97` collision) · clippy `-D warnings` clean · fmt clean · release builds.
