### PR TITLE
Release v0.6.3: FTYPE-safe call-element delete + case-insensitive matches_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-08-25
+
+Patch: two parity/robustness fixes raised during the CLI's Wave-2 read-path re-delegation, verified
+against the stock config and Python `sz_configtool` 4.4.0 and coordinated with the CLI. Both are
+**no-op on shipped data** — the FTYPE guard closes a latent trap that the stock config can't hit, and
+the filter fix corrects a wrapper the CLI had not yet adopted. Gates green: 331 test cases, clippy/fmt
+clean.
+
+### Fixed
+
+- **`matches_filter` is now case-insensitive**, matching every `sz_configtool` list-filter site
+  (`arg.lower() in str(record).lower()`). It previously did a case-sensitive `contains`, so calling
+  the wrapper directly regressed filters such as `listRules none` to zero matches — which is why the
+  CLI kept its own case-insensitive `.contains` rather than adopting it. Both the rendered record and
+  the filter term are now case-folded before the substring test. The rustdoc is corrected (the
+  "mirroring Python's `in`" note referred to the bare operator the tool never uses) and now records
+  that the tool's actual `str(record)` substrate is `FilterSubstrate::PythonRepr`, so callers
+  reproducing the tool's filtering exactly should pass `PythonRepr`.
+- **`delete_{expression,comparison,distinct}_call_element` no longer risk over-deleting a sibling BOM
+  row.** The target `EXEC_ORDER` is derived FTYPE-aware (via the element's feature), but the final
+  `retain` matched only `(call_id, FELEM_ID, EXEC_ORDER)`. If one call ever held two BOM rows sharing
+  the same element **and** `EXEC_ORDER` under different features, disambiguating by feature would
+  derive the right row then drop its sibling too. Not reachable on the stock config (add paths keep
+  `EXEC_ORDER` unique per call, and the no-feature path already errors as ambiguous before `retain`);
+  each `retain` now mirrors the derive predicate as a belt-and-braces guard. (`standardize` was
+  already FTYPE-inclusive and is unchanged.)
+
+### Behaviour note
+
+- The `matches_filter` change is observable: case-insensitive matching returns more results than the
+  previous case-sensitive test for mixed-case terms. This is a parity fix (the SDK behaviour now
+  matches the Python tool) rather than a regression.
+
 ## [0.6.2] - 2026-08-24
 
 Patch: fixes a call-element delete regression found during the CLI's v0.6.x adoption, verified

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -624,10 +624,15 @@ pub fn delete_comparison_call_element(
     )?;
 
     if let Some(cbom_array) = config_data["G2_CONFIG"]["CFG_CFBOM"].as_array_mut() {
+        // Mirror the derive predicate: when a feature disambiguated the target
+        // row, constrain the retain by FTYPE too. Otherwise a sibling row sharing
+        // (call, felem, exec) under another feature would be over-deleted.
         cbom_array.retain(|item| {
             !(item.get("CFCALL_ID").and_then(|v| v.as_i64()) == Some(cfcall_id)
                 && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order))
+                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order)
+                && element_ftype_id
+                    .is_none_or(|ft| item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ft)))
         });
     }
 

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -582,10 +582,15 @@ pub fn delete_distinct_call_element(
     )?;
 
     if let Some(dbom_array) = config_data["G2_CONFIG"]["CFG_DFBOM"].as_array_mut() {
+        // Mirror the derive predicate: when a feature disambiguated the target
+        // row, constrain the retain by FTYPE too. Otherwise a sibling row sharing
+        // (call, felem, exec) under another feature would be over-deleted.
         dbom_array.retain(|item| {
             !(item.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(dfcall_id)
                 && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order))
+                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order)
+                && element_ftype_id
+                    .is_none_or(|ft| item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ft)))
         });
     }
 

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -635,10 +635,15 @@ pub fn delete_expression_call_element(
     )?;
 
     if let Some(ebom_array) = config_data["G2_CONFIG"]["CFG_EFBOM"].as_array_mut() {
+        // Mirror the derive predicate: when a feature disambiguated the target
+        // row, constrain the retain by FTYPE too. Otherwise a sibling row sharing
+        // (call, felem, exec) under another feature would be over-deleted.
         ebom_array.retain(|item| {
             !(item.get("EFCALL_ID").and_then(|v| v.as_i64()) == Some(efcall_id)
                 && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order))
+                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(exec_order)
+                && element_ftype_id
+                    .is_none_or(|ft| item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ft)))
         });
     }
 
@@ -895,5 +900,39 @@ mod tests {
         let bom2 = v2["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
         assert_eq!(bom2.len(), 1);
         assert_eq!(bom2[0]["FTYPE_ID"], json!(57));
+    }
+
+    // Belt-and-braces regression: the derive step is FTYPE-aware, but the retain
+    // used to drop by (call, felem, exec) only. If two rows on one call share the
+    // same element AND the same EXEC_ORDER but differ by feature, the FTYPE-blind
+    // retain over-deleted the sibling. No such collision exists in the stock config
+    // (add paths keep exec unique per call), so this is a synthetic guard against a
+    // future regression rather than a live bug. Pre-fix this asserted len == 0.
+    #[test]
+    fn test_delete_expression_call_element_same_exec_across_features_keeps_sibling() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FELEM": [{"FELEM_ID": 118, "FELEM_CODE": "TOKENIZED_NM"}],
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 57, "FTYPE_CODE": "GROUP_ASSOCIATION"},
+                {"FTYPE_ID": 59, "FTYPE_CODE": "EMPLOYER"}
+            ],
+            "CFG_EFCALL": [{"EFCALL_ID": 97}],
+            "CFG_EFBOM": [
+                {"EFCALL_ID": 97, "FTYPE_ID": 57, "FELEM_ID": 118, "EXEC_ORDER": 13},
+                {"EFCALL_ID": 97, "FTYPE_ID": 59, "FELEM_ID": 118, "EXEC_ORDER": 13}
+            ]
+        }}"#;
+
+        let out = delete_expression_call_element(
+            config,
+            CallSelector::Id(97),
+            "TOKENIZED_NM",
+            Some("GROUP_ASSOCIATION"),
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let bom = v["G2_CONFIG"]["CFG_EFBOM"].as_array().unwrap();
+        assert_eq!(bom.len(), 1, "only the GROUP_ASSOCIATION row is removed");
+        assert_eq!(bom[0]["FTYPE_ID"], json!(59), "EMPLOYER sibling survives");
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -160,8 +160,19 @@ pub fn to_python_repr_string(value: &Value) -> String {
 /// Test whether `filter` occurs as a substring of `record` rendered under the
 /// given [`FilterSubstrate`].
 ///
-/// The match is case-sensitive, mirroring Python's `in` operator on strings.
-/// An empty filter always matches.
+/// The match is **case-insensitive**: both the rendered record and the filter
+/// term are case-folded before the substring test. This mirrors every real
+/// `sz_configtool` list-filter site, which tests `arg.lower() in
+/// str(record).lower()` — not the bare `in` operator. An empty filter always
+/// matches.
+///
+/// ## Substrate and parity
+///
+/// The Python tool stringifies with `str(record)`, whose dict form is the
+/// CPython `repr` (single quotes, `None`/`True`/`False`) — i.e.
+/// [`FilterSubstrate::PythonRepr`]. Callers reproducing the tool's filtering
+/// exactly should pass `PythonRepr`; the other substrates are offered for
+/// callers filtering against a different rendering of their own choosing.
 ///
 /// # Example
 ///
@@ -182,7 +193,9 @@ pub fn matches_filter(record: &Value, filter: &str, substrate: FilterSubstrate) 
         FilterSubstrate::JsonDumps => to_json_dumps_string(record),
         FilterSubstrate::PythonRepr => to_python_repr_string(record),
     };
-    haystack.contains(filter)
+    // Case-fold both sides, matching the tool's `arg.lower() in str(...).lower()`.
+    // An empty filter still matches (`contains("")` is always true).
+    haystack.to_lowercase().contains(&filter.to_lowercase())
 }
 
 #[cfg(test)]
@@ -278,6 +291,35 @@ mod tests {
         assert!(matches_filter(&record, "None", FilterSubstrate::PythonRepr));
         assert!(!matches_filter(&record, "None", FilterSubstrate::JsonDumps));
         assert!(matches_filter(&record, "null", FilterSubstrate::JsonDumps));
+    }
+
+    #[test]
+    fn test_matches_filter_is_case_insensitive() {
+        // The tool filters with `arg.lower() in str(record).lower()`, so a
+        // differently-cased term must still match (e.g. `listRules none`
+        // matching a `None`/`null` in the record).
+        let record = json!({"RULE": "RESOLVE", "J": null});
+
+        // Term case differs from the record in every substrate.
+        assert!(matches_filter(
+            &record,
+            "resolve",
+            FilterSubstrate::JsonDumps
+        ));
+        assert!(matches_filter(
+            &record,
+            "RESOLVE",
+            FilterSubstrate::JsonDumps
+        ));
+        assert!(matches_filter(&record, "ReSoLvE", FilterSubstrate::Compact));
+        // `none` matches the repr rendering of `null` (None) case-insensitively.
+        assert!(matches_filter(&record, "none", FilterSubstrate::PythonRepr));
+        // Non-substring still misses regardless of case.
+        assert!(!matches_filter(
+            &record,
+            "candidate",
+            FilterSubstrate::JsonDumps
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Release v0.6.3

Two parity/robustness fixes raised during the CLI's Wave-2 read-path re-delegation, verified against the stock config and Python `sz_configtool` 4.4.0 and coordinated cross-session with the CLI. **Both are no-op on shipped data.**

### Fixed

- **`matches_filter` is now case-insensitive** — matches every `sz_configtool` list-filter site (`arg.lower() in str(record).lower()`). It previously did a case-sensitive `contains`, so calling the wrapper directly regressed filters such as `listRules none` to zero matches; the CLI kept its own case-insensitive `.contains` rather than adopting it. Both sides are now case-folded. Rustdoc corrected (the "mirroring Python's `in`" note referred to the bare operator the tool never uses) and now records that the tool's real `str(record)` substrate is `FilterSubstrate::PythonRepr`. — `04ff33a`

- **`delete_{expression,comparison,distinct}_call_element` no longer risk over-deleting a sibling BOM row.** `EXEC_ORDER` is derived FTYPE-aware (via the element's feature), but the final `retain` matched only `(call_id, FELEM_ID, EXEC_ORDER)`. If one call held two BOM rows sharing element **and** `EXEC_ORDER` under different features, disambiguating by feature would derive the right row then drop its sibling too. Not reachable on the stock config (add paths keep `EXEC_ORDER` unique per call, and the no-feature path already errors as ambiguous before `retain`); each `retain` now mirrors the derive predicate as a belt-and-braces guard. `standardize` was already FTYPE-inclusive, unchanged. — `2ae2f94`

### Behaviour note

The `matches_filter` change is observable — case-insensitive matching returns more results for mixed-case terms. This is a parity fix (SDK now matches the Python tool), not a regression. No API signatures change; no dependency changes.

### Gates

- `cargo test`: **331 test cases** pass (incl. the stock-template roundtrip) — two new regression tests (same-exec/different-FTYPE over-delete; case-insensitive matching across all three substrates).
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `cargo deny check`: not run locally (cargo-deny not installed); **no dependency changes** vs 0.6.2, so the deny surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
