### PR TITLE
Release v0.7.0: SDK-surface wave (#49, #50, #52, #53, #54, #55, #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,17 @@ policy — details in the sections below):
   `NotFound` / `AlreadyExists` families and given their own stable
   `SzErrorKind` discriminants and `reason_code()` strings (`"NOT_ON_CALL"` /
   `"ALREADY_PRESENT"`, both a permanent machine contract):
-  - **`NotOnCall`** — a call-element delete found nothing to remove (the
-    feature/element is not a BOM row of the call). Re-pointed sites: the shared
+  - **`NotOnCall`** — a call-element delete against an **existing** call found
+    the element is not one of its BOM rows. Re-pointed site: the shared
     `derive_bom_exec_order` "not found" arm (comparison/expression/distinct
-    delete) and the `delete_standardize_call_element` inline existence check.
+    delete). The three delete paths first call a new `ensure_call_exists` guard
+    so a **non-existent call id** (which `CallSelector::Id` does not otherwise
+    validate) stays a hard `NotFound` — "call ID N does not exist" — matching
+    Python `prepCallElement`, which errors on a missing call record before ever
+    looking at the BOM. `delete_standardize_call_element` is **not** re-pointed:
+    standardize has no call/BOM split (the `CFG_SFCALL` row *is* the element) and
+    no benign "not on call" concept, so any miss stays `NotFound` (its nearest
+    Python parity, `deleteStandardizeCall`, hard-errors on a miss).
   - **`AlreadyPresent`** — a call/call-element add is a no-op: a per-feature
     comparison/distinct call is already set, or the element is already on the
     call (all four `add_*_call_element` duplicate checks).
@@ -51,8 +58,15 @@ policy — details in the sections below):
   - **Breaking:** `SzConfigError` is not `#[non_exhaustive]`, so adding these
     variants breaks exhaustive downstream matches.
   - Verified against `tests/fixtures/g2config_template.json` (real Senzing v4
-    template) across all four call families, including a delete-path regression
-    guard that a delete of an on-call element removes exactly one BOM row.
+    template): the `NotOnCall` split across the three BOM-backed families, the
+    `NotFound` guard for a missing call id (all families, standardize included),
+    and a delete-path regression guard that a delete of an on-call element
+    removes exactly one BOM row.
+  - *Note (behavioural, Python-consistent):* a call-element delete now requires
+    the `CFG_?CALL` section to contain the call id, so a delete against a
+    BOM-only config fragment (no owning call row) now returns `NotFound` where it
+    previously proceeded. This also closes an orphan-BOM bug where such a row
+    could be deleted without its call existing.
 - **`FilterSubstrate::ValuesJoin` filter substrate (#56)** reproducing Python
   `do_listComparisonThresholds`' filter rendering: the record's **values only**
   (keys dropped) are each rendered via Python `str()` semantics — bare unquoted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,155 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-25
+
+SDK-surface wave resolving issues #49, #50, #52, #53, #54, #55 and #56, developed on
+`feat/v0.7.0-sdk-surface` in six reviewed steps and coordinated with the downstream
+`sz_configtool` CLI. Every write/validate/delete-path change is verified against
+`tests/fixtures/g2config_template.json` (the real Senzing v4 template), not synthetic
+data. Gates green: 376 test cases (247 unit + 47 integration + 82 doc), clippy
+`-D warnings` / `cargo fmt` clean.
+
+**Breaking changes** (folded into a single minor bump under the crate's stability
+policy — details in the sections below):
+
+1. **`settings::set_setting` value type + FFI value semantics (#52).** The `value`
+   parameter is now `impl Into<serde_json::Value>` (was `&str`) and is stored verbatim;
+   the `SzConfigTool_setSetting` FFI now parses `value` as JSON and rejects invalid JSON,
+   so a bare string must be passed as quoted JSON (`"\"hello\""`).
+2. **`*CallElementParams::exec_order` is now `Option<i64>` (was `i64`) (#55).** Affects
+   `AddComparisonCallElementParams`, `ExpressionCallElementParams` (and its `new()`
+   signature) and `AddDistinctCallElementParams`; `None` auto-allocates the next order.
+3. **New `SzConfigError` variants `NotOnCall` / `AlreadyPresent` (#53, #54).**
+   `SzConfigError` is not `#[non_exhaustive]`, so this breaks exhaustive downstream matches.
+
+### Added
+
+- **Error sub-case surface: `SzConfigError::NotOnCall` / `AlreadyPresent`
+  (#53, #54).** Two benign single-call sub-cases are carved out of the broader
+  `NotFound` / `AlreadyExists` families and given their own stable
+  `SzErrorKind` discriminants and `reason_code()` strings (`"NOT_ON_CALL"` /
+  `"ALREADY_PRESENT"`, both a permanent machine contract):
+  - **`NotOnCall`** — a call-element delete found nothing to remove (the
+    feature/element is not a BOM row of the call). Re-pointed sites: the shared
+    `derive_bom_exec_order` "not found" arm (comparison/expression/distinct
+    delete) and the `delete_standardize_call_element` inline existence check.
+  - **`AlreadyPresent`** — a call/call-element add is a no-op: a per-feature
+    comparison/distinct call is already set, or the element is already on the
+    call (all four `add_*_call_element` duplicate checks).
+  - Hard collisions are deliberately **unchanged**: a taken explicit id and a
+    taken exec-order stay `AlreadyExists`; a genuinely missing id/lookup stays
+    `NotFound`.
+  - New `SzConfigError::message(&self) -> &str` returns the bare inner payload
+    for every variant; `Display` output is byte-for-byte unchanged (both new
+    variants render the bare message, exactly like their parents). New
+    `not_on_call` / `already_present` constructors mirror the sibling variants.
+  - **Breaking:** `SzConfigError` is not `#[non_exhaustive]`, so adding these
+    variants breaks exhaustive downstream matches.
+  - Verified against `tests/fixtures/g2config_template.json` (real Senzing v4
+    template) across all four call families, including a delete-path regression
+    guard that a delete of an on-call element removes exactly one BOM row.
+- **`FilterSubstrate::ValuesJoin` filter substrate (#56)** reproducing Python
+  `do_listComparisonThresholds`' filter rendering: the record's **values only**
+  (keys dropped) are each rendered via Python `str()` semantics — bare unquoted
+  strings, `None`/`True`/`False`, decimal numbers — and joined with a single
+  space (`" ".join(str(v).lower() for v in record.values())`). New public
+  `to_values_join_string(&Value)` renders a value under this substrate;
+  `matches_filter` gains the corresponding arm. `JsonDumps` remains the default.
+  Verified against real `CFG_CFRTN` rows from `tests/fixtures/g2config_template.json`.
+
+### Fixed
+
+- **Threshold cap fields now reject present-but-wrong-type values (#50).** A new
+  module-private `optional_i64` helper backs every threshold param `TryFrom`:
+  a missing or `null` field parses to `None`, an integer to `Some(n)`, but a
+  present-but-wrong-type value (JSON string/float/bool) is now rejected as
+  `InvalidInput` instead of being silently coerced to `None`. Previously
+  `{"candidateCap": "500"}` was dropped by `.and_then(Value::as_i64)` and the
+  update became a silent no-op. Wired into `AddComparisonThresholdParams`,
+  `SetComparisonThresholdParams`, `AddGenericThresholdParams` and
+  `SetGenericThresholdParams` `TryFrom<&Value>` (all their i64 fields —
+  `execOrder`, the score fields, and the `candidateCap`/`scoringCap` caps). The
+  `SzConfigTool_setGenericThreshold` FFI, which bypassed `TryFrom` with inline
+  `.and_then(as_i64)` cap parsing, now routes through
+  `SetGenericThresholdParams::try_from` so it inherits the same strict typing.
+  - *Deliberate parity divergence:* for the **comparison-threshold** score/exec
+    fields this is stricter than the Python CLI, which coerces digit-strings
+    (`{"sameScore": "100"}` → `100`) via `validate_parms`; the SDK rejects a
+    quoted number there as `InvalidInput`. Generic-threshold caps match Python
+    exactly (Python also rejects non-int for those). A typed JSON library
+    rejecting quoted numbers is the intended contract; pass JSON numbers.
+- **`add_generic_threshold` aggregates validation like Python `sz_configtool`
+  (#49).** Missing required fields (`plan`, `behavior`, `scoring_cap`,
+  `candidate_cap`, `send_to_redo`) are now collected into a single
+  `MissingField` error rather than reported one at a time, mirroring Python
+  `do_addGenericThreshold`'s up-front `validate_parms`. The plan / feature /
+  duplicate checks keep their fail-fast ordering, then a collect-all validity
+  block (mirroring `validateGenericThreshold`) validates the `BEHAVIOR` code
+  against the canonical 17-code set via `behavior_domain::behavior_position`
+  (`BEHAVIOR_CODES`) — the exact set Python's `lookupBehaviorCode` checks, not
+  the broader `parse_behavior_code` — and `SEND_TO_REDO` via
+  `send_to_redo_canonical`, joining any failures into one `InvalidInput`. A
+  bogus behaviour code on an existing plan is now rejected instead of written.
+  All four changes are exercised against `tests/fixtures/g2config_template.json`
+  (bogus-behaviour rejection, a valid new per-feature add, a no-op check that
+  every shipped behaviour passes the new validator, and wrong-typed-cap
+  rejection).
+- **`thresholds::add_comparison_threshold` no longer regresses the CFRTN scoring
+  tier order (part of #55).** It (and the FFI-facing
+  `add_comparison_threshold_by_id`) now implement Python
+  `do_addComparisonThreshold`'s three-step order logic via
+  `resolve_cfrtn_exec_order`: an existing all-features (`FTYPE_ID = 0`)
+  return-value tier row's `EXEC_ORDER` is **reused verbatim** (load-bearing
+  scoring invariant — a naive max+1 there was a silent regression), else an
+  explicit order is honoured-or-rejected, else the next free order within
+  `(CFUNC_ID, FTYPE_ID = 0)` is allocated. `EXEC_ORDER` is never emitted as
+  `null`. Verified against CFRTN tier reuse across the 20 shipped all-features
+  tier rows in the real Senzing v4 template.
+- **`command_processor` `addComparisonCallElement` scope bug fixed (part of
+  #55).** It drops its manual next-order calc and passes `exec_order: None`,
+  fixing a per-`(call, feature)` scope bug — it now numbers the whole call,
+  per-`CFCALL_ID`.
+
+### Changed
+
+- **Execution-order auto-allocation policy across all add paths (#55).** Every
+  add path that writes an `EXEC_ORDER` now resolves it through one shared helper,
+  `helpers::get_desired_or_next_order(array, order_field, scope, desired)`
+  (mirroring Python `getDesiredValueOrNext` with its default `seed_order` of 0):
+  `None` auto-allocates the next free order within the row's scope, `Some(n > 0)`
+  is honoured when free and **rejected with `AlreadyExists` when already taken**
+  (SDK-wide reject-if-taken), and a value is always written as a concrete order,
+  never `null`. Scopes: `(FTYPE_ID, FELEM_ID)` for `add_standardize_call` /
+  `add_standardize_call_element` / `add_expression_call`; the call id for the
+  comparison / expression / distinct `add_*_call_element` BOM rows; the whole
+  table for `features::add_feature_comparison`.
+  - **Breaking:** the **comparison call-element** (`AddComparisonCallElementParams`),
+    **expression call-element** (`ExpressionCallElementParams`, and its `new()`
+    signature) and **distinct call-element** (`AddDistinctCallElementParams`)
+    `exec_order` fields changed from `i64` to `Option<i64>`; passing `None` now
+    auto-allocates instead of the field being mandatory.
+  - **`calls::distinct::add_distinct_call_element`** duplicate detection realigned
+    to `(DFCALL_ID, FTYPE_ID, FELEM_ID)` (dropping `EXEC_ORDER` from the identity),
+    matching the comparison/expression siblings and Python `addCallElement`.
+  - The `add_feature` bulk builder and positional BOM loops (`EXEC_ORDER` by
+    1-based list position) are deliberately outside this policy and unchanged.
+  - New `calls` module "Execution-order policy" doc section (with a scope table)
+    and a README mirror. Verified end-to-end against the real Senzing v4 template
+    (`tests/fixtures/g2config_template.json`).
+- **`settings::set_setting` now stores typed JSON values (#52).** *(Breaking —
+  API + FFI.)* The `value` parameter changed from `&str` to
+  `impl Into<serde_json::Value>` and the value is inserted verbatim (no
+  `json!(value)` stringification), matching Python `do_setSetting` which stores
+  the parsed value as-is (e.g. `setSetting {"name": "metaphone_version", "value": 3}`
+  stores the integer `3`). A `&str` value still stores a JSON string, so most
+  Rust callers are unaffected. The `SzConfigTool_setSetting` FFI now parses its
+  `value` C-string as JSON and **returns an error on invalid JSON** — no string
+  fallback; a bare string must be quoted JSON (`"\"hello\""`). The C ABI (3×
+  `char*`) is unchanged; the header comment documents the new value semantics.
+  Verified against `tests/fixtures/g2config_template.json`
+  (`SETTINGS.METAPHONE_VERSION`).
+
 ## [0.6.3] - 2026-08-25
 
 Patch: two parity/robustness fixes raised during the CLI's Wave-2 read-path re-delegation, verified

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ features::set_feature(&config, SetFeatureParams {
 
 All parameter structs implement `TryFrom<&Value>` for easy JSON conversion.
 
+### Execution-order policy
+
+Add paths that write an `EXEC_ORDER` (call elements, feature comparisons and
+comparison thresholds) resolve it uniformly:
+
+- `exec_order: None` — **auto-allocate** the next free order within the row's
+  scope (max in scope + 1).
+- `exec_order: Some(n)` (`n > 0`, free) — **honour** the requested order.
+- `exec_order: Some(n)` (`n > 0`, taken) — **reject** with `AlreadyExists`
+  (never silently reallocated).
+
+An order is always written as a concrete value, never `null`. The scope is the
+call for BOM elements, `(feature, element)` for standardize/expression calls,
+and the whole table for feature comparisons. Comparison thresholds additionally
+**reuse** an existing all-features return-value tier's order first, so
+per-feature overrides stay on the same scoring tier as the base row. See the
+`calls` module docs for the full table.
+
 ## Installation
 
 Add to your `Cargo.toml`:

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -632,6 +632,9 @@ struct SzConfigTool_result SzConfigTool_deleteElementFromFeature(const char *con
                                                                  const char *element_code);
 
 // Create or overwrite a named setting under G2_CONFIG.SETTINGS (name is uppercased).
+// The value param is a JSON-encoded value: it is parsed and stored verbatim as its
+// typed value (e.g. "3" is stored as the number 3). A bare string must be quoted JSON
+// (e.g. "\"hello\""). Invalid JSON returns an error (no string fallback).
 struct SzConfigTool_result SzConfigTool_setSetting(const char *config_json,
                                                    const char *name,
                                                    const char *value);

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -3,7 +3,7 @@
 //! Functions for managing CFG_CFCALL (comparison calls) and CFG_CFBOM
 //! (comparison bill of materials) configuration sections.
 
-use crate::calls::{CallSelector, derive_bom_exec_order, resolve_call_id};
+use crate::calls::{CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id};
 use crate::config_rows::{CfbomRow, CfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
@@ -65,7 +65,12 @@ pub struct AddComparisonCallElementParams {
     pub cfcall_id: i64,
     pub ftype_id: i64,
     pub felem_id: i64,
-    pub exec_order: i64,
+    /// Execution order, allocated per `CFCALL_ID` (see the "Execution-order
+    /// policy" in [`crate::calls`]). `None` auto-allocates the next order on the
+    /// call; `Some(n > 0)` requests that exact order and fails with
+    /// `AlreadyExists` if already taken. The written BOM row always carries a
+    /// concrete order.
+    pub exec_order: Option<i64>,
 }
 
 impl TryFrom<&Value> for AddComparisonCallElementParams {
@@ -85,10 +90,8 @@ impl TryFrom<&Value> for AddComparisonCallElementParams {
                 .get("felemId")
                 .and_then(|v| v.as_i64())
                 .ok_or_else(|| SzConfigError::MissingField("felemId".to_string()))?,
-            exec_order: json
-                .get("execOrder")
-                .and_then(|v| v.as_i64())
-                .ok_or_else(|| SzConfigError::MissingField("execOrder".to_string()))?,
+            // execOrder is optional: absent -> auto-allocate per call.
+            exec_order: json.get("execOrder").and_then(|v| v.as_i64()),
         })
     }
 }
@@ -172,7 +175,7 @@ pub fn add_comparison_call(
         .unwrap_or(false);
 
     if call_exists {
-        return Err(SzConfigError::AlreadyExists(format!(
+        return Err(SzConfigError::AlreadyPresent(format!(
             "Comparison call for feature {} already set",
             params.ftype_code
         )));
@@ -529,20 +532,36 @@ pub fn add_comparison_call_element(
             // ↑ Commented out: Python excludes EXEC_ORDER from duplicate check (sz_configtool line 2941)
             // Reason: Same element in same call is duplicate regardless of position/order
             {
-                return Err(SzConfigError::AlreadyExists(
+                return Err(SzConfigError::AlreadyPresent(
                     "Feature/element already exists for call".to_string(),
                 ));
             }
         }
     }
 
-    // Create new CBOM record via CfbomRow (use params.exec_order directly - no
-    // auto-assignment) so every key is always present.
+    // Allocate EXEC_ORDER per CFCALL_ID (the scope Python addCallElement numbers
+    // BOM execution order within: getDesiredValueOrNext(bom_table,
+    // [call_id_field, "EXEC_ORDER"], ...)). `None` auto-allocates; a supplied
+    // order is honoured or rejected if taken. Never left null.
+    let exec_order = {
+        let empty: Vec<Value> = Vec::new();
+        let cfbom_rows = config_data["G2_CONFIG"]["CFG_CFBOM"]
+            .as_array()
+            .unwrap_or(&empty);
+        crate::helpers::get_desired_or_next_order(
+            cfbom_rows,
+            "EXEC_ORDER",
+            &[("CFCALL_ID", params.cfcall_id)],
+            params.exec_order,
+        )?
+    };
+
+    // Create new CBOM record via CfbomRow so every key is always present.
     let row = CfbomRow {
         cfcall_id: params.cfcall_id,
         ftype_id: params.ftype_id,
         felem_id: params.felem_id,
-        exec_order: params.exec_order,
+        exec_order,
     };
     let new_record = serde_json::to_value(&row)?;
 
@@ -575,7 +594,8 @@ pub fn add_comparison_call_element(
 /// Modified configuration JSON string
 ///
 /// # Errors
-/// - `NotFound` if the element is not on the call (or the call/element codes don't resolve)
+/// - `NotFound` if the call id does not exist, or the call/element codes don't resolve
+/// - `NotOnCall` if the call exists but the element is not one of its BOM rows
 /// - `InvalidInput` if a feature code matches more than one call, or the element
 ///   matches more than one BOM row on the call (ambiguous)
 ///
@@ -604,6 +624,15 @@ pub fn delete_comparison_call_element(
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     let cfcall_id = resolve_call_id(config, &config_data, call, resolve_cfcall_id_for_feature)?;
+    // A non-existent call id is a hard NotFound (Python parity); only a missing
+    // element on an *existing* call is the benign NotOnCall from derive below.
+    ensure_call_exists(
+        &config_data,
+        "CFG_CFCALL",
+        "CFCALL_ID",
+        cfcall_id,
+        "Comparison",
+    )?;
     let felem_id = lookup_element_id(config, element_code)?;
     // When the element appears under multiple features in this call, the
     // element's feature disambiguates to the correct BOM row (Python parity).
@@ -715,11 +744,12 @@ mod tests {
     #[test]
     fn test_add_comparison_call_element_emits_all_keys() {
         let config = base_config();
+        // A specific free order is honoured (exec_order now Option).
         let params = AddComparisonCallElementParams {
             cfcall_id: 1000,
             ftype_id: 5,
             felem_id: 11,
-            exec_order: 2,
+            exec_order: Some(2),
         };
 
         let (modified, new_record) = add_comparison_call_element(&config, params).unwrap();
@@ -729,6 +759,54 @@ mod tests {
         assert_all_keys(cfbom, &CFBOM_KEYS);
         assert_all_keys(&new_record, &CFBOM_KEYS);
         assert_eq!(cfbom["EXEC_ORDER"], json!(2));
+    }
+
+    #[test]
+    fn test_add_comparison_call_element_auto_allocates_and_rejects_taken() {
+        // A call carrying one BOM row at order 1; a second element auto-allocates
+        // to 2, an explicit free order is honoured, and a taken order is rejected.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 1000, "FTYPE_ID": 5, "FELEM_ID": 11, "EXEC_ORDER": 1}
+            ],
+            "CFG_CFCALL": [{"CFCALL_ID": 1000, "FTYPE_ID": 5, "CFUNC_ID": 7}],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_CFUNC": [{"CFUNC_ID": 7, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FELEM": [{"FELEM_ID": 12, "FELEM_CODE": "LAST_NAME"}]
+        }}"#;
+
+        // None -> max (1) + 1 = 2.
+        let (modified, _) = add_comparison_call_element(
+            config,
+            AddComparisonCallElementParams {
+                cfcall_id: 1000,
+                ftype_id: 5,
+                felem_id: 12,
+                exec_order: None,
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let new_row = value["G2_CONFIG"]["CFG_CFBOM"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["FELEM_ID"].as_i64() == Some(12))
+            .unwrap();
+        assert_eq!(new_row["EXEC_ORDER"], json!(2));
+
+        // A taken order on the same call -> AlreadyExists.
+        let err = add_comparison_call_element(
+            config,
+            AddComparisonCallElementParams {
+                cfcall_id: 1000,
+                ftype_id: 5,
+                felem_id: 12,
+                exec_order: Some(1),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 
     #[test]
@@ -829,14 +907,37 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_comparison_call_element_not_found() {
+    fn test_delete_comparison_call_element_missing_call_is_not_found() {
+        // A call id that does not exist at all is a hard NotFound (Python's
+        // prepCallElement errors on the missing call record before touching the
+        // BOM), NOT the benign NotOnCall.
         let config = populated_config();
-        let err = delete_comparison_call_element(&config, CallSelector::Id(7), "LAST_NAME", None);
-        assert!(err.is_ok());
-        // Element on a call that has no such BOM row -> NotFound.
         let err =
-            delete_comparison_call_element(&config, CallSelector::Id(999), "FIRST_NAME", None);
-        assert_eq!(err.unwrap_err().kind(), crate::error::SzErrorKind::NotFound);
+            delete_comparison_call_element(&config, CallSelector::Id(999), "FIRST_NAME", None)
+                .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
+        assert_eq!(err.to_string(), "Comparison call ID 999 does not exist");
+    }
+
+    #[test]
+    fn test_delete_comparison_call_element_not_on_existing_call_is_not_on_call() {
+        // The call exists, but this element is not among its BOM rows -> the
+        // benign NotOnCall sub-case (step D). MIDDLE_NAME exists as an element
+        // but is not on call 7.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 13, "FELEM_CODE": "MIDDLE_NAME"}
+            ],
+            "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+        let err = delete_comparison_call_element(config, CallSelector::Id(7), "MIDDLE_NAME", None)
+            .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotOnCall);
     }
 
     // #41: stored order deliberately differs from the sorted (FTYPE_ID, CFCALL_ID)

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -3,7 +3,7 @@
 //! Functions for managing CFG_DFCALL (distinct calls) and CFG_DFBOM
 //! (distinct bill of materials) configuration sections.
 
-use crate::calls::{CallSelector, derive_bom_exec_order, resolve_call_id};
+use crate::calls::{CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id};
 use crate::config_rows::{DfbomRow, DfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
@@ -58,7 +58,12 @@ pub struct AddDistinctCallElementParams {
     pub dfcall_id: i64,
     pub ftype_id: i64,
     pub felem_id: i64,
-    pub exec_order: i64,
+    /// Execution order, allocated per `DFCALL_ID` (see the "Execution-order
+    /// policy" in [`crate::calls`]). `None` auto-allocates the next order on the
+    /// call; `Some(n > 0)` requests that exact order and fails with
+    /// `AlreadyExists` if already taken. The written BOM row always carries a
+    /// concrete order.
+    pub exec_order: Option<i64>,
 }
 
 /// Parameters for setting (updating) a distinct call
@@ -147,7 +152,7 @@ pub fn add_distinct_call(config: &str, params: AddDistinctCallParams) -> Result<
         .unwrap_or(false);
 
     if call_exists {
-        return Err(SzConfigError::AlreadyExists(format!(
+        return Err(SzConfigError::AlreadyPresent(format!(
             "Distinct call for feature {} already set",
             params.ftype_code
         )));
@@ -476,7 +481,10 @@ pub fn add_distinct_call_element(
     let mut config_data: Value =
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
-    // Check if element already exists
+    // Check if element already exists. Dup identity is (DFCALL_ID, FTYPE_ID,
+    // FELEM_ID) — EXEC_ORDER is NOT part of it (realigned to match the
+    // comparison/expression siblings and Python addCallElement, which treats the
+    // same element on a call as a duplicate regardless of position).
     if let Some(dbom_array) = config_data
         .get("G2_CONFIG")
         .and_then(|g| g.get("CFG_DFBOM"))
@@ -486,21 +494,36 @@ pub fn add_distinct_call_element(
             if item.get("DFCALL_ID").and_then(|v| v.as_i64()) == Some(params.dfcall_id)
                 && item.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(params.ftype_id)
                 && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(params.felem_id)
-                && item.get("EXEC_ORDER").and_then(|v| v.as_i64()) == Some(params.exec_order)
             {
-                return Err(SzConfigError::AlreadyExists(
+                return Err(SzConfigError::AlreadyPresent(
                     "Distinct call element already exists".to_string(),
                 ));
             }
         }
     }
 
+    // Allocate EXEC_ORDER per DFCALL_ID (the scope Python addCallElement numbers
+    // BOM execution order within). `None` auto-allocates; a supplied order is
+    // honoured or rejected if taken. Never left null.
+    let exec_order = {
+        let empty: Vec<Value> = Vec::new();
+        let dfbom_rows = config_data["G2_CONFIG"]["CFG_DFBOM"]
+            .as_array()
+            .unwrap_or(&empty);
+        crate::helpers::get_desired_or_next_order(
+            dfbom_rows,
+            "EXEC_ORDER",
+            &[("DFCALL_ID", params.dfcall_id)],
+            params.exec_order,
+        )?
+    };
+
     // Create new DBOM record via DfbomRow so every key is always present.
     let row = DfbomRow {
         dfcall_id: params.dfcall_id,
         ftype_id: params.ftype_id,
         felem_id: params.felem_id,
-        exec_order: params.exec_order,
+        exec_order,
     };
     let new_record = serde_json::to_value(&row)?;
 
@@ -533,7 +556,8 @@ pub fn add_distinct_call_element(
 /// Modified configuration JSON string
 ///
 /// # Errors
-/// - `NotFound` if the element is not on the call (or the call/element codes don't resolve)
+/// - `NotFound` if the call id does not exist, or the call/element codes don't resolve
+/// - `NotOnCall` if the call exists but the element is not one of its BOM rows
 /// - `InvalidInput` if a feature code matches more than one call, or the element
 ///   matches more than one BOM row on the call (ambiguous)
 ///
@@ -562,6 +586,15 @@ pub fn delete_distinct_call_element(
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     let dfcall_id = resolve_call_id(config, &config_data, call, resolve_dfcall_id_for_feature)?;
+    // A non-existent call id is a hard NotFound (Python parity); only a missing
+    // element on an *existing* call is the benign NotOnCall from derive below.
+    ensure_call_exists(
+        &config_data,
+        "CFG_DFCALL",
+        "DFCALL_ID",
+        dfcall_id,
+        "Distinct",
+    )?;
     let felem_id = lookup_element_id(config, element_code)?;
     // When the element appears under multiple features in this call, the
     // element's feature disambiguates to the correct BOM row (Python parity).
@@ -676,11 +709,12 @@ mod tests {
     #[test]
     fn test_add_distinct_call_element_emits_all_keys() {
         let config = base_config();
+        // A specific free order is honoured (exec_order now Option).
         let params = AddDistinctCallElementParams {
             dfcall_id: 1000,
             ftype_id: 5,
             felem_id: 11,
-            exec_order: 3,
+            exec_order: Some(3),
         };
 
         let (modified, new_record) = add_distinct_call_element(&config, params).unwrap();
@@ -690,6 +724,53 @@ mod tests {
         assert_all_keys(dfbom, &DFBOM_KEYS);
         assert_all_keys(&new_record, &DFBOM_KEYS);
         assert_eq!(dfbom["EXEC_ORDER"], json!(3));
+    }
+
+    #[test]
+    fn test_add_distinct_call_element_auto_alloc_and_dup_ignores_exec_order() {
+        // Call 1000 carries one BOM row at order 1. Auto-alloc gives 2, and the
+        // dup check on (DFCALL_ID, FTYPE_ID, FELEM_ID) rejects the same element
+        // even when a DIFFERENT exec_order is requested.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_DFBOM": [
+                {"DFCALL_ID": 1000, "FTYPE_ID": 5, "FELEM_ID": 11, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+
+        // New element -> next order 2.
+        let (modified, _) = add_distinct_call_element(
+            config,
+            AddDistinctCallElementParams {
+                dfcall_id: 1000,
+                ftype_id: 5,
+                felem_id: 12,
+                exec_order: None,
+            },
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let new_row = value["G2_CONFIG"]["CFG_DFBOM"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["FELEM_ID"].as_i64() == Some(12))
+            .unwrap();
+        assert_eq!(new_row["EXEC_ORDER"], json!(2));
+
+        // Same (call, ftype, felem) but a different exec_order -> still a dup.
+        let err = add_distinct_call_element(
+            config,
+            AddDistinctCallElementParams {
+                dfcall_id: 1000,
+                ftype_id: 5,
+                felem_id: 11,
+                exec_order: Some(99),
+            },
+        )
+        .unwrap_err();
+        // A duplicate element on the call is the benign "already present"
+        // sub-case (step D), distinct from a taken exec-order (AlreadyExists).
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyPresent);
     }
 
     // #40 fixtures: DFCALL_ID (11) deliberately differs from FTYPE_ID (3). The

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -3,7 +3,7 @@
 //! Functions for managing CFG_EFCALL (expression calls) and CFG_EFBOM
 //! (expression bill of materials) configuration sections.
 
-use crate::calls::{CallSelector, derive_bom_exec_order, resolve_call_id};
+use crate::calls::{CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id};
 use crate::config_rows::{EfbomRow, EfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
@@ -47,12 +47,17 @@ impl<'a> AddExpressionCallParams<'a> {
 pub struct ExpressionCallElementParams {
     pub ftype_id: i64,
     pub felem_id: i64,
-    pub exec_order: i64,
+    /// Execution order, allocated per `EFCALL_ID` (see the "Execution-order
+    /// policy" in [`crate::calls`]). `None` auto-allocates the next order on the
+    /// call; `Some(n > 0)` requests that exact order and fails with
+    /// `AlreadyExists` if already taken. The written BOM row always carries a
+    /// concrete order.
+    pub exec_order: Option<i64>,
     pub felem_req: String,
 }
 
 impl ExpressionCallElementParams {
-    pub fn new(ftype_id: i64, felem_id: i64, exec_order: i64, felem_req: String) -> Self {
+    pub fn new(ftype_id: i64, felem_id: i64, exec_order: Option<i64>, felem_req: String) -> Self {
         Self {
             ftype_id,
             felem_id,
@@ -133,42 +138,20 @@ pub fn add_expression_call(
         ));
     }
 
-    // Determine exec_order
-    let final_exec_order = if let Some(order) = params.exec_order {
-        // Check if this exec_order is already taken for this feature/element
-        let order_taken = config_data["G2_CONFIG"]["CFG_EFCALL"]
+    // Determine exec_order per (FTYPE_ID, FELEM_ID) via the shared helper: a
+    // supplied value is honoured or rejected if taken, otherwise the next free
+    // order is allocated (Scheme C — same policy as the standardize call path).
+    let final_exec_order = {
+        let empty: Vec<Value> = Vec::new();
+        let efcall_rows = config_data["G2_CONFIG"]["CFG_EFCALL"]
             .as_array()
-            .map(|arr| {
-                arr.iter().any(|call| {
-                    call["FTYPE_ID"].as_i64() == Some(ftype_id)
-                        && call["FELEM_ID"].as_i64() == Some(felem_id)
-                        && call["EXEC_ORDER"].as_i64() == Some(order)
-                })
-            })
-            .unwrap_or(false);
-
-        if order_taken {
-            return Err(SzConfigError::AlreadyExists(format!(
-                "Execution order {order} already taken for this feature/element"
-            )));
-        }
-        order
-    } else {
-        // Get next available exec_order for this feature/element combination
-        config_data["G2_CONFIG"]["CFG_EFCALL"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter(|call| {
-                        call["FTYPE_ID"].as_i64() == Some(ftype_id)
-                            && call["FELEM_ID"].as_i64() == Some(felem_id)
-                    })
-                    .filter_map(|call| call["EXEC_ORDER"].as_i64())
-                    .max()
-                    .map(|max| max + 1)
-                    .unwrap_or(1)
-            })
-            .unwrap_or(1)
+            .unwrap_or(&empty);
+        crate::helpers::get_desired_or_next_order(
+            efcall_rows,
+            "EXEC_ORDER",
+            &[("FTYPE_ID", ftype_id), ("FELEM_ID", felem_id)],
+            params.exec_order,
+        )?
     };
 
     // Lookup expression feature ID if specified
@@ -537,20 +520,35 @@ pub fn add_expression_call_element(
             // ↑ Commented out: Python excludes EXEC_ORDER from duplicate check (sz_configtool line 2941)
             // Reason: Same element in same call is duplicate regardless of position/order
             {
-                return Err(SzConfigError::AlreadyExists(
+                return Err(SzConfigError::AlreadyPresent(
                     "Feature/element already exists for call".to_string(),
                 ));
             }
         }
     }
 
-    // Create new EBOM record via EfbomRow (use params.exec_order directly - no
-    // auto-assignment) so every key is always present.
+    // Allocate EXEC_ORDER per EFCALL_ID (the scope Python addCallElement numbers
+    // BOM execution order within). `None` auto-allocates; a supplied order is
+    // honoured or rejected if taken. Never left null.
+    let exec_order = {
+        let empty: Vec<Value> = Vec::new();
+        let efbom_rows = config_data["G2_CONFIG"]["CFG_EFBOM"]
+            .as_array()
+            .unwrap_or(&empty);
+        crate::helpers::get_desired_or_next_order(
+            efbom_rows,
+            "EXEC_ORDER",
+            &[("EFCALL_ID", efcall_id)],
+            params.exec_order,
+        )?
+    };
+
+    // Create new EBOM record via EfbomRow so every key is always present.
     let row = EfbomRow {
         efcall_id,
         ftype_id: params.ftype_id,
         felem_id: params.felem_id,
-        exec_order: params.exec_order,
+        exec_order,
         felem_req: params.felem_req,
     };
     let new_record = serde_json::to_value(&row)?;
@@ -588,7 +586,8 @@ pub fn add_expression_call_element(
 /// Modified configuration JSON string
 ///
 /// # Errors
-/// - `NotFound` if the element is not on the call (or the call/element codes don't resolve)
+/// - `NotFound` if the call id does not exist, or the call/element codes don't resolve
+/// - `NotOnCall` if the call exists but the element is not one of its BOM rows
 /// - `InvalidInput` if a feature code matches more than one call, or the element
 ///   matches more than one BOM row on the call (ambiguous)
 ///
@@ -598,6 +597,7 @@ pub fn add_expression_call_element(
 /// use sz_configtool_lib::calls::expression::delete_expression_call_element;
 /// let config = r#"{"G2_CONFIG": {
 ///     "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}],
+///     "CFG_EFCALL": [{"EFCALL_ID": 9, "FTYPE_ID": 3, "EFUNC_ID": 1, "EXEC_ORDER": 1}],
 ///     "CFG_EFBOM": [{"EFCALL_ID": 9, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "No"}]
 /// }}"#;
 /// let out = delete_expression_call_element(
@@ -615,6 +615,15 @@ pub fn delete_expression_call_element(
         serde_json::from_str(config).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
     let efcall_id = resolve_call_id(config, &config_data, call, resolve_efcall_id_for_feature)?;
+    // A non-existent call id is a hard NotFound (Python parity); only a missing
+    // element on an *existing* call is the benign NotOnCall from derive below.
+    ensure_call_exists(
+        &config_data,
+        "CFG_EFCALL",
+        "EFCALL_ID",
+        efcall_id,
+        "Expression",
+    )?;
     let felem_id = lookup_element_id(config, element_code)?;
     // When the element appears under multiple features in this call, the
     // element's feature disambiguates to the correct BOM row (Python parity).
@@ -741,7 +750,8 @@ mod tests {
     #[test]
     fn test_add_expression_call_element_emits_all_keys() {
         let config = base_config();
-        let params = ExpressionCallElementParams::new(5, 11, 2, "Yes".to_string());
+        // A specific free order is honoured (exec_order now Option).
+        let params = ExpressionCallElementParams::new(5, 11, Some(2), "Yes".to_string());
 
         let (modified, new_record) = add_expression_call_element(&config, 1000, params).unwrap();
         let value: Value = serde_json::from_str(&modified).unwrap();
@@ -751,6 +761,39 @@ mod tests {
         assert_all_keys(&new_record, &EFBOM_KEYS);
         assert_eq!(efbom["FELEM_REQ"], json!("Yes"));
         assert_eq!(efbom["EXEC_ORDER"], json!(2));
+    }
+
+    #[test]
+    fn test_add_expression_call_element_auto_allocates_and_rejects_taken() {
+        // One BOM row at order 1 on call 1000; auto-alloc gives 2, taken -> reject.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_EFBOM": [
+                {"EFCALL_ID": 1000, "FTYPE_ID": 5, "FELEM_ID": 11, "EXEC_ORDER": 1, "FELEM_REQ": "No"}
+            ]
+        }}"#;
+
+        let (modified, _) = add_expression_call_element(
+            config,
+            1000,
+            ExpressionCallElementParams::new(5, 12, None, "No".to_string()),
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let new_row = value["G2_CONFIG"]["CFG_EFBOM"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["FELEM_ID"].as_i64() == Some(12))
+            .unwrap();
+        assert_eq!(new_row["EXEC_ORDER"], json!(2));
+
+        let err = add_expression_call_element(
+            config,
+            1000,
+            ExpressionCallElementParams::new(5, 12, Some(1), "No".to_string()),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 
     // #40 fixtures: two expression calls bound to the same feature (legitimate —

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -10,6 +10,40 @@
 //!
 //! Each call type links functions to features/elements with execution order and
 //! maintains associated bill of materials (BOM) records for element relationships.
+//!
+//! # Execution-order policy
+//!
+//! Every add path that writes an `EXEC_ORDER` resolves it through one shared
+//! helper, [`crate::helpers::get_desired_or_next_order`], so the behaviour is
+//! uniform across the SDK. The three intents are:
+//!
+//! - **Auto-allocate** (`exec_order: None`): the next free order *within the
+//!   row's scope* is used (max in scope + 1, seeded at `0` so an empty scope
+//!   starts at `1`).
+//! - **Honour** (`Some(n)`, `n > 0`, free in scope): the requested order is used
+//!   verbatim.
+//! - **Reject** (`Some(n)`, `n > 0`, already taken in scope): the call fails with
+//!   `AlreadyExists` rather than silently reallocating (the SDK-wide
+//!   reject-if-taken policy). A non-positive value falls through to
+//!   auto-allocation.
+//!
+//! An order is always resolved to a concrete value — it is never written as
+//! `null`. The *scope* (the senior key fields that partition the order space)
+//! differs per family:
+//!
+//! | Path | Section | Scope |
+//! |------|---------|-------|
+//! | `add_standardize_call` / `add_standardize_call_element` | `CFG_SFCALL` | `(FTYPE_ID, FELEM_ID)` |
+//! | `add_expression_call` | `CFG_EFCALL` | `(FTYPE_ID, FELEM_ID)` |
+//! | comparison / expression / distinct `add_*_call_element` | `CFG_?FBOM` | `(call id)` |
+//! | `features::add_feature_comparison` | `CFG_FBOM` | whole table |
+//! | `thresholds::add_comparison_threshold` | `CFG_CFRTN` | `(CFUNC_ID, FTYPE_ID=0)`, after tier reuse |
+//!
+//! The comparison-threshold path additionally reuses an existing all-features
+//! (`FTYPE_ID = 0`) return-value tier's order before falling back to the policy
+//! above — see [`crate::thresholds`]. The `add_feature` bulk builder and the
+//! positional BOM loops assign `EXEC_ORDER` by 1-based list position and are
+//! deliberately outside this policy.
 
 pub mod comparison;
 pub mod distinct;
@@ -115,7 +149,7 @@ pub(crate) fn derive_bom_exec_order(
         .collect();
 
     match orders.as_slice() {
-        [] => Err(SzConfigError::NotFound(format!(
+        [] => Err(SzConfigError::NotOnCall(format!(
             "{label} call element not found"
         ))),
         [order] => Ok(*order),
@@ -123,6 +157,40 @@ pub(crate) fn derive_bom_exec_order(
             "Ambiguous {label} call element: element matches {} rows across features; specify the element's feature to disambiguate",
             many.len()
         ))),
+    }
+}
+
+/// Assert that a call with `call_id` exists in `section`, returning `NotFound`
+/// otherwise.
+///
+/// This distinguishes the two "no BOM row" situations that
+/// [`derive_bom_exec_order`] alone cannot: a *missing element on an existing
+/// call* (the benign [`SzConfigError::NotOnCall`]) versus a *call that does not
+/// exist at all* (a hard [`SzConfigError::NotFound`], matching Python's
+/// `prepCallElement`, which errors on a missing call record before ever looking
+/// at the BOM). Delete-by-`CallSelector::Id` skips the resolver's existence
+/// check, so the call-family delete paths call this first.
+pub(crate) fn ensure_call_exists(
+    root: &Value,
+    section: &str,
+    id_field: &str,
+    call_id: i64,
+    label: &str,
+) -> Result<()> {
+    let exists = root
+        .get("G2_CONFIG")
+        .and_then(|g| g.get(section))
+        .and_then(|v| v.as_array())
+        .is_some_and(|rows| {
+            rows.iter()
+                .any(|r| r.get(id_field).and_then(|v| v.as_i64()) == Some(call_id))
+        });
+    if exists {
+        Ok(())
+    } else {
+        Err(SzConfigError::NotFound(format!(
+            "{label} call ID {call_id} does not exist"
+        )))
     }
 }
 

--- a/src/calls/standardize.rs
+++ b/src/calls/standardize.rs
@@ -43,6 +43,11 @@ pub struct AddStandardizeCallElementParams {
     pub ftype_id: i64,
     pub sfunc_id: i64,
     pub felem_id: Option<i64>,
+    /// Execution order, allocated per `(FTYPE_ID, FELEM_ID)` (see the
+    /// "Execution-order policy" in [`crate::calls`]). `None` auto-allocates the
+    /// next order for that feature/element; `Some(n > 0)` requests that exact
+    /// order and fails with `AlreadyExists` if already taken. The written row
+    /// always carries a concrete order, never null.
     pub exec_order: Option<i64>,
 }
 
@@ -134,42 +139,20 @@ pub fn add_standardize_call(
         ));
     }
 
-    // Determine exec_order: use provided value or get next available for this feature/element
-    let final_exec_order = if let Some(order) = params.exec_order {
-        // Check if this exec_order is already taken for this feature/element
-        let order_taken = config_data["G2_CONFIG"]["CFG_SFCALL"]
+    // Determine exec_order per (FTYPE_ID, FELEM_ID) via the shared helper: a
+    // supplied value is honoured or rejected if taken, otherwise the next free
+    // order is allocated (Scheme C — same policy as the *element path).
+    let final_exec_order = {
+        let empty: Vec<Value> = Vec::new();
+        let sfcall_rows = config_data["G2_CONFIG"]["CFG_SFCALL"]
             .as_array()
-            .map(|arr| {
-                arr.iter().any(|call| {
-                    call["FTYPE_ID"].as_i64() == Some(ftype_id)
-                        && call["FELEM_ID"].as_i64() == Some(felem_id)
-                        && call["EXEC_ORDER"].as_i64() == Some(order)
-                })
-            })
-            .unwrap_or(false);
-
-        if order_taken {
-            return Err(SzConfigError::AlreadyExists(format!(
-                "Execution order {order} already taken for this feature/element"
-            )));
-        }
-        order
-    } else {
-        // Get next available exec_order for this feature/element combination
-        config_data["G2_CONFIG"]["CFG_SFCALL"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter(|call| {
-                        call["FTYPE_ID"].as_i64() == Some(ftype_id)
-                            && call["FELEM_ID"].as_i64() == Some(felem_id)
-                    })
-                    .filter_map(|call| call["EXEC_ORDER"].as_i64())
-                    .max()
-                    .map(|max| max + 1)
-                    .unwrap_or(1)
-            })
-            .unwrap_or(1)
+            .unwrap_or(&empty);
+        crate::helpers::get_desired_or_next_order(
+            sfcall_rows,
+            "EXEC_ORDER",
+            &[("FTYPE_ID", ftype_id), ("FELEM_ID", felem_id)],
+            params.exec_order,
+        )?
     };
 
     // Create new CFG_SFCALL record via SfcallRow so every key is always present.
@@ -435,7 +418,7 @@ pub fn add_standardize_call_element(
                 && item.get("SFUNC_ID").and_then(|v| v.as_i64()) == Some(params.sfunc_id)
                 && item.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(final_felem_id)
             {
-                return Err(SzConfigError::AlreadyExists(
+                return Err(SzConfigError::AlreadyPresent(
                     "Standardize call element already exists".to_string(),
                 ));
             }
@@ -445,14 +428,32 @@ pub fn add_standardize_call_element(
     // Get next SFCALL_ID
     let sfcall_id = get_next_id(&config_data, "G2_CONFIG.CFG_SFCALL", "SFCALL_ID", 1000)?;
 
+    // Allocate EXEC_ORDER per (FTYPE_ID, FELEM_ID) — the scope Python
+    // do_addStandardizeCall numbers standardize execution order within
+    // (getDesiredValueOrNext("CFG_SFCALL", ["FTYPE_ID","FELEM_ID","EXEC_ORDER"])).
+    // `None` auto-allocates the next order; a supplied order is honoured or
+    // rejected if taken. An order is always resolved, never left null.
+    let exec_order = {
+        let empty: Vec<Value> = Vec::new();
+        let sfcall_rows = config_data["G2_CONFIG"]["CFG_SFCALL"]
+            .as_array()
+            .unwrap_or(&empty);
+        crate::helpers::get_desired_or_next_order(
+            sfcall_rows,
+            "EXEC_ORDER",
+            &[("FTYPE_ID", params.ftype_id), ("FELEM_ID", final_felem_id)],
+            params.exec_order,
+        )?
+    };
+
     // Create new call element record via SfcallRow so every key is always
-    // present (EXEC_ORDER null when not specified - seed-then-null pattern).
+    // present; EXEC_ORDER now always carries the allocated value.
     let row = SfcallRow {
         sfcall_id,
         ftype_id: params.ftype_id,
         felem_id: final_felem_id,
         sfunc_id: params.sfunc_id,
-        exec_order: params.exec_order,
+        exec_order: Some(exec_order),
     };
     let new_record = serde_json::to_value(&row)?;
 
@@ -499,7 +500,7 @@ pub fn delete_standardize_call_element(
         .unwrap_or(false);
 
     if !element_exists {
-        return Err(SzConfigError::NotFound(
+        return Err(SzConfigError::NotOnCall(
             "Standardize call element not found".to_string(),
         ));
     }
@@ -605,7 +606,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_standardize_call_element_emits_exec_order_null_when_absent() {
+    fn test_add_standardize_call_element_auto_allocates_exec_order_when_absent() {
         let config = base_config();
         let params = AddStandardizeCallElementParams {
             ftype_id: 5,
@@ -618,10 +619,40 @@ mod tests {
         let value: Value = serde_json::from_str(&modified).unwrap();
         let sfcall = &value["G2_CONFIG"]["CFG_SFCALL"][0];
 
-        // EXEC_ORDER key present but null (seed-then-null preserved); FELEM_ID -1.
+        // EXEC_ORDER is now auto-allocated (not left null): the first row for
+        // (FTYPE_ID 5, FELEM_ID -1) gets order 1. FELEM_ID defaults to -1.
         assert_all_keys(sfcall, &SFCALL_KEYS);
-        assert_eq!(sfcall["EXEC_ORDER"], Value::Null);
+        assert_eq!(sfcall["EXEC_ORDER"], json!(1));
         assert_eq!(sfcall["FELEM_ID"], json!(-1));
+    }
+
+    #[test]
+    fn test_add_standardize_call_element_increments_per_feature_element() {
+        // A second element on the same (FTYPE_ID, FELEM_ID) scope increments.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 5, "FTYPE_ID": 5, "FELEM_ID": 11, "SFUNC_ID": 7, "EXEC_ORDER": 1}
+            ],
+            "CFG_FTYPE": [{"FTYPE_ID": 5, "FTYPE_CODE": "NAME"}],
+            "CFG_SFUNC": [{"SFUNC_ID": 7, "SFUNC_CODE": "PARSE_NAME"}],
+            "CFG_FELEM": [{"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"}]
+        }}"#;
+        let params = AddStandardizeCallElementParams {
+            ftype_id: 5,
+            sfunc_id: 8,
+            felem_id: Some(11),
+            exec_order: None,
+        };
+        let (modified, _) = add_standardize_call_element(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let new_row = value["G2_CONFIG"]["CFG_SFCALL"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["SFUNC_ID"].as_i64() == Some(8))
+            .unwrap();
+        // Existing (5,11) order 1 -> next is 2.
+        assert_eq!(new_row["EXEC_ORDER"], json!(2));
     }
 
     // #40 regression fixtures: SFCALL_ID (5) deliberately differs from FTYPE_ID

--- a/src/calls/standardize.rs
+++ b/src/calls/standardize.rs
@@ -500,7 +500,12 @@ pub fn delete_standardize_call_element(
         .unwrap_or(false);
 
     if !element_exists {
-        return Err(SzConfigError::NotOnCall(
+        // Standardize has no call/BOM two-tier split (the CFG_SFCALL row *is* the
+        // element), and Python has no deleteStandardizeCallElement — its nearest
+        // parity, deleteStandardizeCall, hard-errors on a miss. So a non-match is
+        // a plain NotFound, not the benign NotOnCall used by the BOM-backed
+        // comparison/expression/distinct families.
+        return Err(SzConfigError::NotFound(
             "Standardize call element not found".to_string(),
         ));
     }

--- a/src/command_processor.rs
+++ b/src/command_processor.rs
@@ -586,30 +586,16 @@ fn execute_command(config: &str, cmd: &str, params: &Value) -> Result<String> {
                 .as_i64()
                 .ok_or_else(|| SzConfigError::InvalidStructure("CFCALL_ID missing".to_string()))?;
 
-            // Determine next exec_order
-            let cfbom_array = config_val["G2_CONFIG"]["CFG_CFBOM"]
-                .as_array()
-                .ok_or_else(|| SzConfigError::MissingSection("CFG_CFBOM".to_string()))?;
-
-            let next_order = cfbom_array
-                .iter()
-                .filter(|bom| {
-                    bom["CFCALL_ID"].as_i64() == Some(cfcall_id)
-                        && bom["FTYPE_ID"].as_i64() == Some(ftype_id)
-                })
-                .filter_map(|bom| bom["EXEC_ORDER"].as_i64())
-                .max()
-                .unwrap_or(0)
-                + 1;
-
-            // Call underlying SDK function
+            // exec_order: None -> the SDK auto-allocates per CFCALL_ID. This drops
+            // the old manual calc, which scoped by (call, ftype) and so restarted
+            // the count per element-feature instead of numbering the whole call.
             crate::calls::comparison::add_comparison_call_element(
                 config,
                 crate::calls::comparison::AddComparisonCallElementParams {
                     cfcall_id,
                     ftype_id,
                     felem_id,
-                    exec_order: next_order,
+                    exec_order: None,
                 },
             )
             .map(|(cfg, _)| cfg)

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -45,7 +45,15 @@ pub(crate) fn validate_derived(value: &str) -> Result<&'static str> {
 /// Parameters for adding an element to a feature (a new CFG_FBOM row).
 ///
 /// `display_level` defaults to `1`, `derived` to `"No"`, and `display_delim` to
-/// null when omitted. `EXEC_ORDER` is always allocated automatically.
+/// null when omitted.
+///
+/// This path does not accept an `exec_order`: `EXEC_ORDER` is *always*
+/// auto-allocated across the whole `CFG_FBOM` table (max + 1). To request a
+/// specific order (honour-or-reject), use
+/// [`features::add_feature_comparison`](crate::features::add_feature_comparison),
+/// which shares the same table but takes an `exec_order`. `DISPLAY_LEVEL` is the
+/// display fact carried on the FBOM row (0 = not displayed); the element's
+/// `FELEM_DESC` lives on the `CFG_FELEM` row, not here.
 #[derive(Debug, Clone, Default)]
 pub struct AddElementToFeatureParams<'a> {
     pub feature_code: &'a str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,21 +16,47 @@ use std::fmt;
 ///
 /// The variant set will not be restructured without a version bump. The enum is
 /// deliberately **not** `#[non_exhaustive]`, so downstream `match` expressions
-/// can be exhaustive today; adding a variant is therefore a breaking change and
-/// will be released as such.
+/// can be exhaustive today. Under this crate's stability policy a new variant
+/// may be introduced to split a previously-conflated sub-case out of an existing
+/// one (as [`NotOnCall`](SzConfigError::NotOnCall) and
+/// [`AlreadyPresent`](SzConfigError::AlreadyPresent) were carved out of the
+/// broader "not found" / "already exists" families); such an addition is
+/// released with a version bump and called out in the changelog so exhaustive
+/// downstream matches can be updated.
 ///
 /// Note that [`kind`](SzConfigError::kind) and
 /// [`reason_code`](SzConfigError::reason_code) are variant-level only: two
-/// distinct "not found" situations both classify as [`SzErrorKind::NotFound`].
-/// Sub-case discrimination within a variant is not part of this surface.
+/// distinct "not found" situations that share a variant both classify the same
+/// way (e.g. two [`NotFound`](SzConfigError::NotFound) cases both report
+/// [`SzErrorKind::NotFound`]). Where a sub-case is common enough to branch on it
+/// is promoted to its own variant with its own stable
+/// [`reason_code`](SzConfigError::reason_code); otherwise, finer discrimination
+/// within a variant is not part of this surface.
 #[derive(Debug)]
 pub enum SzConfigError {
     /// JSON parsing error
     JsonParse(String),
     /// Item not found
     NotFound(String), // Generic not found with description
+    /// A call-element delete targeted an element that is not on the given call.
+    ///
+    /// This is the benign single-call "not on call" sub-case carved out of the
+    /// broader [`NotFound`](Self::NotFound) family: the call exists (or is
+    /// addressed by id) but the requested feature/element is not one of its BOM
+    /// rows, so there is nothing to delete. Its
+    /// [`reason_code`](Self::reason_code) is `"NOT_ON_CALL"`.
+    NotOnCall(String),
     /// Item already exists
     AlreadyExists(String), // Generic already exists with description
+    /// A call or call-element add targeted something that is already present.
+    ///
+    /// This is the benign single-call "already there" sub-case carved out of the
+    /// broader [`AlreadyExists`](Self::AlreadyExists) family: a per-feature call
+    /// is already set, or the feature/element is already a BOM row of the call,
+    /// so the add is a no-op rather than a hard collision (contrast a taken
+    /// explicit id or exec-order, which remain [`AlreadyExists`](Self::AlreadyExists)).
+    /// Its [`reason_code`](Self::reason_code) is `"ALREADY_PRESENT"`.
+    AlreadyPresent(String),
     /// Invalid input
     InvalidInput(String),
     /// Missing required section
@@ -56,17 +82,25 @@ pub enum SzConfigError {
 ///
 /// This is a **variant-level** discriminant only. It intentionally does not
 /// distinguish sub-cases *within* a variant — for example, two different
-/// "not found" situations both report [`SzErrorKind::NotFound`]. Callers that
-/// need to tell those apart must still inspect the message (or a future
-/// structured field); this method does not discharge that need.
+/// "not found" situations that share the [`NotFound`](SzConfigError::NotFound)
+/// variant both report [`SzErrorKind::NotFound`]. Where a sub-case is worth
+/// branching on it is promoted to its own variant with its own discriminant
+/// (see [`NotOnCall`](SzErrorKind::NotOnCall) and
+/// [`AlreadyPresent`](SzErrorKind::AlreadyPresent)); callers needing finer
+/// discrimination than the variant set provides must still inspect the message,
+/// and this method does not discharge that need.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SzErrorKind {
     /// JSON could not be parsed. Corresponds to [`SzConfigError::JsonParse`].
     JsonParse,
     /// A requested item was not found. Corresponds to [`SzConfigError::NotFound`].
     NotFound,
+    /// A call-element delete targeted an element not on the call. Corresponds to [`SzConfigError::NotOnCall`].
+    NotOnCall,
     /// An item already exists. Corresponds to [`SzConfigError::AlreadyExists`].
     AlreadyExists,
+    /// A call or call-element add targeted something already present. Corresponds to [`SzConfigError::AlreadyPresent`].
+    AlreadyPresent,
     /// Input failed validation. Corresponds to [`SzConfigError::InvalidInput`].
     InvalidInput,
     /// A required config section is missing. Corresponds to [`SzConfigError::MissingSection`].
@@ -100,7 +134,9 @@ impl SzConfigError {
         match self {
             Self::JsonParse(_) => SzErrorKind::JsonParse,
             Self::NotFound(_) => SzErrorKind::NotFound,
+            Self::NotOnCall(_) => SzErrorKind::NotOnCall,
             Self::AlreadyExists(_) => SzErrorKind::AlreadyExists,
+            Self::AlreadyPresent(_) => SzErrorKind::AlreadyPresent,
             Self::InvalidInput(_) => SzErrorKind::InvalidInput,
             Self::MissingSection(_) => SzErrorKind::MissingSection,
             Self::InvalidStructure(_) => SzErrorKind::InvalidStructure,
@@ -132,7 +168,9 @@ impl SzConfigError {
         match self {
             Self::JsonParse(_) => "JSON_PARSE",
             Self::NotFound(_) => "NOT_FOUND",
+            Self::NotOnCall(_) => "NOT_ON_CALL",
             Self::AlreadyExists(_) => "ALREADY_EXISTS",
+            Self::AlreadyPresent(_) => "ALREADY_PRESENT",
             Self::InvalidInput(_) => "INVALID_INPUT",
             Self::MissingSection(_) => "MISSING_SECTION",
             Self::InvalidStructure(_) => "INVALID_STRUCTURE",
@@ -152,9 +190,19 @@ impl SzConfigError {
         Self::NotFound(msg.into())
     }
 
+    /// Create a not-on-call error (call-element delete found nothing to remove)
+    pub fn not_on_call<S: Into<String>>(msg: S) -> Self {
+        Self::NotOnCall(msg.into())
+    }
+
     /// Create an already exists error
     pub fn already_exists<S: Into<String>>(msg: S) -> Self {
         Self::AlreadyExists(msg.into())
+    }
+
+    /// Create an already-present error (call or call-element add is a no-op)
+    pub fn already_present<S: Into<String>>(msg: S) -> Self {
+        Self::AlreadyPresent(msg.into())
     }
 
     /// Create an invalid input error (validation)
@@ -166,6 +214,42 @@ impl SzConfigError {
     pub fn not_implemented<S: Into<String>>(msg: S) -> Self {
         Self::NotImplemented(msg.into())
     }
+
+    /// Return the bare inner message payload carried by this error.
+    ///
+    /// Every variant wraps a single `String`; this returns that string directly,
+    /// without any of the category prefixes that
+    /// [`Display`](std::fmt::Display) prepends for some variants (e.g. the
+    /// `"Invalid input: "` in front of an [`InvalidInput`](Self::InvalidInput)).
+    /// It is the complement of [`kind`](Self::kind)/[`reason_code`](Self::reason_code):
+    /// those classify the error, this recovers its human-readable detail without
+    /// re-parsing the formatted string.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sz_configtool_lib::SzConfigError;
+    ///
+    /// let err = SzConfigError::validation("DISPLAY_LEVEL must be >= 0");
+    /// // Display prefixes the category; message() is the bare payload.
+    /// assert_eq!(err.to_string(), "Invalid input: DISPLAY_LEVEL must be >= 0");
+    /// assert_eq!(err.message(), "DISPLAY_LEVEL must be >= 0");
+    /// ```
+    pub fn message(&self) -> &str {
+        match self {
+            Self::JsonParse(msg)
+            | Self::NotFound(msg)
+            | Self::NotOnCall(msg)
+            | Self::AlreadyExists(msg)
+            | Self::AlreadyPresent(msg)
+            | Self::InvalidInput(msg)
+            | Self::MissingSection(msg)
+            | Self::InvalidStructure(msg)
+            | Self::MissingField(msg)
+            | Self::InvalidConfig(msg)
+            | Self::NotImplemented(msg) => msg,
+        }
+    }
 }
 
 impl fmt::Display for SzConfigError {
@@ -173,7 +257,9 @@ impl fmt::Display for SzConfigError {
         match self {
             Self::JsonParse(msg) => write!(f, "JSON parse error: {msg}"),
             Self::NotFound(msg) => write!(f, "{msg}"),
+            Self::NotOnCall(msg) => write!(f, "{msg}"),
             Self::AlreadyExists(msg) => write!(f, "{msg}"),
+            Self::AlreadyPresent(msg) => write!(f, "{msg}"),
             Self::InvalidInput(msg) => write!(f, "Invalid input: {msg}"),
             Self::MissingSection(section) => write!(f, "Missing config section: {section}"),
             Self::InvalidStructure(msg) => write!(f, "Invalid config structure: {msg}"),
@@ -201,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_kind_and_reason_code_cover_all_variants() {
-        let cases: [(SzConfigError, SzErrorKind, &str); 9] = [
+        let cases: [(SzConfigError, SzErrorKind, &str); 11] = [
             (
                 SzConfigError::JsonParse("x".into()),
                 SzErrorKind::JsonParse,
@@ -213,9 +299,19 @@ mod tests {
                 "NOT_FOUND",
             ),
             (
+                SzConfigError::NotOnCall("x".into()),
+                SzErrorKind::NotOnCall,
+                "NOT_ON_CALL",
+            ),
+            (
                 SzConfigError::AlreadyExists("x".into()),
                 SzErrorKind::AlreadyExists,
                 "ALREADY_EXISTS",
+            ),
+            (
+                SzConfigError::AlreadyPresent("x".into()),
+                SzErrorKind::AlreadyPresent,
+                "ALREADY_PRESENT",
             ),
             (
                 SzConfigError::InvalidInput("x".into()),
@@ -253,6 +349,43 @@ mod tests {
             assert_eq!(err.kind(), kind, "kind mismatch for {err:?}");
             assert_eq!(err.reason_code(), code, "reason_code mismatch for {err:?}");
         }
+    }
+
+    #[test]
+    fn test_message_returns_bare_payload_for_all_variants() {
+        // message() is the raw inner payload for every variant, with none of the
+        // category prefixes Display prepends.
+        let variants: [SzConfigError; 11] = [
+            SzConfigError::JsonParse("p".into()),
+            SzConfigError::NotFound("p".into()),
+            SzConfigError::NotOnCall("p".into()),
+            SzConfigError::AlreadyExists("p".into()),
+            SzConfigError::AlreadyPresent("p".into()),
+            SzConfigError::InvalidInput("p".into()),
+            SzConfigError::MissingSection("p".into()),
+            SzConfigError::InvalidStructure("p".into()),
+            SzConfigError::MissingField("p".into()),
+            SzConfigError::InvalidConfig("p".into()),
+            SzConfigError::NotImplemented("p".into()),
+        ];
+        for err in &variants {
+            assert_eq!(err.message(), "p", "message mismatch for {err:?}");
+        }
+    }
+
+    #[test]
+    fn test_display_wording_unchanged_for_new_variants() {
+        // The new sub-case variants render the BARE message, exactly like their
+        // parent NotFound/AlreadyExists variants (no added prefix).
+        assert_eq!(
+            SzConfigError::NotOnCall("Comparison call element not found".into()).to_string(),
+            "Comparison call element not found"
+        );
+        assert_eq!(
+            SzConfigError::AlreadyPresent("Feature/element already exists for call".into())
+                .to_string(),
+            "Feature/element already exists for call"
+        );
     }
 
     #[test]

--- a/src/features.rs
+++ b/src/features.rs
@@ -143,6 +143,11 @@ impl<'a> TryFrom<&'a Value> for SetFeatureParams<'a> {
 pub struct AddFeatureComparisonParams<'a> {
     pub feature_code: Option<&'a str>,
     pub element_code: Option<&'a str>,
+    /// Execution order of the new `CFG_FBOM` row (whole-table scope; see the
+    /// "Execution-order policy" in [`crate::calls`]). `None` auto-allocates the
+    /// next order across the whole table; `Some(n > 0)` requests that exact
+    /// order and fails with `AlreadyExists` if already taken. It is never left
+    /// null on the written row.
     pub exec_order: Option<i64>,
     pub display_level: Option<i64>,
     pub display_delim: Option<&'a str>,
@@ -1415,12 +1420,19 @@ pub fn add_feature_comparison(
         )));
     }
 
-    // Build record via FbomRow so every CFG_FBOM key is present; unset optional
-    // fields serialize as null (seed-then-null preserved).
+    // Allocate EXEC_ORDER over the whole CFG_FBOM table (empty scope), honouring
+    // a caller-supplied value or rejecting it if taken (mirrors Python
+    // do_addElementToFeature: getDesiredValueOrNext("CFG_FBOM", "EXEC_ORDER", ...)).
+    // An order is always resolved to a concrete value here, never left null.
+    let exec_order =
+        helpers::get_desired_or_next_order(fbom_array, "EXEC_ORDER", &[], params.exec_order)?;
+
+    // Build record via FbomRow so every CFG_FBOM key is present; the remaining
+    // optional fields serialize as null (seed-then-null preserved).
     let record = serde_json::to_value(&FbomRow {
         ftype_id,
         felem_id,
-        exec_order: params.exec_order,
+        exec_order: Some(exec_order),
         display_level: params.display_level,
         display_delim: params.display_delim.map(str::to_string),
         derived: params.derived.map(str::to_string),
@@ -1963,8 +1975,9 @@ mod tests {
         );
     }
 
-    /// add_feature_comparison must write a complete CFG_FBOM row with all keys
-    /// present as null when the optional params are not supplied.
+    /// add_feature_comparison must write a complete CFG_FBOM row: every key
+    /// present, EXEC_ORDER now auto-allocated (whole-table scope, never null),
+    /// and the remaining unset optionals present as null.
     #[test]
     fn test_add_feature_comparison_emits_all_keys() {
         let config = r#"{"G2_CONFIG": {
@@ -1981,11 +1994,46 @@ mod tests {
         assert_all_keys(fbom, &FBOM_KEYS);
         assert_eq!(fbom["FTYPE_ID"], json!(1));
         assert_eq!(fbom["FELEM_ID"], json!(5));
-        // Optionals not supplied -> present as null.
-        assert_eq!(fbom["EXEC_ORDER"], Value::Null);
+        // EXEC_ORDER auto-allocated over an empty table -> 1 (never null).
+        assert_eq!(fbom["EXEC_ORDER"], json!(1));
+        // The remaining unset optionals are present as null.
         assert_eq!(fbom["DISPLAY_LEVEL"], Value::Null);
         assert_eq!(fbom["DISPLAY_DELIM"], Value::Null);
         assert_eq!(fbom["DERIVED"], Value::Null);
+    }
+
+    /// add_feature_comparison honours a free EXEC_ORDER and rejects a taken one
+    /// (whole-table scope), mirroring Python do_addElementToFeature.
+    #[test]
+    fn test_add_feature_comparison_honours_and_rejects_exec_order() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 1, "FTYPE_CODE": "PERSON"}],
+            "CFG_FELEM": [
+                {"FELEM_ID": 5, "FELEM_CODE": "MYELEM"},
+                {"FELEM_ID": 6, "FELEM_CODE": "OTHERELEM"}
+            ],
+            "CFG_FBOM": [
+                {"FTYPE_ID": 1, "FELEM_ID": 5, "EXEC_ORDER": 3,
+                 "DISPLAY_LEVEL": 1, "DISPLAY_DELIM": null, "DERIVED": "No"}
+            ]
+        }}"#;
+
+        // A free order is honoured.
+        let params = AddFeatureComparisonParams::new("PERSON", "OTHERELEM").with_exec_order(7);
+        let modified = add_feature_comparison(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let new_row = value["G2_CONFIG"]["CFG_FBOM"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["FELEM_ID"].as_i64() == Some(6))
+            .unwrap();
+        assert_eq!(new_row["EXEC_ORDER"], json!(7));
+
+        // A taken order (3, used whole-table) is rejected.
+        let params = AddFeatureComparisonParams::new("PERSON", "OTHERELEM").with_exec_order(3);
+        let err = add_feature_comparison(config, params).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 
     /// add_feature_distinct_call_element must write a CFG_DFCALL row with exactly

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4887,17 +4887,17 @@ pub extern "C" fn SzConfigTool_setGenericThreshold(
         }
     };
 
-    handle_result!(crate::thresholds::set_generic_threshold(
-        config,
-        crate::thresholds::SetGenericThresholdParams {
-            plan: Some(&plan_code_str),
-            behavior: Some(behavior_str),
-            feature: updates_value.get("feature").and_then(|v| v.as_str()),
-            candidate_cap: updates_value.get("candidateCap").and_then(|v| v.as_i64()),
-            scoring_cap: updates_value.get("scoringCap").and_then(|v| v.as_i64()),
-            send_to_redo: updates_value.get("sendToRedo").and_then(|v| v.as_str()),
-        },
-    ))
+    // Parse the cap fields via the params' TryFrom so the FFI path applies the
+    // SAME strict integer typing as the Rust API: a present-but-wrong-type cap
+    // (e.g. {"candidateCap": "500"}) is rejected as InvalidInput rather than
+    // silently coerced to None and no-op'd. The FFI supplies plan/behavior out
+    // of band (gplan_id + behavior C-strings), so overwrite those two after.
+    handle_result!((|| -> crate::error::Result<String> {
+        let mut params = crate::thresholds::SetGenericThresholdParams::try_from(&updates_value)?;
+        params.plan = Some(&plan_code_str);
+        params.behavior = Some(behavior_str);
+        crate::thresholds::set_generic_threshold(config, params)
+    })())
 }
 
 /// List all generic thresholds
@@ -9854,6 +9854,12 @@ pub extern "C" fn SzConfigTool_deleteElementFromFeature(
 
 /// Set (create or overwrite) a named configuration setting.
 ///
+/// The `value` parameter is a JSON-encoded value: it is parsed with
+/// `serde_json` and stored verbatim as its typed value (an integer stays an
+/// integer, a JSON string stays a string). A bare string must therefore be
+/// quoted JSON (e.g. `"\"hello\""`). Invalid JSON returns an error — there is
+/// no string fallback.
+///
 /// # Safety
 /// All pointers must be valid null-terminated C strings.
 #[unsafe(no_mangle)]
@@ -9865,7 +9871,12 @@ pub extern "C" fn SzConfigTool_setSetting(
     let config = ffi_required_str!(config_json, "config_json");
     let name = ffi_required_str!(name, "name");
     let value = ffi_required_str!(value, "value");
-    handle_result!(crate::settings::set_setting(config, name, value))
+    handle_result!((|| {
+        let value: serde_json::Value = serde_json::from_str(value).map_err(|e| {
+            crate::error::SzConfigError::InvalidInput(format!("value is not valid JSON: {e}"))
+        })?;
+        crate::settings::set_setting(config, name, value)
+    })())
 }
 
 /// Delete a comparison function and all dependent rows (cascade).
@@ -10145,7 +10156,7 @@ pub extern "C" fn SzConfigTool_deleteExpressionCallElement(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::Value;
+    use serde_json::{Value, json};
 
     /// Read (and free) the response string of an FFI result, asserting success.
     fn take_response(result: SzConfigTool_result) -> String {
@@ -10159,7 +10170,8 @@ mod tests {
         s
     }
 
-    /// #38.3: setSetting FFI round-trips and uppercases the name.
+    /// #52: setSetting FFI parses the value as JSON — an integer is stored as a
+    /// JSON number, not a quoted string — and uppercases the name.
     #[test]
     fn test_ffi_set_setting() {
         let config = CString::new(r#"{"G2_CONFIG": {}}"#).unwrap();
@@ -10168,7 +10180,32 @@ mod tests {
         let result = SzConfigTool_setSetting(config.as_ptr(), name.as_ptr(), value.as_ptr());
         let modified = take_response(result);
         let v: Value = serde_json::from_str(&modified).unwrap();
-        assert_eq!(v["G2_CONFIG"]["SETTINGS"]["MY_SETTING"], "42");
+        assert_eq!(v["G2_CONFIG"]["SETTINGS"]["MY_SETTING"], json!(42));
+        assert_ne!(v["G2_CONFIG"]["SETTINGS"]["MY_SETTING"], json!("42"));
+    }
+
+    /// #52: a quoted JSON string value is stored as a JSON string.
+    #[test]
+    fn test_ffi_set_setting_quoted_string() {
+        let config = CString::new(r#"{"G2_CONFIG": {}}"#).unwrap();
+        let name = CString::new("greeting").unwrap();
+        let value = CString::new(r#""hello""#).unwrap();
+        let result = SzConfigTool_setSetting(config.as_ptr(), name.as_ptr(), value.as_ptr());
+        let modified = take_response(result);
+        let v: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(v["G2_CONFIG"]["SETTINGS"]["GREETING"], json!("hello"));
+    }
+
+    /// #52: an unparseable value returns an error (no string fallback).
+    #[test]
+    fn test_ffi_set_setting_invalid_json_errors() {
+        let config = CString::new(r#"{"G2_CONFIG": {}}"#).unwrap();
+        let name = CString::new("bad").unwrap();
+        // Bare unquoted text is not valid JSON.
+        let value = CString::new("not json").unwrap();
+        let result = SzConfigTool_setSetting(config.as_ptr(), name.as_ptr(), value.as_ptr());
+        assert_ne!(result.returnCode, 0);
+        assert!(result.response.is_null());
     }
 
     /// #38.1/#38.2: addElementToFeature then deleteElementFromFeature round-trip.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,7 +6,7 @@
 //! stringified** — a term like `"K": 1` (with a space after the colon) matches
 //! under a spaced JSON rendering but misses under a compact one.
 //!
-//! [`FilterSubstrate`] names the three renderings this substrate supports, and
+//! [`FilterSubstrate`] names the four renderings this substrate supports, and
 //! [`matches_filter`] performs the substring test under a chosen rendering.
 //!
 //! ## Deliberate limitation: `ensure_ascii` is *not* reproduced
@@ -43,6 +43,12 @@ pub enum FilterSubstrate {
     /// CPython `repr` of the equivalent Python object: `None`/`True`/`False`,
     /// single-quoted strings, `", "`/`": "` spacing (`{'K': 1, 'J': None}`).
     PythonRepr,
+    /// Values-only, space-joined, Python-`str`-rendered form used by
+    /// `do_listComparisonThresholds`: keys are dropped and each value is rendered
+    /// as `str(v)` (bare unquoted strings, `None`/`True`/`False`) then joined with
+    /// a single space (`{"K": "a", "J": null}` -> `a None`). See
+    /// [`to_values_join_string`].
+    ValuesJoin,
 }
 
 /// Render a JSON value the way Python's `json.dumps` does by default.
@@ -157,6 +163,59 @@ pub fn to_python_repr_string(value: &Value) -> String {
     }
 }
 
+/// Render a JSON value the way Python's `str()` builtin does.
+///
+/// This is the per-value rendering used by `do_listComparisonThresholds`, which
+/// filters over `str(v)` for each dict *value* (not the whole dict). It differs
+/// from [`to_python_repr_string`] only for scalars: `str("hi")` is the **bare**
+/// `hi` (no quotes), whereas `repr("hi")` is `'hi'`. Containers are rendered
+/// identically to `repr` (Python's `str()` of a list/dict delegates to `repr` of
+/// its members), so they delegate to [`to_python_repr_string`] here.
+///
+/// - `null` -> `None`
+/// - `true`/`false` -> `True`/`False`
+/// - numbers -> their decimal form
+/// - strings -> the string itself, unquoted
+/// - arrays/objects -> as [`to_python_repr_string`]
+fn python_str_string(value: &Value) -> String {
+    match value {
+        Value::Null => "None".to_string(),
+        Value::Bool(true) => "True".to_string(),
+        Value::Bool(false) => "False".to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Array(_) | Value::Object(_) => to_python_repr_string(value),
+    }
+}
+
+/// Render a JSON value as the values-only, space-joined string that
+/// `do_listComparisonThresholds` filters against.
+///
+/// For an object, its **values** (keys dropped) are each rendered via Python
+/// `str()` semantics (see [`python_str_string`]) and joined with a single space,
+/// reproducing `" ".join(str(v) for v in record.values())`. Any non-object value
+/// renders as a single `str()`-rendered value.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use sz_configtool_lib::filter::to_values_join_string;
+///
+/// let v = json!({"id": 2, "function": "GNR_COMP", "feature": "all", "note": null});
+/// assert_eq!(to_values_join_string(&v), "2 GNR_COMP all None");
+/// ```
+pub fn to_values_join_string(value: &Value) -> String {
+    match value {
+        Value::Object(map) => map
+            .values()
+            .map(python_str_string)
+            .collect::<Vec<_>>()
+            .join(" "),
+        other => python_str_string(other),
+    }
+}
+
 /// Test whether `filter` occurs as a substring of `record` rendered under the
 /// given [`FilterSubstrate`].
 ///
@@ -192,6 +251,7 @@ pub fn matches_filter(record: &Value, filter: &str, substrate: FilterSubstrate) 
         FilterSubstrate::Compact => serde_json::to_string(record).unwrap_or_default(),
         FilterSubstrate::JsonDumps => to_json_dumps_string(record),
         FilterSubstrate::PythonRepr => to_python_repr_string(record),
+        FilterSubstrate::ValuesJoin => to_values_join_string(record),
     };
     // Case-fold both sides, matching the tool's `arg.lower() in str(...).lower()`.
     // An empty filter still matches (`contains("")` is always true).
@@ -328,6 +388,141 @@ mod tests {
         assert!(matches_filter(&record, "", FilterSubstrate::Compact));
         assert!(matches_filter(&record, "", FilterSubstrate::JsonDumps));
         assert!(matches_filter(&record, "", FilterSubstrate::PythonRepr));
+    }
+
+    #[test]
+    fn test_values_join_bare_strings_and_none() {
+        // Values-only, space-joined; strings are BARE (no quotes), null -> None.
+        let v = json!({"id": 2, "function": "GNR_COMP", "feature": "all", "note": null});
+        assert_eq!(to_values_join_string(&v), "2 GNR_COMP all None");
+        // Contrast: repr would quote the strings and keep keys.
+        assert_eq!(
+            to_python_repr_string(&v),
+            "{'id': 2, 'function': 'GNR_COMP', 'feature': 'all', 'note': None}"
+        );
+    }
+
+    #[test]
+    fn test_values_join_bools_and_numbers() {
+        let v = json!({"a": true, "b": false, "c": 100, "d": "x"});
+        assert_eq!(to_values_join_string(&v), "True False 100 x");
+    }
+
+    #[test]
+    fn test_values_join_non_object() {
+        // A non-object renders as a single str()-rendered value.
+        assert_eq!(to_values_join_string(&json!("hi")), "hi");
+        assert_eq!(to_values_join_string(&Value::Null), "None");
+        assert_eq!(to_values_join_string(&json!(42)), "42");
+        // Nested containers delegate to repr.
+        assert_eq!(
+            to_values_join_string(&json!([1, "a", null])),
+            "[1, 'a', None]"
+        );
+    }
+
+    #[test]
+    fn test_matches_filter_values_join_boundary() {
+        // The space-join boundary between two values is matchable, and the
+        // keys are absent so a key-only term misses.
+        let v = json!({"function": "GNR_COMP", "feature": "all"});
+        // Boundary-spanning term across the single space between values.
+        assert!(matches_filter(
+            &v,
+            "gnr_comp all",
+            FilterSubstrate::ValuesJoin
+        ));
+        // The key "function" is dropped from the values-join rendering.
+        assert!(!matches_filter(&v, "function", FilterSubstrate::ValuesJoin));
+        // But it IS present under json.dumps (keys retained).
+        assert!(matches_filter(&v, "function", FilterSubstrate::JsonDumps));
+    }
+
+    #[test]
+    fn test_matches_filter_values_join_case_insensitive() {
+        let v = json!({"function": "GNR_COMP", "feature": "all"});
+        assert!(matches_filter(&v, "GNR_COMP", FilterSubstrate::ValuesJoin));
+        assert!(matches_filter(&v, "gnr_comp", FilterSubstrate::ValuesJoin));
+        assert!(!matches_filter(&v, "str_comp", FilterSubstrate::ValuesJoin));
+    }
+
+    #[test]
+    fn test_values_join_against_real_template_cfrtn() {
+        // Exercise ValuesJoin against the real Senzing v4 template: build a
+        // comparison-threshold object from actual CFG_CFRTN rows the way Python's
+        // do_listComparisonThresholds does, and assert a real CFUNC_CODE matches.
+        let path = format!(
+            "{}/tests/fixtures/g2config_template.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read template fixture '{path}': {e}"));
+        let config: Value = serde_json::from_str(&raw).expect("template is not valid JSON");
+        let g2 = &config["G2_CONFIG"];
+
+        // Build CFUNC_ID -> CFUNC_CODE and FTYPE_ID -> FTYPE_CODE lookups.
+        let cfunc_by_id: std::collections::HashMap<i64, &str> = g2["CFG_CFUNC"]
+            .as_array()
+            .expect("CFG_CFUNC array")
+            .iter()
+            .map(|r| {
+                (
+                    r["CFUNC_ID"].as_i64().unwrap(),
+                    r["CFUNC_CODE"].as_str().unwrap(),
+                )
+            })
+            .collect();
+        let ftype_by_id: std::collections::HashMap<i64, &str> = g2["CFG_FTYPE"]
+            .as_array()
+            .expect("CFG_FTYPE array")
+            .iter()
+            .map(|r| {
+                (
+                    r["FTYPE_ID"].as_i64().unwrap(),
+                    r["FTYPE_CODE"].as_str().unwrap(),
+                )
+            })
+            .collect();
+
+        // Find a CFRTN row whose function is GNR_COMP (a real code in the template).
+        let cfrtn_rows = g2["CFG_CFRTN"].as_array().expect("CFG_CFRTN array");
+        let mut gnr_matches = 0usize;
+        for row in cfrtn_rows {
+            let cfunc_id = row["CFUNC_ID"].as_i64().unwrap();
+            let cfunc_code = cfunc_by_id[&cfunc_id];
+            let ftype_id = row.get("FTYPE_ID").and_then(|v| v.as_i64()).unwrap_or(0);
+            let feature = if ftype_id != 0 {
+                ftype_by_id[&ftype_id]
+            } else {
+                "all"
+            };
+            // Mirror format_comparison_threshold_json's field order.
+            let cfrtn_json = json!({
+                "id": row["CFRTN_ID"],
+                "function": cfunc_code,
+                "returnOrder": row["EXEC_ORDER"],
+                "scoreName": row["CFUNC_RTNVAL"],
+                "feature": feature,
+                "sameScore": row["SAME_SCORE"],
+                "closeScore": row["CLOSE_SCORE"],
+                "likelyScore": row["LIKELY_SCORE"],
+                "plausibleScore": row["PLAUSIBLE_SCORE"],
+                "unlikelyScore": row["UN_LIKELY_SCORE"],
+            });
+
+            if matches_filter(&cfrtn_json, "GNR_COMP", FilterSubstrate::ValuesJoin) {
+                gnr_matches += 1;
+                // The rendered form must be values-only and space-joined.
+                let rendered = to_values_join_string(&cfrtn_json);
+                assert!(rendered.contains("GNR_COMP"));
+                assert!(!rendered.contains("function")); // key dropped
+                assert!(!rendered.contains('{')); // not a dict rendering
+            }
+        }
+        assert!(
+            gnr_matches > 0,
+            "expected at least one GNR_COMP threshold in the real template"
+        );
     }
 
     #[test]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -268,6 +268,79 @@ pub fn get_desired_or_next_id(
     get_next_id_with_min(array, id_field, min_value)
 }
 
+/// Resolve an execution-order value within a scope, honouring a desired value or
+/// allocating the next available one.
+///
+/// This is the order-field analogue of [`get_desired_or_next_id`] and mirrors
+/// Python `getDesiredValueOrNext` with its default `seed_order` of `0`. A row is
+/// *in scope* when every `(field, value)` pair in `scope` matches that row's
+/// field (compared as `i64`); `scope` is the list of *senior* key fields that
+/// partition the order space (e.g. `[("CFCALL_ID", 42)]` numbers `EXEC_ORDER`
+/// independently per call, and an empty scope numbers `order_field` across the
+/// whole table).
+///
+/// Over the in-scope rows:
+/// - `desired == Some(d)` with `d > 0` and `d` free -> returns `d`.
+/// - `desired == Some(d)` with `d > 0` but `d` already taken -> `AlreadyExists`
+///   (the reject-if-taken policy; Python instead silently reallocates, but this
+///   SDK surfaces the collision).
+/// - otherwise (`None`, or a non-positive `d`) -> `(max in scope, seed 0) + 1`.
+///
+/// Never returns `null`/absent: an order is always resolved to a concrete value.
+///
+/// # Arguments
+/// * `array` - The section's rows to scan
+/// * `order_field` - The order column being allocated (e.g. `"EXEC_ORDER"`)
+/// * `scope` - Senior `(field, value)` keys that partition the order space
+/// * `desired` - Caller-requested order, or `None` to auto-allocate
+///
+/// # Errors
+/// Returns `AlreadyExists` when a positive `desired` value is already taken
+/// within the scope.
+pub(crate) fn get_desired_or_next_order(
+    array: &[Value],
+    order_field: &str,
+    scope: &[(&str, i64)],
+    desired: Option<i64>,
+) -> Result<i64> {
+    // seed_order default is 0 (Python getDesiredValueOrNext default).
+    let mut last: i64 = 0;
+    let mut taken = false;
+
+    for row in array {
+        let in_scope = scope
+            .iter()
+            .all(|(field, value)| row.get(*field).and_then(|v| v.as_i64()) == Some(*value));
+        if !in_scope {
+            continue;
+        }
+        if let Some(order) = row.get(order_field).and_then(|v| v.as_i64()) {
+            if let Some(d) = desired
+                && d > 0
+                && order == d
+            {
+                taken = true;
+            }
+            if order > last {
+                last = order;
+            }
+        }
+    }
+
+    if let Some(d) = desired
+        && d > 0
+    {
+        if taken {
+            return Err(SzConfigError::AlreadyExists(format!(
+                "The specified {order_field} {d} is already taken"
+            )));
+        }
+        return Ok(d);
+    }
+
+    Ok(last + 1)
+}
+
 /// Get the next available ID or use desired ID (for config sections)
 ///
 /// Same as get_desired_or_next_id but works with section paths
@@ -1044,5 +1117,63 @@ mod tests {
         // Absent section behaves like zero matches.
         let cfg = json!({"G2_CONFIG": {}});
         assert!(resolve_cfcall_id_for_feature(&cfg, 1).is_err());
+    }
+
+    #[test]
+    fn test_get_desired_or_next_order_empty_and_scoped() {
+        let rows = vec![
+            json!({"CALL_ID": 1, "EXEC_ORDER": 1}),
+            json!({"CALL_ID": 1, "EXEC_ORDER": 3}),
+            json!({"CALL_ID": 2, "EXEC_ORDER": 9}),
+        ];
+
+        // Empty scope -> whole-table max (9) + 1.
+        assert_eq!(
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[], None).unwrap(),
+            10
+        );
+
+        // Scoped to CALL_ID 1 -> max (3) + 1.
+        assert_eq!(
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[("CALL_ID", 1)], None).unwrap(),
+            4
+        );
+
+        // Scoped to a fresh CALL_ID with no rows -> seed 0 + 1.
+        assert_eq!(
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[("CALL_ID", 99)], None).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_get_desired_or_next_order_honour_and_reject() {
+        let rows = vec![
+            json!({"CALL_ID": 1, "EXEC_ORDER": 1}),
+            json!({"CALL_ID": 1, "EXEC_ORDER": 2}),
+        ];
+
+        // Desired free within scope -> honoured.
+        assert_eq!(
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[("CALL_ID", 1)], Some(5)).unwrap(),
+            5
+        );
+
+        // Desired taken within scope -> AlreadyExists.
+        let err =
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[("CALL_ID", 1)], Some(2)).unwrap_err();
+        assert_eq!(err.kind(), SzConfigError::already_exists("").kind());
+
+        // The same value is free under a different scope key -> honoured there.
+        assert_eq!(
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[("CALL_ID", 7)], Some(2)).unwrap(),
+            2
+        );
+
+        // Non-positive desired falls through to auto-allocation.
+        assert_eq!(
+            get_desired_or_next_order(&rows, "EXEC_ORDER", &[("CALL_ID", 1)], Some(0)).unwrap(),
+            3
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,10 @@ pub use behavior_domain::{
 };
 pub use behavior_overrides::{delete_behavior_override, list_behavior_overrides_resolved};
 pub use export::render_config;
-pub use filter::{FilterSubstrate, matches_filter, to_json_dumps_string, to_python_repr_string};
+pub use filter::{
+    FilterSubstrate, matches_filter, to_json_dumps_string, to_python_repr_string,
+    to_values_join_string,
+};
 pub use helpers::FieldUpdate;
 pub use helpers::{
     resolve_cfcall_id_for_feature, resolve_dfcall_id_for_feature, resolve_efcall_id_for_feature,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,13 +11,16 @@ use serde_json::{Value, json};
 ///
 /// The `SETTINGS` object under `G2_CONFIG` is created if absent. The `name` is
 /// upper-cased before use, and an existing setting of the same name is
-/// overwritten silently. No validation is applied to `value` — it is stored
-/// verbatim as a JSON string.
+/// overwritten silently. The `value` is stored verbatim as its typed JSON
+/// value — an integer stays an integer, a string stays a string — no
+/// validation is applied.
 ///
 /// # Arguments
 /// * `config_json` - JSON configuration string
 /// * `name` - Setting name (upper-cased before storing)
-/// * `value` - Setting value (stored as a JSON string, unvalidated)
+/// * `value` - Setting value, stored verbatim as its typed JSON value
+///   (accepts anything convertible into `serde_json::Value`, e.g. an integer,
+///   a `&str`, or a pre-built `Value`)
 ///
 /// # Returns
 /// Modified configuration JSON string
@@ -31,11 +34,14 @@ use serde_json::{Value, json};
 /// use sz_configtool_lib::settings::set_setting;
 ///
 /// let config = r#"{"G2_CONFIG": {}}"#;
-/// let updated = set_setting(config, "my_setting", "42")?;
-/// assert!(updated.contains("MY_SETTING"));
-/// # Ok::<(), sz_configtool_lib::error::SzConfigError>(())
+/// // A typed integer is stored as a JSON number, not a quoted string.
+/// let updated = set_setting(config, "metaphone_version", 3)?;
+/// let parsed: serde_json::Value = serde_json::from_str(&updated)?;
+/// assert_eq!(parsed["G2_CONFIG"]["SETTINGS"]["METAPHONE_VERSION"], serde_json::json!(3));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub fn set_setting(config_json: &str, name: &str, value: &str) -> Result<String> {
+pub fn set_setting(config_json: &str, name: &str, value: impl Into<Value>) -> Result<String> {
+    let value = value.into();
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
@@ -59,7 +65,7 @@ pub fn set_setting(config_json: &str, name: &str, value: &str) -> Result<String>
         .and_then(|v| v.as_object_mut())
         .expect("SETTINGS object was just ensured");
 
-    settings.insert(name.to_uppercase(), json!(value));
+    settings.insert(name.to_uppercase(), value);
 
     serde_json::to_string(&config).map_err(|e| SzConfigError::JsonParse(e.to_string()))
 }
@@ -93,6 +99,31 @@ mod tests {
         assert_eq!(value["G2_CONFIG"]["SETTINGS"]["FOO"], json!("new"));
         // Exactly one entry — overwrite, not append.
         assert_eq!(value["G2_CONFIG"]["SETTINGS"].as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_set_setting_stores_typed_integer() {
+        let config = r#"{"G2_CONFIG": {}}"#;
+        let modified = set_setting(config, "metaphone_version", 3).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        // Stored verbatim as a JSON number, not a quoted string.
+        assert_eq!(
+            value["G2_CONFIG"]["SETTINGS"]["METAPHONE_VERSION"],
+            json!(3)
+        );
+        assert_ne!(
+            value["G2_CONFIG"]["SETTINGS"]["METAPHONE_VERSION"],
+            json!("3")
+        );
+    }
+
+    #[test]
+    fn test_set_setting_stores_str_verbatim() {
+        // A &str value is still stored as a JSON string.
+        let config = r#"{"G2_CONFIG": {}}"#;
+        let modified = set_setting(config, "foo", "bar").unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        assert_eq!(value["G2_CONFIG"]["SETTINGS"]["FOO"], json!("bar"));
     }
 
     #[test]

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -70,6 +70,15 @@ pub struct AddComparisonThresholdParams<'a> {
     pub cfunc_code: Option<&'a str>,
     pub ftype_code: Option<&'a str>,
     pub cfunc_rtnval: Option<&'a str>,
+    /// Requested return-value execution order (tier). This is only consulted
+    /// when no all-features tier row already exists for this
+    /// `(cfunc, rtnval)` — that tier's order is reused verbatim so per-feature
+    /// overrides stay on the same tier as the base row (a load-bearing scoring
+    /// invariant). When no tier row exists, `Some(n > 0)` is honoured (or
+    /// rejected with `AlreadyExists` if taken within the `(CFUNC_ID,
+    /// FTYPE_ID=0)` scope) and `None` auto-allocates the next order. The written
+    /// row always carries a concrete order. See the "Execution-order policy" in
+    /// [`crate::calls`].
     pub exec_order: Option<i64>,
     pub same_score: Option<i64>,
     pub close_score: Option<i64>,
@@ -97,12 +106,12 @@ impl<'a> TryFrom<&'a Value> for AddComparisonThresholdParams<'a> {
             cfunc_code: json.get("cfuncCode").and_then(|v| v.as_str()),
             ftype_code: json.get("ftypeCode").and_then(|v| v.as_str()),
             cfunc_rtnval: json.get("cfuncRtnval").and_then(|v| v.as_str()),
-            exec_order: json.get("execOrder").and_then(|v| v.as_i64()),
-            same_score: json.get("sameScore").and_then(|v| v.as_i64()),
-            close_score: json.get("closeScore").and_then(|v| v.as_i64()),
-            likely_score: json.get("likelyScore").and_then(|v| v.as_i64()),
-            plausible_score: json.get("plausibleScore").and_then(|v| v.as_i64()),
-            un_likely_score: json.get("unlikelyScore").and_then(|v| v.as_i64()),
+            exec_order: optional_i64(json, "execOrder")?,
+            same_score: optional_i64(json, "sameScore")?,
+            close_score: optional_i64(json, "closeScore")?,
+            likely_score: optional_i64(json, "likelyScore")?,
+            plausible_score: optional_i64(json, "plausibleScore")?,
+            un_likely_score: optional_i64(json, "unlikelyScore")?,
         })
     }
 }
@@ -144,8 +153,8 @@ impl<'a> TryFrom<&'a Value> for AddGenericThresholdParams<'a> {
         Ok(Self {
             plan: json.get("plan").and_then(|v| v.as_str()),
             behavior: json.get("behavior").and_then(|v| v.as_str()),
-            scoring_cap: json.get("scoringCap").and_then(|v| v.as_i64()),
-            candidate_cap: json.get("candidateCap").and_then(|v| v.as_i64()),
+            scoring_cap: optional_i64(json, "scoringCap")?,
+            candidate_cap: optional_i64(json, "candidateCap")?,
             send_to_redo: json.get("sendToRedo").and_then(|v| v.as_str()),
             feature: json.get("feature").and_then(|v| v.as_str()),
         })
@@ -174,12 +183,12 @@ impl<'a> TryFrom<&'a Value> for SetComparisonThresholdParams<'a> {
             cfunc_code: json.get("cfuncCode").and_then(|v| v.as_str()),
             ftype_code: json.get("ftypeCode").and_then(|v| v.as_str()),
             cfunc_rtnval: json.get("cfuncRtnval").and_then(|v| v.as_str()),
-            exec_order: json.get("execOrder").and_then(|v| v.as_i64()),
-            same_score: json.get("sameScore").and_then(|v| v.as_i64()),
-            close_score: json.get("closeScore").and_then(|v| v.as_i64()),
-            likely_score: json.get("likelyScore").and_then(|v| v.as_i64()),
-            plausible_score: json.get("plausibleScore").and_then(|v| v.as_i64()),
-            un_likely_score: json.get("unlikelyScore").and_then(|v| v.as_i64()),
+            exec_order: optional_i64(json, "execOrder")?,
+            same_score: optional_i64(json, "sameScore")?,
+            close_score: optional_i64(json, "closeScore")?,
+            likely_score: optional_i64(json, "likelyScore")?,
+            plausible_score: optional_i64(json, "plausibleScore")?,
+            un_likely_score: optional_i64(json, "unlikelyScore")?,
         })
     }
 }
@@ -203,8 +212,8 @@ impl<'a> TryFrom<&'a Value> for SetGenericThresholdParams<'a> {
             plan: json.get("plan").and_then(|v| v.as_str()),
             behavior: json.get("behavior").and_then(|v| v.as_str()),
             feature: json.get("feature").and_then(|v| v.as_str()),
-            candidate_cap: json.get("candidateCap").and_then(|v| v.as_i64()),
-            scoring_cap: json.get("scoringCap").and_then(|v| v.as_i64()),
+            candidate_cap: optional_i64(json, "candidateCap")?,
+            scoring_cap: optional_i64(json, "scoringCap")?,
             send_to_redo: json.get("sendToRedo").and_then(|v| v.as_str()),
         })
     }
@@ -267,6 +276,27 @@ fn resolve_ftype_id_or_all(config_json: &str, feature: &str) -> Result<i64> {
     }
 }
 
+/// Read an optional integer field from a JSON object with strict typing.
+///
+/// This exists so a present-but-wrong-type numeric field (a JSON string, float,
+/// or bool) is *rejected* rather than silently coerced to `None` — the trap the
+/// old `.and_then(Value::as_i64)` parsing fell into, where
+/// `{"candidateCap": "500"}` was quietly dropped and the update became a no-op.
+///
+/// - missing key or JSON `null` -> `Ok(None)` (the field is genuinely absent)
+/// - integer value -> `Ok(Some(n))`
+/// - any other present value (string / float / bool / array / object) ->
+///   `Err(SzConfigError::InvalidInput)`
+fn optional_i64(json: &Value, key: &str) -> Result<Option<i64>> {
+    match json.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) => v
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| SzConfigError::InvalidInput(format!("{key} must be an integer"))),
+    }
+}
+
 /// Canonicalise a `sendToRedo` value to the title-case form stored on disk.
 ///
 /// Accepts `"Yes"`/`"No"` in any case and returns the canonical `"Yes"`/`"No"`.
@@ -282,6 +312,59 @@ fn send_to_redo_canonical(value: &str) -> Result<&'static str> {
 }
 
 // ===== Comparison Thresholds (CFG_CFRTN) =====
+
+/// Resolve the `EXEC_ORDER` for a new `CFG_CFRTN` (comparison threshold) row.
+///
+/// Mirrors Python `do_addComparisonThreshold`'s three-step logic, which is
+/// load-bearing for scoring — it keeps every return value of one comparison
+/// function on the same tier across features:
+///
+/// 1. **Tier reuse.** If a return-value tier row already exists for this
+///    `(CFUNC_ID, CFUNC_RTNVAL)` at the all-features level (`FTYPE_ID = 0`), its
+///    `EXEC_ORDER` is reused verbatim — a per-feature override must land on the
+///    same tier as the base row. This takes precedence over any `desired` value,
+///    and a naive max+1 here would be a silent scoring regression.
+/// 2. **Honour desired.** Otherwise, if `desired` is `Some(n > 0)`, it is
+///    honoured — unless already taken within the `(CFUNC_ID, FTYPE_ID = 0)`
+///    scope, in which case `AlreadyExists` is returned (reject-if-taken policy).
+/// 3. **Next available.** Otherwise the next free order within
+///    `(CFUNC_ID, FTYPE_ID = 0)` is allocated.
+///
+/// Never returns `null`: an order is always resolved to a concrete value.
+fn resolve_cfrtn_exec_order(
+    cfrtn_array: &[Value],
+    cfunc_id: i64,
+    rtnval_upper: &str,
+    desired: Option<i64>,
+) -> Result<i64> {
+    // Step 1: reuse the all-features tier row's EXEC_ORDER when present.
+    let tier_order = cfrtn_array.iter().find_map(|row| {
+        let is_tier = row["CFUNC_ID"].as_i64() == Some(cfunc_id)
+            && row["FTYPE_ID"].as_i64() == Some(0)
+            && row["CFUNC_RTNVAL"]
+                .as_str()
+                .map(|s| s.eq_ignore_ascii_case(rtnval_upper))
+                .unwrap_or(false);
+        if is_tier {
+            row["EXEC_ORDER"].as_i64()
+        } else {
+            None
+        }
+    });
+    if let Some(order) = tier_order {
+        return Ok(order);
+    }
+
+    // Steps 2 & 3: honour desired (reject if taken) else next-available, scoped
+    // to (CFUNC_ID, FTYPE_ID = 0) — exactly Python's getDesiredValueOrNext
+    // over ["CFUNC_ID", "FTYPE_ID", "EXEC_ORDER"] with [cfuncID, 0, ...].
+    helpers::get_desired_or_next_order(
+        cfrtn_array,
+        "EXEC_ORDER",
+        &[("CFUNC_ID", cfunc_id), ("FTYPE_ID", 0)],
+        desired,
+    )
+}
 
 /// Add a new comparison threshold (CFG_CFRTN record)
 ///
@@ -337,14 +420,19 @@ pub fn add_comparison_threshold(
     // Get next ID
     let cfrtn_id = helpers::get_next_id_from_array(cfrtn_array, "CFRTN_ID")?;
 
+    // Resolve EXEC_ORDER: reuse the all-features tier row when present, else
+    // honour/allocate within (CFUNC_ID, FTYPE_ID=0). Never null.
+    let exec_order =
+        resolve_cfrtn_exec_order(cfrtn_array, cfunc_id, &rtnval_upper, params.exec_order)?;
+
     // Build a complete row via CfrtnRow so every CFG_CFRTN key is present
-    // (unset seed-then-null fields serialize as null).
+    // (unset seed-then-null score fields serialize as null).
     let row = CfrtnRow {
         cfrtn_id,
         cfunc_id,
         ftype_id,
         cfunc_rtnval: rtnval_upper,
-        exec_order: params.exec_order,
+        exec_order: Some(exec_order),
         same_score: params.same_score,
         close_score: params.close_score,
         likely_score: params.likely_score,
@@ -394,14 +482,19 @@ pub(crate) fn add_comparison_threshold_by_id(
     // Get next ID
     let cfrtn_id = crate::helpers::get_next_id_from_array(cfrtn_array, "CFRTN_ID")?;
 
+    // Resolve EXEC_ORDER: reuse the all-features tier row when present, else
+    // honour/allocate within (CFUNC_ID, FTYPE_ID=0). Never null.
+    let resolved_exec_order =
+        resolve_cfrtn_exec_order(cfrtn_array, cfunc_id, &rtnval_upper, exec_order)?;
+
     // Build a complete row via CfrtnRow so every CFG_CFRTN key is present
-    // (unset seed-then-null fields serialize as null).
+    // (unset seed-then-null score fields serialize as null).
     let row = CfrtnRow {
         cfrtn_id,
         cfunc_id,
         ftype_id: ftype,
         cfunc_rtnval: rtnval_upper,
-        exec_order,
+        exec_order: Some(resolved_exec_order),
         same_score,
         close_score,
         likely_score,
@@ -733,22 +826,35 @@ pub fn add_generic_threshold(
     config_json: &str,
     params: AddGenericThresholdParams,
 ) -> Result<String> {
-    // Extract and validate required fields
-    let plan = params
-        .plan
-        .ok_or_else(|| SzConfigError::MissingField("plan".to_string()))?;
-    let behavior = params
-        .behavior
-        .ok_or_else(|| SzConfigError::MissingField("behavior".to_string()))?;
-    let scoring_cap = params
-        .scoring_cap
-        .ok_or_else(|| SzConfigError::MissingField("scoring_cap".to_string()))?;
-    let candidate_cap = params
-        .candidate_cap
-        .ok_or_else(|| SzConfigError::MissingField("candidate_cap".to_string()))?;
-    let send_to_redo = params
-        .send_to_redo
-        .ok_or_else(|| SzConfigError::MissingField("send_to_redo".to_string()))?;
+    // Aggregate ALL missing required fields into a single MissingField error,
+    // mirroring Python `do_addGenericThreshold`'s up-front `validate_parms`
+    // (which reports every absent parameter at once rather than one at a time).
+    // Field order matches the Python required list: PLAN, BEHAVIOR, SCORINGCAP,
+    // CANDIDATECAP, SENDTOREDO.
+    let mut missing: Vec<&str> = Vec::new();
+    if params.plan.is_none() {
+        missing.push("plan");
+    }
+    if params.behavior.is_none() {
+        missing.push("behavior");
+    }
+    if params.scoring_cap.is_none() {
+        missing.push("scoring_cap");
+    }
+    if params.candidate_cap.is_none() {
+        missing.push("candidate_cap");
+    }
+    if params.send_to_redo.is_none() {
+        missing.push("send_to_redo");
+    }
+    if !missing.is_empty() {
+        return Err(SzConfigError::MissingField(missing.join(", ")));
+    }
+    let plan = params.plan.expect("checked present above");
+    let behavior = params.behavior.expect("checked present above");
+    let scoring_cap = params.scoring_cap.expect("checked present above");
+    let candidate_cap = params.candidate_cap.expect("checked present above");
+    let send_to_redo = params.send_to_redo.expect("checked present above");
 
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
@@ -756,9 +862,6 @@ pub fn add_generic_threshold(
     let plan_upper = plan.to_uppercase();
     let behavior_upper = behavior.to_uppercase();
     let feature_upper = params.feature.unwrap_or("ALL").to_uppercase();
-
-    // Validate sendToRedo and store the canonical title-case form ("Yes"/"No").
-    let redo_canonical = send_to_redo_canonical(send_to_redo)?;
 
     // Lookup plan ID
     let gplan_array = config["G2_CONFIG"]["CFG_GPLAN"]
@@ -800,6 +903,40 @@ pub fn add_generic_threshold(
             "Generic threshold: plan={plan_upper}, behavior={behavior_upper}, feature={feature_upper}"
         )));
     }
+
+    // Collect-all validity block, mirroring Python `validateGenericThreshold`
+    // (which appends every failure to one `errorList` and reports them together
+    // AFTER the plan/feature/duplicate checks). Two things are validated here:
+    //
+    //   1. BEHAVIOR must be one of the canonical 17 codes. We use
+    //      `behavior_domain::behavior_position` (backed by `BEHAVIOR_CODES`),
+    //      the EXACT set Python's `lookupBehaviorCode` checks against — NOT the
+    //      broader `parse_behavior_code`, which also accepts variants that are
+    //      not valid generic-threshold behaviours.
+    //   2. SEND_TO_REDO must canonicalise to "Yes"/"No" via
+    //      `send_to_redo_canonical`.
+    //
+    // The caps are already `i64` (typed at the API/FFI boundary via
+    // `optional_i64`), so Python's `isinstance(int)` cap checks are enforced
+    // upstream and need no runtime check here.
+    let mut validity_errors: Vec<String> = Vec::new();
+    if crate::behavior_domain::behavior_position(&behavior_upper).is_none() {
+        validity_errors.push(format!(
+            "Invalid behavior code '{behavior_upper}'. Valid codes: {}",
+            crate::behavior_domain::BEHAVIOR_CODES.join(", ")
+        ));
+    }
+    let redo_canonical = match send_to_redo_canonical(send_to_redo) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            validity_errors.push(e.to_string());
+            None
+        }
+    };
+    if !validity_errors.is_empty() {
+        return Err(SzConfigError::InvalidInput(validity_errors.join("; ")));
+    }
+    let redo_canonical = redo_canonical.expect("no validity errors implies redo canonicalised");
 
     // Build a complete row via GenericThresholdRow so every
     // CFG_GENERIC_THRESHOLD key is present.
@@ -1139,8 +1276,9 @@ mod tests {
             "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}]
         }}"#;
 
-        // Only the required fields supplied; the seed-then-null fields must
-        // surface as null, never dropped.
+        // Only the required fields supplied. EXEC_ORDER is now auto-allocated
+        // (never null): with no tier row and an empty (CFUNC_ID 5, FTYPE_ID 0)
+        // scope, the first order is 1. The score fields remain seed-then-null.
         let params = AddComparisonThresholdParams::new("GNR_COMP", "NAME", "FULL_SCORE");
         let modified = add_comparison_threshold(config, params).unwrap();
         let value: Value = serde_json::from_str(&modified).unwrap();
@@ -1150,9 +1288,57 @@ mod tests {
         assert_eq!(row["CFUNC_ID"], json!(5));
         assert_eq!(row["FTYPE_ID"], json!(3));
         assert_eq!(row["CFUNC_RTNVAL"], json!("FULL_SCORE"));
-        assert_eq!(row["EXEC_ORDER"], Value::Null);
+        assert_eq!(row["EXEC_ORDER"], json!(1));
         assert_eq!(row["SAME_SCORE"], Value::Null);
         assert_eq!(row["UN_LIKELY_SCORE"], Value::Null);
+    }
+
+    // Tier reuse (synthetic): a per-feature override reuses the all-features
+    // tier row's EXEC_ORDER verbatim, even when a different order is requested.
+    #[test]
+    fn test_add_comparison_threshold_reuses_all_features_tier_order() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_CFUNC": [{"CFUNC_ID": 5, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_CFRTN": [
+                {"CFRTN_ID": 1, "CFUNC_ID": 5, "FTYPE_ID": 0, "CFUNC_RTNVAL": "GNR_SN", "EXEC_ORDER": 4}
+            ]
+        }}"#;
+
+        // Adding a NAME-specific GNR_SN row must reuse the tier order (4), NOT
+        // honour the requested 99 (tier reuse takes precedence — scoring
+        // invariant).
+        let mut params = AddComparisonThresholdParams::new("GNR_COMP", "NAME", "GNR_SN");
+        params.exec_order = Some(99);
+        let modified = add_comparison_threshold(config, params).unwrap();
+        let value: Value = serde_json::from_str(&modified).unwrap();
+        let new_row = value["G2_CONFIG"]["CFG_CFRTN"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["FTYPE_ID"].as_i64() == Some(3))
+            .unwrap();
+        assert_eq!(new_row["EXEC_ORDER"], json!(4));
+    }
+
+    // Reject-if-taken (Q1): with no tier row, an explicit order already used in
+    // the (CFUNC_ID, FTYPE_ID=0) scope is rejected rather than reallocated.
+    #[test]
+    fn test_add_comparison_threshold_rejects_taken_explicit_order() {
+        let config = r#"{"G2_CONFIG": {
+            "CFG_CFUNC": [{"CFUNC_ID": 5, "CFUNC_CODE": "GNR_COMP"}],
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "NAME"}],
+            "CFG_CFRTN": [
+                {"CFRTN_ID": 1, "CFUNC_ID": 5, "FTYPE_ID": 0, "CFUNC_RTNVAL": "GNR_FN", "EXEC_ORDER": 1}
+            ]
+        }}"#;
+
+        // New rtnval (no tier row), explicit order 1 already taken in the
+        // (5, 0) scope -> AlreadyExists.
+        let mut params = AddComparisonThresholdParams::new("GNR_COMP", "all", "GNR_SN");
+        params.exec_order = Some(1);
+        let err = add_comparison_threshold(config, params).unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::AlreadyExists);
     }
 
     #[test]

--- a/tests/error_subcases.rs
+++ b/tests/error_subcases.rs
@@ -1,0 +1,408 @@
+//! Error sub-case surface (v0.7.0 STEP D / #53 + #54) exercised against the REAL
+//! Senzing v4 template (`tests/fixtures/g2config_template.json`), never
+//! synthetic-only config. Two past delete-path regressions slipped through
+//! synthetic tests, so the sub-case classification AND the "delete removes
+//! exactly one row" invariant are proven here on the shipped data.
+//!
+//! Step D carves two benign single-call sub-cases out of the broader
+//! `NotFound` / `AlreadyExists` families:
+//!   - [`SzErrorKind::NotOnCall`] — a call-element delete found nothing to
+//!     remove (the element is not a BOM row of the call).
+//!   - [`SzErrorKind::AlreadyPresent`] — a call/call-element add is a no-op (the
+//!     per-feature call is already set, or the element is already on the call).
+//!
+//! Hard collisions stay put: a taken explicit id and a taken exec-order remain
+//! `AlreadyExists`, and a genuinely missing id/lookup remains `NotFound`. The
+//! negative guards at the bottom prove those did NOT get reclassified.
+
+use serde_json::Value;
+use sz_configtool_lib::calls::CallSelector;
+use sz_configtool_lib::calls::comparison::{
+    AddComparisonCallElementParams, AddComparisonCallParams, add_comparison_call,
+    add_comparison_call_element, delete_comparison_call_element, get_comparison_call,
+};
+use sz_configtool_lib::calls::distinct::{
+    AddDistinctCallElementParams, add_distinct_call_element, delete_distinct_call_element,
+};
+use sz_configtool_lib::calls::expression::{
+    ExpressionCallElementParams, add_expression_call_element, delete_expression_call_element,
+};
+use sz_configtool_lib::calls::standardize::{
+    AddStandardizeCallElementParams, DeleteStandardizeCallElementParams,
+    add_standardize_call_element, delete_standardize_call_element,
+};
+use sz_configtool_lib::error::SzErrorKind;
+
+fn template() -> String {
+    let path = format!(
+        "{}/tests/fixtures/g2config_template.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"))
+}
+
+fn parse(config: &str) -> Value {
+    serde_json::from_str(config).unwrap()
+}
+
+fn rows<'a>(v: &'a Value, section: &str) -> &'a Vec<Value> {
+    v["G2_CONFIG"][section]
+        .as_array()
+        .unwrap_or_else(|| panic!("section {section} missing"))
+}
+
+fn felem_code(v: &Value, id: i64) -> String {
+    v["G2_CONFIG"]["CFG_FELEM"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["FELEM_ID"].as_i64() == Some(id))
+        .and_then(|r| r["FELEM_CODE"].as_str())
+        .unwrap_or_else(|| panic!("no FELEM_CODE for id {id}"))
+        .to_string()
+}
+
+/// A BOM row `(call_id, ftype_id, felem_id)` whose `(call_id, felem_id)` pair is
+/// unique across the whole `bom_section` — so deleting it by `(call, element)`
+/// with no feature disambiguator resolves to exactly one row (never ambiguous).
+fn unique_bom_target(v: &Value, bom_section: &str, id_field: &str) -> (i64, i64, i64) {
+    let bom = rows(v, bom_section);
+    for row in bom {
+        let call_id = row[id_field].as_i64().unwrap();
+        let felem_id = row["FELEM_ID"].as_i64().unwrap();
+        let ftype_id = row["FTYPE_ID"].as_i64().unwrap();
+        let matches = bom
+            .iter()
+            .filter(|r| {
+                r[id_field].as_i64() == Some(call_id) && r["FELEM_ID"].as_i64() == Some(felem_id)
+            })
+            .count();
+        if matches == 1 {
+            return (call_id, ftype_id, felem_id);
+        }
+    }
+    panic!("no unique (call, felem) BOM row in {bom_section}");
+}
+
+/// A `felem_id` that exists in `CFG_FELEM` but is NOT a BOM row of `call_id`
+/// within `bom_section` — the "not on this call" element used to drive delete.
+fn felem_not_on_call(v: &Value, bom_section: &str, id_field: &str, call_id: i64) -> i64 {
+    let bom = rows(v, bom_section);
+    let on_call: Vec<i64> = bom
+        .iter()
+        .filter(|r| r[id_field].as_i64() == Some(call_id))
+        .filter_map(|r| r["FELEM_ID"].as_i64())
+        .collect();
+    v["G2_CONFIG"]["CFG_FELEM"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|r| r["FELEM_ID"].as_i64())
+        .find(|id| *id >= 0 && !on_call.contains(id))
+        .expect("a FELEM not on the chosen call")
+}
+
+// ============================================================================
+// NotOnCall: delete of an element that is NOT on the call, all four families.
+// ============================================================================
+
+#[test]
+fn delete_element_not_on_call_is_not_on_call_all_families() {
+    let config = template();
+    let v = parse(&config);
+
+    // --- comparison ---
+    let (call_id, _, _) = unique_bom_target(&v, "CFG_CFBOM", "CFCALL_ID");
+    let missing = felem_not_on_call(&v, "CFG_CFBOM", "CFCALL_ID", call_id);
+    let code = felem_code(&v, missing);
+    let err = delete_comparison_call_element(&config, CallSelector::Id(call_id), &code, None)
+        .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotOnCall, "comparison");
+
+    // --- expression ---
+    let (call_id, _, _) = unique_bom_target(&v, "CFG_EFBOM", "EFCALL_ID");
+    let missing = felem_not_on_call(&v, "CFG_EFBOM", "EFCALL_ID", call_id);
+    let code = felem_code(&v, missing);
+    let err = delete_expression_call_element(&config, CallSelector::Id(call_id), &code, None)
+        .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotOnCall, "expression");
+
+    // --- distinct ---
+    let (call_id, _, _) = unique_bom_target(&v, "CFG_DFBOM", "DFCALL_ID");
+    let missing = felem_not_on_call(&v, "CFG_DFBOM", "DFCALL_ID", call_id);
+    let code = felem_code(&v, missing);
+    let err =
+        delete_distinct_call_element(&config, CallSelector::Id(call_id), &code, None).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotOnCall, "distinct");
+
+    // --- standardize (no BOM table: the SFCALL rows ARE the elements) ---
+    let sfcall = &rows(&v, "CFG_SFCALL")[0];
+    let err = delete_standardize_call_element(
+        &config,
+        DeleteStandardizeCallElementParams {
+            ftype_id: sfcall["FTYPE_ID"].as_i64().unwrap(),
+            sfunc_id: sfcall["SFUNC_ID"].as_i64().unwrap(),
+            // A FELEM_ID no standardize row carries -> not on the call.
+            felem_id: Some(9_999_999),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotOnCall, "standardize");
+}
+
+// ============================================================================
+// NotFound (NOT NotOnCall): delete against a call id that does not exist at all
+// is a hard error, distinct from the benign "element not on an existing call".
+// (The by-id delete path does not validate call existence via the resolver, so
+// this guards the ensure_call_exists check that draws that line — Python's
+// prepCallElement errors on a missing call record before touching the BOM.)
+// ============================================================================
+
+#[test]
+fn delete_element_missing_call_id_is_not_found_all_families() {
+    let config = template();
+    let v = parse(&config);
+    // A real element code so the failure is the call id, not the element lookup.
+    let (_, _, felem_id) = unique_bom_target(&v, "CFG_CFBOM", "CFCALL_ID");
+    let code = felem_code(&v, felem_id);
+    const GHOST: i64 = 9_999_999;
+
+    let err =
+        delete_comparison_call_element(&config, CallSelector::Id(GHOST), &code, None).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotFound, "comparison");
+
+    let err =
+        delete_expression_call_element(&config, CallSelector::Id(GHOST), &code, None).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotFound, "expression");
+
+    let err =
+        delete_distinct_call_element(&config, CallSelector::Id(GHOST), &code, None).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotFound, "distinct");
+}
+
+// ============================================================================
+// Delete-path regression guard: an element that IS on the call removes EXACTLY
+// one BOM row (the two past regressions were over/under-deletion here).
+// ============================================================================
+
+#[test]
+fn delete_element_on_call_removes_exactly_one_row_all_families() {
+    let config = template();
+    let v = parse(&config);
+
+    // --- comparison ---
+    let before = rows(&v, "CFG_CFBOM").len();
+    let (call_id, _, felem_id) = unique_bom_target(&v, "CFG_CFBOM", "CFCALL_ID");
+    let code = felem_code(&v, felem_id);
+    let out =
+        delete_comparison_call_element(&config, CallSelector::Id(call_id), &code, None).unwrap();
+    assert_eq!(
+        rows(&parse(&out), "CFG_CFBOM").len(),
+        before - 1,
+        "comparison must drop exactly one CFBOM row"
+    );
+
+    // --- expression ---
+    let before = rows(&v, "CFG_EFBOM").len();
+    let (call_id, _, felem_id) = unique_bom_target(&v, "CFG_EFBOM", "EFCALL_ID");
+    let code = felem_code(&v, felem_id);
+    let out =
+        delete_expression_call_element(&config, CallSelector::Id(call_id), &code, None).unwrap();
+    assert_eq!(
+        rows(&parse(&out), "CFG_EFBOM").len(),
+        before - 1,
+        "expression must drop exactly one EFBOM row"
+    );
+
+    // --- distinct ---
+    let before = rows(&v, "CFG_DFBOM").len();
+    let (call_id, _, felem_id) = unique_bom_target(&v, "CFG_DFBOM", "DFCALL_ID");
+    let code = felem_code(&v, felem_id);
+    let out =
+        delete_distinct_call_element(&config, CallSelector::Id(call_id), &code, None).unwrap();
+    assert_eq!(
+        rows(&parse(&out), "CFG_DFBOM").len(),
+        before - 1,
+        "distinct must drop exactly one DFBOM row"
+    );
+
+    // --- standardize: delete a real (ftype, sfunc, felem) triple, drop one row ---
+    let before = rows(&v, "CFG_SFCALL").len();
+    let sfcall = &rows(&v, "CFG_SFCALL")[0];
+    let felem = sfcall["FELEM_ID"].as_i64().unwrap();
+    let out = delete_standardize_call_element(
+        &config,
+        DeleteStandardizeCallElementParams {
+            ftype_id: sfcall["FTYPE_ID"].as_i64().unwrap(),
+            sfunc_id: sfcall["SFUNC_ID"].as_i64().unwrap(),
+            felem_id: if felem == -1 { None } else { Some(felem) },
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        rows(&parse(&out), "CFG_SFCALL").len(),
+        before - 1,
+        "standardize must drop exactly one SFCALL row"
+    );
+}
+
+// ============================================================================
+// AlreadyPresent: adding an element already on the call, all four families.
+// ============================================================================
+
+#[test]
+fn add_duplicate_element_is_already_present_all_families() {
+    let config = template();
+    let v = parse(&config);
+
+    // --- comparison ---
+    let (call_id, ftype_id, felem_id) = unique_bom_target(&v, "CFG_CFBOM", "CFCALL_ID");
+    let err = add_comparison_call_element(
+        &config,
+        AddComparisonCallElementParams {
+            cfcall_id: call_id,
+            ftype_id,
+            felem_id,
+            exec_order: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyPresent, "comparison");
+
+    // --- expression ---
+    let (call_id, ftype_id, felem_id) = unique_bom_target(&v, "CFG_EFBOM", "EFCALL_ID");
+    let err = add_expression_call_element(
+        &config,
+        call_id,
+        ExpressionCallElementParams::new(ftype_id, felem_id, None, "No".to_string()),
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyPresent, "expression");
+
+    // --- distinct ---
+    let (call_id, ftype_id, felem_id) = unique_bom_target(&v, "CFG_DFBOM", "DFCALL_ID");
+    let err = add_distinct_call_element(
+        &config,
+        AddDistinctCallElementParams {
+            dfcall_id: call_id,
+            ftype_id,
+            felem_id,
+            exec_order: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyPresent, "distinct");
+
+    // --- standardize ---
+    let sfcall = &rows(&v, "CFG_SFCALL")[0];
+    let felem = sfcall["FELEM_ID"].as_i64().unwrap();
+    let err = add_standardize_call_element(
+        &config,
+        AddStandardizeCallElementParams {
+            ftype_id: sfcall["FTYPE_ID"].as_i64().unwrap(),
+            sfunc_id: sfcall["SFUNC_ID"].as_i64().unwrap(),
+            felem_id: if felem == -1 { None } else { Some(felem) },
+            exec_order: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyPresent, "standardize");
+}
+
+// ============================================================================
+// AlreadyPresent: a per-feature call that is already set (comparison/distinct).
+// ============================================================================
+
+#[test]
+fn add_call_for_feature_already_set_is_already_present() {
+    let config = template();
+    let v = parse(&config);
+
+    // NAME (FTYPE_ID 1) already has a comparison call in the template. Adding a
+    // second comparison call for the same feature is the benign "already set"
+    // no-op -> AlreadyPresent (not AlreadyExists).
+    assert!(
+        rows(&v, "CFG_CFCALL")
+            .iter()
+            .any(|c| c["FTYPE_ID"].as_i64() == Some(1)),
+        "precondition: NAME has a comparison call"
+    );
+    let err = add_comparison_call(
+        &config,
+        AddComparisonCallParams {
+            ftype_code: "NAME".to_string(),
+            cfunc_code: "GNR_COMP".to_string(),
+            element_list: vec!["NAME_FULL".to_string()],
+            id: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.kind(),
+        SzErrorKind::AlreadyPresent,
+        "comparison already-set"
+    );
+}
+
+// ============================================================================
+// Negative guards: hard collisions were NOT reclassified by step D.
+// ============================================================================
+
+#[test]
+fn taken_explicit_id_is_still_already_exists() {
+    let config = template();
+    let v = parse(&config);
+    // An explicit, already-used CFCALL_ID is a hard collision. The id check runs
+    // before the per-feature "already set" check, so this is AlreadyExists even
+    // for a feature that also already has a call.
+    let taken = rows(&v, "CFG_CFCALL")[0]["CFCALL_ID"].as_i64().unwrap();
+    let err = add_comparison_call(
+        &config,
+        AddComparisonCallParams {
+            ftype_code: "NAME".to_string(),
+            cfunc_code: "GNR_COMP".to_string(),
+            element_list: vec!["NAME_FULL".to_string()],
+            id: Some(taken),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyExists);
+}
+
+#[test]
+fn missing_call_id_is_still_not_found() {
+    let config = template();
+    // Addressing a call by an id that does not exist is a genuine lookup miss ->
+    // NotFound (NOT the NotOnCall delete sub-case).
+    let err = get_comparison_call(&config, CallSelector::Id(9_999_999)).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotFound);
+}
+
+#[test]
+fn taken_exec_order_is_still_already_exists() {
+    let config = template();
+    let v = parse(&config);
+
+    // Pick a comparison call, a taken EXEC_ORDER on it, and a FREE element (not
+    // yet on the call). The dup check passes (free element), so allocation runs
+    // and rejects the taken order -> AlreadyExists, unchanged by step D.
+    let (call_id, ftype_id, _) = unique_bom_target(&v, "CFG_CFBOM", "CFCALL_ID");
+    let taken_order = rows(&v, "CFG_CFBOM")
+        .iter()
+        .find(|r| r["CFCALL_ID"].as_i64() == Some(call_id))
+        .and_then(|r| r["EXEC_ORDER"].as_i64())
+        .unwrap();
+    let free_felem = felem_not_on_call(&v, "CFG_CFBOM", "CFCALL_ID", call_id);
+    let err = add_comparison_call_element(
+        &config,
+        AddComparisonCallElementParams {
+            cfcall_id: call_id,
+            ftype_id,
+            felem_id: free_felem,
+            exec_order: Some(taken_order),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyExists);
+}

--- a/tests/error_subcases.rs
+++ b/tests/error_subcases.rs
@@ -104,11 +104,13 @@ fn felem_not_on_call(v: &Value, bom_section: &str, id_field: &str, call_id: i64)
 }
 
 // ============================================================================
-// NotOnCall: delete of an element that is NOT on the call, all four families.
+// NotOnCall: delete of an element that is NOT on the call, for the three
+// BOM-backed families (comparison/expression/distinct). Standardize has no
+// NotOnCall concept — see the missing-call NotFound test.
 // ============================================================================
 
 #[test]
-fn delete_element_not_on_call_is_not_on_call_all_families() {
+fn delete_element_not_on_call_is_not_on_call_bom_families() {
     let config = template();
     let v = parse(&config);
 
@@ -136,19 +138,9 @@ fn delete_element_not_on_call_is_not_on_call_all_families() {
         delete_distinct_call_element(&config, CallSelector::Id(call_id), &code, None).unwrap_err();
     assert_eq!(err.kind(), SzErrorKind::NotOnCall, "distinct");
 
-    // --- standardize (no BOM table: the SFCALL rows ARE the elements) ---
-    let sfcall = &rows(&v, "CFG_SFCALL")[0];
-    let err = delete_standardize_call_element(
-        &config,
-        DeleteStandardizeCallElementParams {
-            ftype_id: sfcall["FTYPE_ID"].as_i64().unwrap(),
-            sfunc_id: sfcall["SFUNC_ID"].as_i64().unwrap(),
-            // A FELEM_ID no standardize row carries -> not on the call.
-            felem_id: Some(9_999_999),
-        },
-    )
-    .unwrap_err();
-    assert_eq!(err.kind(), SzErrorKind::NotOnCall, "standardize");
+    // Standardize is deliberately NOT here: it has no BOM/two-tier split (the
+    // SFCALL row IS the element) and no benign "not on call" concept — any miss
+    // is a hard NotFound (see the missing-call test below).
 }
 
 // ============================================================================
@@ -179,6 +171,22 @@ fn delete_element_missing_call_id_is_not_found_all_families() {
     let err =
         delete_distinct_call_element(&config, CallSelector::Id(GHOST), &code, None).unwrap_err();
     assert_eq!(err.kind(), SzErrorKind::NotFound, "distinct");
+
+    // Standardize: a delete that matches no SFCALL row (here a non-existent
+    // element on a real (ftype, sfunc)) is a hard NotFound — Python's nearest
+    // parity, deleteStandardizeCall, errors on a miss; there is no benign
+    // "not on call" for the BOM-less standardize family.
+    let sfcall = &rows(&v, "CFG_SFCALL")[0];
+    let err = delete_standardize_call_element(
+        &config,
+        DeleteStandardizeCallElementParams {
+            ftype_id: sfcall["FTYPE_ID"].as_i64().unwrap(),
+            sfunc_id: sfcall["SFUNC_ID"].as_i64().unwrap(),
+            felem_id: Some(GHOST),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotFound, "standardize");
 }
 
 // ============================================================================

--- a/tests/exec_order_allocation.rs
+++ b/tests/exec_order_allocation.rs
@@ -1,0 +1,463 @@
+//! Execution-order auto-allocation (v0.7.0 STEP C / #55) exercised against the
+//! REAL Senzing v4 template (`tests/fixtures/g2config_template.json`), never
+//! synthetic-only config. Two past regressions slipped through synthetic tests,
+//! so the allocation/tier policy is proven here on the shipped data.
+//!
+//! Covers:
+//!  - E1 `features::add_feature_comparison` — whole-table CFG_FBOM allocation.
+//!  - E2 `calls::standardize::add_standardize_call_element` — per (FTYPE_ID,
+//!    FELEM_ID) allocation.
+//!  - E3 `thresholds::add_comparison_threshold` — CFRTN all-features tier REUSE
+//!    (load-bearing scoring invariant), next-available, and reject-if-taken.
+//!  - D1/D2/D3 comparison/expression/distinct `add_*_call_element` — per-call
+//!    allocation (None -> max+1, explicit-free honoured, explicit-taken ->
+//!    AlreadyExists) plus the distinct dup-check realignment (a duplicate
+//!    element is AlreadyPresent, not AlreadyExists — step D).
+//!  - command_processor `addComparisonCallElement` dispatch (per-call order).
+
+use serde_json::Value;
+use sz_configtool_lib::calls::comparison::{
+    AddComparisonCallElementParams, add_comparison_call_element,
+};
+use sz_configtool_lib::calls::distinct::{AddDistinctCallElementParams, add_distinct_call_element};
+use sz_configtool_lib::calls::expression::{
+    ExpressionCallElementParams, add_expression_call_element,
+};
+use sz_configtool_lib::calls::standardize::{
+    AddStandardizeCallElementParams, add_standardize_call_element,
+};
+use sz_configtool_lib::command_processor::CommandProcessor;
+use sz_configtool_lib::error::SzErrorKind;
+use sz_configtool_lib::features::{AddFeatureComparisonParams, add_feature_comparison};
+use sz_configtool_lib::thresholds::{AddComparisonThresholdParams, add_comparison_threshold};
+
+fn template() -> String {
+    let path = format!(
+        "{}/tests/fixtures/g2config_template.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"))
+}
+
+fn parse(config: &str) -> Value {
+    serde_json::from_str(config).unwrap()
+}
+
+fn rows<'a>(v: &'a Value, section: &str) -> &'a Vec<Value> {
+    v["G2_CONFIG"][section].as_array().unwrap()
+}
+
+fn feature_id(v: &Value, code: &str) -> i64 {
+    rows(v, "CFG_FTYPE")
+        .iter()
+        .find(|r| r["FTYPE_CODE"].as_str() == Some(code))
+        .and_then(|r| r["FTYPE_ID"].as_i64())
+        .unwrap_or_else(|| panic!("feature {code} not in template"))
+}
+
+fn element_id(v: &Value, code: &str) -> i64 {
+    rows(v, "CFG_FELEM")
+        .iter()
+        .find(|r| r["FELEM_CODE"].as_str() == Some(code))
+        .and_then(|r| r["FELEM_ID"].as_i64())
+        .unwrap_or_else(|| panic!("element {code} not in template"))
+}
+
+// ============================================================================
+// E1: add_feature_comparison — whole-table CFG_FBOM allocation
+// ============================================================================
+
+#[test]
+fn e1_add_feature_comparison_allocates_whole_table_next() {
+    let config = template();
+    let before = parse(&config);
+    let whole_max = rows(&before, "CFG_FBOM")
+        .iter()
+        .filter_map(|r| r["EXEC_ORDER"].as_i64())
+        .max()
+        .unwrap();
+
+    // GENDER exists but is not an FBOM element of NAME.
+    let params = AddFeatureComparisonParams::new("NAME", "GENDER");
+    let modified = add_feature_comparison(&config, params).unwrap();
+    let after = parse(&modified);
+
+    let name_id = feature_id(&after, "NAME");
+    let gender_id = element_id(&after, "GENDER");
+    let new_row = rows(&after, "CFG_FBOM")
+        .iter()
+        .find(|r| {
+            r["FTYPE_ID"].as_i64() == Some(name_id) && r["FELEM_ID"].as_i64() == Some(gender_id)
+        })
+        .expect("new NAME/GENDER FBOM row");
+    // None -> next order across the whole table.
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(whole_max + 1));
+}
+
+#[test]
+fn e1_add_feature_comparison_rejects_taken_whole_table_order() {
+    let config = template();
+    // Order 1 is certainly used somewhere in the whole CFG_FBOM table, so a
+    // whole-table honour of 1 must be rejected.
+    let params = AddFeatureComparisonParams::new("NAME", "GENDER").with_exec_order(1);
+    let err = add_feature_comparison(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyExists);
+}
+
+// ============================================================================
+// E2: add_standardize_call_element — per (FTYPE_ID, FELEM_ID) allocation
+// ============================================================================
+
+#[test]
+fn e2_add_standardize_call_element_allocates_per_feature_element() {
+    let config = template();
+    let before = parse(&config);
+
+    // Scope (FTYPE_ID = NAME, FELEM_ID = -1) carries standardize calls in the
+    // template; compute its current max and a free SFUNC_ID for that scope.
+    let name_id = feature_id(&before, "NAME");
+    let scope_orders: Vec<i64> = rows(&before, "CFG_SFCALL")
+        .iter()
+        .filter(|r| r["FTYPE_ID"].as_i64() == Some(name_id) && r["FELEM_ID"].as_i64() == Some(-1))
+        .filter_map(|r| r["EXEC_ORDER"].as_i64())
+        .collect();
+    let scope_max = *scope_orders.iter().max().unwrap();
+    let used_sfuncs: Vec<i64> = rows(&before, "CFG_SFCALL")
+        .iter()
+        .filter(|r| r["FTYPE_ID"].as_i64() == Some(name_id) && r["FELEM_ID"].as_i64() == Some(-1))
+        .filter_map(|r| r["SFUNC_ID"].as_i64())
+        .collect();
+    let free_sfunc = rows(&before, "CFG_SFUNC")
+        .iter()
+        .filter_map(|r| r["SFUNC_ID"].as_i64())
+        .find(|id| !used_sfuncs.contains(id))
+        .expect("a SFUNC_ID free for the NAME/-1 scope");
+
+    let params = AddStandardizeCallElementParams {
+        ftype_id: name_id,
+        sfunc_id: free_sfunc,
+        felem_id: None, // -> -1
+        exec_order: None,
+    };
+    let (modified, _) = add_standardize_call_element(&config, params).unwrap();
+    let after = parse(&modified);
+
+    let new_row = rows(&after, "CFG_SFCALL")
+        .iter()
+        .find(|r| {
+            r["FTYPE_ID"].as_i64() == Some(name_id)
+                && r["FELEM_ID"].as_i64() == Some(-1)
+                && r["SFUNC_ID"].as_i64() == Some(free_sfunc)
+        })
+        .expect("new standardize call element");
+    // Per-scope next order.
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(scope_max + 1));
+}
+
+// ============================================================================
+// E3: add_comparison_threshold — CFRTN tier reuse / next / reject
+// ============================================================================
+
+#[test]
+fn e3_comparison_threshold_reuses_all_features_tier_order() {
+    let config = template();
+    let before = parse(&config);
+
+    // ID_COMP (cfunc 9) ships a FULL_SCORE all-features (FTYPE_ID=0) tier row.
+    let tier_order = rows(&before, "CFG_CFRTN")
+        .iter()
+        .find(|r| {
+            r["CFUNC_ID"].as_i64() == Some(9)
+                && r["FTYPE_ID"].as_i64() == Some(0)
+                && r["CFUNC_RTNVAL"].as_str() == Some("FULL_SCORE")
+        })
+        .and_then(|r| r["EXEC_ORDER"].as_i64())
+        .expect("ID_COMP FULL_SCORE tier row in template");
+
+    // NAME has no ID_COMP/FULL_SCORE row yet. Request a bogus order 99 — tier
+    // reuse must win and the new row must carry the tier's order, NOT 99.
+    let mut params = AddComparisonThresholdParams::new("ID_COMP", "NAME", "FULL_SCORE");
+    params.exec_order = Some(99);
+    let modified = add_comparison_threshold(&config, params).unwrap();
+    let after = parse(&modified);
+
+    let name_id = feature_id(&after, "NAME");
+    let new_row = rows(&after, "CFG_CFRTN")
+        .iter()
+        .find(|r| {
+            r["CFUNC_ID"].as_i64() == Some(9)
+                && r["FTYPE_ID"].as_i64() == Some(name_id)
+                && r["CFUNC_RTNVAL"].as_str() == Some("FULL_SCORE")
+        })
+        .expect("new ID_COMP/NAME/FULL_SCORE row");
+    assert_eq!(
+        new_row["EXEC_ORDER"].as_i64(),
+        Some(tier_order),
+        "tier reuse must take precedence over the requested order"
+    );
+}
+
+#[test]
+fn e3_comparison_threshold_next_available_when_no_tier() {
+    let config = template();
+    let before = parse(&config);
+
+    // A brand-new return value for ID_COMP at the all-features level: no tier
+    // row exists, so the next free order within (CFUNC_ID 9, FTYPE_ID 0) is used.
+    let scope_max = rows(&before, "CFG_CFRTN")
+        .iter()
+        .filter(|r| r["CFUNC_ID"].as_i64() == Some(9) && r["FTYPE_ID"].as_i64() == Some(0))
+        .filter_map(|r| r["EXEC_ORDER"].as_i64())
+        .max()
+        .unwrap();
+
+    let params = AddComparisonThresholdParams::new("ID_COMP", "all", "NEW_RTNVAL_X");
+    let modified = add_comparison_threshold(&config, params).unwrap();
+    let after = parse(&modified);
+
+    let new_row = rows(&after, "CFG_CFRTN")
+        .iter()
+        .find(|r| {
+            r["CFUNC_ID"].as_i64() == Some(9)
+                && r["FTYPE_ID"].as_i64() == Some(0)
+                && r["CFUNC_RTNVAL"].as_str() == Some("NEW_RTNVAL_X")
+        })
+        .expect("new ID_COMP/all/NEW_RTNVAL_X row");
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(scope_max + 1));
+}
+
+#[test]
+fn e3_comparison_threshold_rejects_taken_explicit_order() {
+    let config = template();
+    let before = parse(&config);
+    // A used order within (CFUNC_ID 9, FTYPE_ID 0).
+    let taken = rows(&before, "CFG_CFRTN")
+        .iter()
+        .find(|r| r["CFUNC_ID"].as_i64() == Some(9) && r["FTYPE_ID"].as_i64() == Some(0))
+        .and_then(|r| r["EXEC_ORDER"].as_i64())
+        .unwrap();
+
+    // New return value (no tier), explicit already-taken order -> AlreadyExists.
+    let mut params = AddComparisonThresholdParams::new("ID_COMP", "all", "NEW_RTNVAL_Y");
+    params.exec_order = Some(taken);
+    let err = add_comparison_threshold(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyExists);
+}
+
+// ============================================================================
+// D1/D2/D3: BOM call-element allocation (per call)
+// ============================================================================
+
+/// Return (call_id, ftype_id, max_order, a free element id) for the first call
+/// in `call_section` and its BOM in `bom_section`.
+fn first_call_probe(
+    v: &Value,
+    call_section: &str,
+    call_id_field: &str,
+    bom_section: &str,
+) -> (i64, i64, i64, i64) {
+    let call = &rows(v, call_section)[0];
+    let call_id = call[call_id_field].as_i64().unwrap();
+    let ftype_id = call["FTYPE_ID"].as_i64().unwrap_or(1);
+    let bom: Vec<&Value> = rows(v, bom_section)
+        .iter()
+        .filter(|b| b[call_id_field].as_i64() == Some(call_id))
+        .collect();
+    let max_order = bom
+        .iter()
+        .filter_map(|b| b["EXEC_ORDER"].as_i64())
+        .max()
+        .unwrap();
+    let used_felems: Vec<i64> = bom.iter().filter_map(|b| b["FELEM_ID"].as_i64()).collect();
+    let free_felem = rows(v, "CFG_FELEM")
+        .iter()
+        .filter_map(|r| r["FELEM_ID"].as_i64())
+        .find(|id| !used_felems.contains(id))
+        .expect("a free element for the call");
+    (call_id, ftype_id, max_order, free_felem)
+}
+
+#[test]
+fn d1_comparison_call_element_allocates_per_call() {
+    let config = template();
+    let before = parse(&config);
+    let (call_id, ftype_id, max_order, free_felem) =
+        first_call_probe(&before, "CFG_CFCALL", "CFCALL_ID", "CFG_CFBOM");
+
+    // None -> max+1.
+    let (modified, _) = add_comparison_call_element(
+        &config,
+        AddComparisonCallElementParams {
+            cfcall_id: call_id,
+            ftype_id,
+            felem_id: free_felem,
+            exec_order: None,
+        },
+    )
+    .unwrap();
+    let after = parse(&modified);
+    let new_row = rows(&after, "CFG_CFBOM")
+        .iter()
+        .find(|b| {
+            b["CFCALL_ID"].as_i64() == Some(call_id) && b["FELEM_ID"].as_i64() == Some(free_felem)
+        })
+        .unwrap();
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(max_order + 1));
+
+    // Explicit free order honoured.
+    let (modified2, _) = add_comparison_call_element(
+        &config,
+        AddComparisonCallElementParams {
+            cfcall_id: call_id,
+            ftype_id,
+            felem_id: free_felem,
+            exec_order: Some(max_order + 5),
+        },
+    )
+    .unwrap();
+    let after2 = parse(&modified2);
+    let honoured = rows(&after2, "CFG_CFBOM")
+        .iter()
+        .find(|b| {
+            b["CFCALL_ID"].as_i64() == Some(call_id) && b["FELEM_ID"].as_i64() == Some(free_felem)
+        })
+        .unwrap();
+    assert_eq!(honoured["EXEC_ORDER"].as_i64(), Some(max_order + 5));
+
+    // Explicit taken order rejected (order 1 exists on the call).
+    let err = add_comparison_call_element(
+        &config,
+        AddComparisonCallElementParams {
+            cfcall_id: call_id,
+            ftype_id,
+            felem_id: free_felem,
+            exec_order: Some(1),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyExists);
+}
+
+#[test]
+fn d2_expression_call_element_allocates_per_call() {
+    let config = template();
+    let before = parse(&config);
+    let (call_id, ftype_id, max_order, free_felem) =
+        first_call_probe(&before, "CFG_EFCALL", "EFCALL_ID", "CFG_EFBOM");
+
+    let (modified, _) = add_expression_call_element(
+        &config,
+        call_id,
+        ExpressionCallElementParams::new(ftype_id, free_felem, None, "No".to_string()),
+    )
+    .unwrap();
+    let after = parse(&modified);
+    let new_row = rows(&after, "CFG_EFBOM")
+        .iter()
+        .find(|b| {
+            b["EFCALL_ID"].as_i64() == Some(call_id) && b["FELEM_ID"].as_i64() == Some(free_felem)
+        })
+        .unwrap();
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(max_order + 1));
+
+    // Explicit taken order rejected.
+    let err = add_expression_call_element(
+        &config,
+        call_id,
+        ExpressionCallElementParams::new(ftype_id, free_felem, Some(1), "No".to_string()),
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::AlreadyExists);
+}
+
+#[test]
+fn d3_distinct_call_element_allocates_per_call_and_dup_check_realigned() {
+    let config = template();
+    let before = parse(&config);
+    let (call_id, ftype_id, max_order, free_felem) =
+        first_call_probe(&before, "CFG_DFCALL", "DFCALL_ID", "CFG_DFBOM");
+
+    // None -> max+1.
+    let (modified, _) = add_distinct_call_element(
+        &config,
+        AddDistinctCallElementParams {
+            dfcall_id: call_id,
+            ftype_id,
+            felem_id: free_felem,
+            exec_order: None,
+        },
+    )
+    .unwrap();
+    let after = parse(&modified);
+    let new_row = rows(&after, "CFG_DFBOM")
+        .iter()
+        .find(|b| {
+            b["DFCALL_ID"].as_i64() == Some(call_id) && b["FELEM_ID"].as_i64() == Some(free_felem)
+        })
+        .unwrap();
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(max_order + 1));
+
+    // Dup-check realignment: an element already on the call is a duplicate even
+    // when a different exec_order is requested (EXEC_ORDER no longer part of the
+    // dup identity). Reuse an element that IS already on the call.
+    let existing_felem = rows(&before, "CFG_DFBOM")
+        .iter()
+        .find(|b| b["DFCALL_ID"].as_i64() == Some(call_id))
+        .and_then(|b| b["FELEM_ID"].as_i64())
+        .unwrap();
+    let err = add_distinct_call_element(
+        &config,
+        AddDistinctCallElementParams {
+            dfcall_id: call_id,
+            ftype_id,
+            felem_id: existing_felem,
+            exec_order: Some(9999), // different order, still a dup
+        },
+    )
+    .unwrap_err();
+    // Step D: a duplicate element on the call is the benign "already present"
+    // sub-case, distinct from a taken exec-order (which stays AlreadyExists).
+    assert_eq!(err.kind(), SzErrorKind::AlreadyPresent);
+}
+
+// ============================================================================
+// command_processor addComparisonCallElement dispatch (per-call order)
+// ============================================================================
+
+#[test]
+fn command_processor_add_comparison_call_element_allocates_per_call() {
+    let config = template();
+    let before = parse(&config);
+
+    // NATIONAL_ID's comparison call and its current max BOM order.
+    let nat_id = feature_id(&before, "NATIONAL_ID");
+    let cfcall_id = rows(&before, "CFG_CFCALL")
+        .iter()
+        .find(|c| c["FTYPE_ID"].as_i64() == Some(nat_id))
+        .and_then(|c| c["CFCALL_ID"].as_i64())
+        .expect("NATIONAL_ID comparison call");
+    let max_order = rows(&before, "CFG_CFBOM")
+        .iter()
+        .filter(|b| b["CFCALL_ID"].as_i64() == Some(cfcall_id))
+        .filter_map(|b| b["EXEC_ORDER"].as_i64())
+        .max()
+        .unwrap();
+
+    // GENDER exists but is not on NATIONAL_ID's comparison call.
+    let script = r#"addComparisonCallElement {"feature": "NATIONAL_ID", "element": "GENDER"}"#;
+    let mut processor = CommandProcessor::new(config);
+    let result = processor.process_script(script).expect("dispatch ok");
+    let after = parse(&result);
+
+    let gender_id = element_id(&after, "GENDER");
+    let new_row = rows(&after, "CFG_CFBOM")
+        .iter()
+        .find(|b| {
+            b["CFCALL_ID"].as_i64() == Some(cfcall_id) && b["FELEM_ID"].as_i64() == Some(gender_id)
+        })
+        .expect("GENDER added to NATIONAL_ID comparison call");
+    // Per-call allocation -> max+1 (the old per-(call,ftype) calc would also give
+    // max+1 here since all rows share the feature, but this pins the new path).
+    assert_eq!(new_row["EXEC_ORDER"].as_i64(), Some(max_order + 1));
+}

--- a/tests/generic_threshold_validation.rs
+++ b/tests/generic_threshold_validation.rs
@@ -1,0 +1,140 @@
+//! Generic-threshold validation exercised against the REAL Senzing v4 template
+//! (`tests/fixtures/g2config_template.json`), not synthetic config.
+//!
+//! Covers the v0.7.0 STEP B hardening (#49/#50 + comparison-cap fold-in):
+//!  - `add_generic_threshold` rejects a bogus BEHAVIOR code via the canonical
+//!    17-code domain (`behavior_domain::BEHAVIOR_CODES`).
+//!  - `add_generic_threshold` succeeds for a genuinely new (plan, behavior,
+//!    feature) tuple on the shipped template.
+//!  - Every distinct BEHAVIOR already shipped in the template passes the new
+//!    validator (the tightened check is a no-op on real data).
+//!  - The strict `optional_i64` boundary rejects a present-but-wrong-type cap
+//!    (`{"candidateCap": "500"}`) instead of silently coercing it to `None`
+//!    and turning the update into a no-op.
+
+use serde_json::{Value, json};
+use sz_configtool_lib::error::SzErrorKind;
+use sz_configtool_lib::thresholds::{
+    AddGenericThresholdParams, SetGenericThresholdParams, add_generic_threshold,
+    set_generic_threshold,
+};
+
+fn template() -> String {
+    let path = format!(
+        "{}/tests/fixtures/g2config_template.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"))
+}
+
+/// (a) A bogus behaviour code on an existing plan must be rejected as
+/// `InvalidInput` — the tightened validity block, not a silent add.
+#[test]
+fn add_generic_threshold_rejects_bogus_behavior_on_template() {
+    let config = template();
+
+    // INGEST is a real plan; "BOGUS" is not one of the canonical 17 codes.
+    let params = AddGenericThresholdParams::new("INGEST", "BOGUS", 20, 10, "No");
+    let err = add_generic_threshold(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::InvalidInput);
+    assert!(
+        err.to_string().contains("BOGUS"),
+        "error should name the offending code: {err}"
+    );
+}
+
+/// (b) A genuinely new (plan, behavior, feature) tuple must be added. The
+/// template ships no `(SEARCH, NAME, NAME-feature)` row, so this is a real add.
+#[test]
+fn add_generic_threshold_succeeds_for_new_tuple_on_template() {
+    let config = template();
+
+    let before: Value = serde_json::from_str(&config).unwrap();
+    let before_len = before["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+        .as_array()
+        .unwrap()
+        .len();
+
+    // SEARCH plan + NAME behaviour + NAME feature (FTYPE_ID 1) is absent.
+    let mut params = AddGenericThresholdParams::new("SEARCH", "NAME", 15, 25, "yes");
+    params.feature = Some("NAME");
+    let modified = add_generic_threshold(&config, params).unwrap();
+
+    let after: Value = serde_json::from_str(&modified).unwrap();
+    let rows = after["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+        .as_array()
+        .unwrap();
+    assert_eq!(rows.len(), before_len + 1);
+
+    // The new row carries the NAME feature (FTYPE_ID 1) and canonical redo.
+    let new_row = rows
+        .iter()
+        .find(|r| {
+            r["GPLAN_ID"].as_i64() == Some(2)
+                && r["BEHAVIOR"].as_str() == Some("NAME")
+                && r["FTYPE_ID"].as_i64() == Some(1)
+        })
+        .expect("newly added SEARCH/NAME/NAME row must exist");
+    assert_eq!(new_row["CANDIDATE_CAP"], json!(25));
+    assert_eq!(new_row["SCORING_CAP"], json!(15));
+    // Lower-case "yes" input canonicalises to title-case "Yes".
+    assert_eq!(new_row["SEND_TO_REDO"], json!("Yes"));
+}
+
+/// (c) The tightened behaviour validator must be a no-op on shipped data: every
+/// distinct BEHAVIOR already in the template is a recognised canonical code.
+#[test]
+fn every_template_generic_threshold_behavior_is_canonical() {
+    let config = template();
+    let value: Value = serde_json::from_str(&config).unwrap();
+    let rows = value["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+        .as_array()
+        .unwrap();
+
+    let mut behaviors: Vec<&str> = rows.iter().filter_map(|r| r["BEHAVIOR"].as_str()).collect();
+    behaviors.sort_unstable();
+    behaviors.dedup();
+    assert!(!behaviors.is_empty(), "template must have threshold rows");
+
+    for b in behaviors {
+        assert!(
+            sz_configtool_lib::behavior_domain::behavior_position(b).is_some(),
+            "shipped BEHAVIOR '{b}' must pass the canonical 17-code validator"
+        );
+    }
+}
+
+/// (d) A present-but-wrong-type cap must now surface as `InvalidInput` at the
+/// JSON boundary (`SetGenericThresholdParams::try_from`) rather than being
+/// silently dropped to `None` and turning the update into a no-op.
+#[test]
+fn set_generic_threshold_wrong_typed_cap_errors_on_template() {
+    // A string where an integer is required.
+    let updates = json!({"candidateCap": "500"});
+    let err = SetGenericThresholdParams::try_from(&updates).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::InvalidInput);
+
+    // Contrast: a correctly-typed cap parses and actually mutates a real
+    // template row (proving the previous case was a genuine rejection, not a
+    // blanket failure). INGEST/NAME/all (FTYPE_ID 0) exists in the template.
+    let config = template();
+    let ok_updates = json!({"candidateCap": 500});
+    let mut params = SetGenericThresholdParams::try_from(&ok_updates).unwrap();
+    params.plan = Some("INGEST");
+    params.behavior = Some("NAME");
+    let modified = set_generic_threshold(&config, params).unwrap();
+
+    let after: Value = serde_json::from_str(&modified).unwrap();
+    let row = after["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| {
+            r["GPLAN_ID"].as_i64() == Some(1)
+                && r["BEHAVIOR"].as_str() == Some("NAME")
+                && r["FTYPE_ID"].as_i64() == Some(0)
+        })
+        .expect("INGEST/NAME/all row must exist");
+    assert_eq!(row["CANDIDATE_CAP"], json!(500));
+}

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -255,3 +255,41 @@ fn test_add_feature_fbom_display_delim_multiple_elements() {
         "DISPLAY_DELIM should be null for element without display_delim"
     );
 }
+
+/// #52: `set_setting` against the real Senzing v4 template.
+///
+/// The template ships `SETTINGS.METAPHONE_VERSION` as the integer `3`. Setting
+/// it to the integer `4` must store a JSON number (not a quoted string) and the
+/// whole document must still round-trip through serde as valid JSON.
+#[test]
+fn test_set_setting_template_metaphone_version() {
+    let path = format!(
+        "{}/tests/fixtures/g2config_template.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"));
+
+    // Sanity: the template really does carry an integer METAPHONE_VERSION of 3.
+    let before: Value = serde_json::from_str(&raw).expect("template is not valid JSON");
+    assert_eq!(
+        before["G2_CONFIG"]["SETTINGS"]["METAPHONE_VERSION"],
+        json!(3),
+        "template precondition: METAPHONE_VERSION should be integer 3"
+    );
+
+    let updated = sz_configtool_lib::set_setting(&raw, "metaphone_version", 4)
+        .expect("set_setting should succeed on the real template");
+
+    // Whole doc round-trips as valid JSON...
+    let after: Value = serde_json::from_str(&updated).expect("updated config is not valid JSON");
+    // ...and the setting is stored as a JSON number, not a quoted string.
+    assert_eq!(
+        after["G2_CONFIG"]["SETTINGS"]["METAPHONE_VERSION"],
+        json!(4)
+    );
+    assert_ne!(
+        after["G2_CONFIG"]["SETTINGS"]["METAPHONE_VERSION"],
+        json!("4")
+    );
+}


### PR DESCRIPTION
## Release v0.7.0 — SDK-surface wave

Seven issues (#49, #50, #52, #53, #54, #55, #56) from the CLI's Wave-2/Wave-9 re-delegation, closing #51 by decision. Planned, implemented, and adversarially reviewed via subagent workflows; verified against the Python `sz_configtool` 4.4.0 reference and the stock Senzing v4 template. **This is a breaking release.**

### Breaking changes
1. **`settings::set_setting`** value param `&str` → `impl Into<serde_json::Value>`; the value is stored **verbatim with its JSON type** (`3` → integer, not `"3"`), matching Python `do_setSetting` (#52). The `SzConfigTool_setSetting` FFI now parses its value C-string as JSON and **errors on invalid JSON** (no string fallback) — a bare string must be quoted JSON (`"\"hello\""`). C ABI (3× `char*`) unchanged; header comment updated.
2. **Call-element `exec_order` params** (`AddComparisonCallElementParams`, `ExpressionCallElementParams` + its `new()`, `AddDistinctCallElementParams`) `i64` → `Option<i64>`; `None` auto-allocates (#55).
3. **New `SzConfigError` variants** `NotOnCall` / `AlreadyPresent` (`SzErrorKind` + `reason_code()` `"NOT_ON_CALL"` / `"ALREADY_PRESENT"`); the enum is not `#[non_exhaustive]`, so exhaustive downstream matches must add arms (#53, #54).

### Highlights
- **#55** — one EXEC_ORDER auto-allocation policy (`get_desired_or_next_order`): auto-allocate next-available over the row's natural scope, honour an explicit value, **reject-if-taken** (`AlreadyExists`), never write `null`. CFRTN `FTYPE_ID=0` scoring **tier-reuse preserved** (load-bearing; a naive max+1 there was a silent regression). Distinct dup-check realigned to `(DFCALL_ID, FTYPE_ID, FELEM_ID)`. New "Execution-order policy" doc section + README mirror.
- **#49/#50 (+comparison caps)** — `add_generic_threshold` validates the `BEHAVIOR` code against the canonical 17-code set (`behavior_position`) and aggregates validation errors like Python; threshold cap fields reject **present-but-wrong-type** values instead of silently dropping them (`optional_i64`), including the FFI path that bypassed `TryFrom`.
- **#53/#54** — `NotOnCall`/`AlreadyPresent` sub-cases + a bare-payload `SzConfigError::message()` accessor (`Display` byte-for-byte unchanged) so the CLI can retire its copied enum.
- **#56** — `FilterSubstrate::ValuesJoin` reproducing `do_listComparisonThresholds`' values-only, bare-`str()`, space-joined filter — completing the CLI's ability to route every list filter through `matches_filter`.

### Review-found bugs fixed (before this PR)
Adversarial subagent review + a focused re-review of the fix caught two real defects, both fixed:
1. The `NotOnCall` re-point in `derive_bom_exec_order` over-reached — a delete against a **non-existent call id** (via `CallSelector::Id`, which skips existence validation) was mis-classified as benign `NotOnCall` instead of `NotFound`, and a unit test had been flipped to bless it. Fixed with an `ensure_call_exists` guard in the three `delete_*_call_element` paths (Python `prepCallElement`'s call-record-before-BOM order); test corrected + cross-family coverage added.
2. The same re-point wrongly hit `delete_standardize_call_element` — standardize has no call/BOM split and no benign not-on-call concept (Python has no `deleteStandardizeCallElement`; `deleteStandardizeCall` hard-errors on a miss). Reverted `NotOnCall`→`NotFound`.

### Documented minor divergences (deliberate)
- Comparison-threshold score/exec fields now reject **digit-strings** (`"100"`) that the Python CLI coerces (deliberate strict typing; generic caps match Python exactly).
- An explicit-`null` required generic cap → `MissingField` vs Python's post-lookup `InvalidInput` (edge case).
- A call-element delete now requires the `CFG_?CALL` section to contain the id — a BOM-only fragment now `NotFound`s (Python-consistent; also closes an orphan-BOM delete). `command_processor addComparisonThreshold` still hardcodes `exec_order: None` (pre-existing; possible follow-up).

### Gates
- `cargo test`: **378 test cases + 82 doctests**, 0 failures. Three new integration suites (`exec_order_allocation.rs`, `error_subcases.rs`, `generic_threshold_validation.rs`) exercise the real template.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo fmt --check`: clean.
- No dependency changes beyond the version bump (Cargo.toml/Cargo.lock 0.6.3 → 0.7.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
