### PR TITLE
Release v0.8.0: NotInFeature error sub-case for call-element delete (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-08-25
+
+Resolves #58 from the CLI's v0.7.0 delete re-delegation. Verified against Python `sz_configtool`
+4.4.0 (`prepCallElement`) and the stock Senzing v4 template, and adversarially reviewed by subagents
+(no classification defect found). Gates green: 380 test cases + 82 doctests, clippy/fmt clean.
+
+### Added
+
+- **`SzConfigError::NotInFeature` / `SzErrorKind::NotInFeature` (`reason_code` `"NOT_IN_FEATURE"`) —
+  the hard-error counterpart to `NotOnCall` (#58).** A call-element delete addressed *with* an element
+  feature now distinguishes Python's two-tier check: the element must first be a member of that
+  feature (a `CFG_FBOM` element) — a non-member (or a nonexistent element code) is a hard
+  `NotInFeature` (`"{element} is not an element of {feature}"`), mirroring Python's
+  `lookupFeatureElement` error, rather than the benign `NotOnCall` ("the element is valid but not on
+  this call"). Previously both collapsed into `NotOnCall`, so a consumer could not tell an error from
+  a warning off `kind()` alone. `delete_{comparison,expression,distinct}_call_element` gained a shared
+  `resolve_feature_element_id` guard for this; the feature-less path (`element_feature: None`) keeps a
+  plain global element lookup and cannot raise it, matching Python's `ftype_id < 0` branch.
+  - The delete paths now resolve the element feature **before** the element (Python's order), so a
+    delete naming both a missing feature and a missing element reports the feature first.
+  - The library emits the core `"{element} is not an element of {feature}"`; the CLI-specific
+    `(use command "getFeature ...")` hint Python appends is left to the CLI (no display logic in the
+    library).
+  - **Breaking:** `SzConfigError` is not `#[non_exhaustive]`, so the new variant adds an arm to
+    exhaustive downstream matches.
+  - Verified against `tests/fixtures/g2config_template.json` (every real-feature BOM element is a
+    `CFG_FBOM` member; only `FTYPE_ID = -1` sentinel rows are not, and those take the `None` path).
+
 ## [0.7.0] - 2026-08-25
 
 SDK-surface wave resolving issues #49, #50, #52, #53, #54, #55 and #56, developed on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/src/calls/comparison.rs
+++ b/src/calls/comparison.rs
@@ -3,7 +3,10 @@
 //! Functions for managing CFG_CFCALL (comparison calls) and CFG_CFBOM
 //! (comparison bill of materials) configuration sections.
 
-use crate::calls::{CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id};
+use crate::calls::{
+    CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id,
+    resolve_feature_element_id,
+};
 use crate::config_rows::{CfbomRow, CfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
@@ -633,12 +636,19 @@ pub fn delete_comparison_call_element(
         cfcall_id,
         "Comparison",
     )?;
-    let felem_id = lookup_element_id(config, element_code)?;
-    // When the element appears under multiple features in this call, the
-    // element's feature disambiguates to the correct BOM row (Python parity).
-    let element_ftype_id = match element_feature {
-        Some(f) => Some(lookup_feature_id(config, f)?),
-        None => None,
+    // When an element feature is given it (a) disambiguates the target BOM row
+    // and (b) requires the element to be a member of that feature — a non-member
+    // is a hard NotInFeature, not the benign NotOnCall (Python parity). Resolve
+    // the feature first, then the element scoped to it.
+    let (felem_id, element_ftype_id) = match element_feature {
+        Some(f) => {
+            let ftype_id = lookup_feature_id(config, f)?;
+            (
+                resolve_feature_element_id(&config_data, config, ftype_id, element_code, f)?,
+                Some(ftype_id),
+            )
+        }
+        None => (lookup_element_id(config, element_code)?, None),
     };
 
     // Derive EXEC_ORDER from the located BOM row (also validates existence).
@@ -917,6 +927,52 @@ mod tests {
                 .unwrap_err();
         assert_eq!(err.kind(), crate::error::SzErrorKind::NotFound);
         assert_eq!(err.to_string(), "Comparison call ID 999 does not exist");
+    }
+
+    #[test]
+    fn test_delete_comparison_call_element_in_feature_not_on_call_is_not_on_call() {
+        // #58: element feature supplied, MIDDLE_NAME IS a member of NAME's FBOM
+        // but is not on call 7 -> the benign NotOnCall, NOT NotInFeature.
+        let config = r#"{"G2_CONFIG": {
+            "CFG_FTYPE": [
+                {"FTYPE_ID": 3, "FTYPE_CODE": "NAME"},
+                {"FTYPE_ID": 4, "FTYPE_CODE": "ADDRESS"}
+            ],
+            "CFG_FELEM": [
+                {"FELEM_ID": 11, "FELEM_CODE": "FIRST_NAME"},
+                {"FELEM_ID": 13, "FELEM_CODE": "MIDDLE_NAME"},
+                {"FELEM_ID": 20, "FELEM_CODE": "STREET"}
+            ],
+            "CFG_FBOM": [
+                {"FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1},
+                {"FTYPE_ID": 3, "FELEM_ID": 13, "EXEC_ORDER": 2},
+                {"FTYPE_ID": 4, "FELEM_ID": 20, "EXEC_ORDER": 1}
+            ],
+            "CFG_CFCALL": [{"CFCALL_ID": 7, "FTYPE_ID": 3, "CFUNC_ID": 1}],
+            "CFG_CFBOM": [
+                {"CFCALL_ID": 7, "FTYPE_ID": 3, "FELEM_ID": 11, "EXEC_ORDER": 1}
+            ]
+        }}"#;
+        let err = delete_comparison_call_element(
+            config,
+            CallSelector::Id(7),
+            "MIDDLE_NAME",
+            Some("NAME"),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotOnCall);
+
+        // The same element under a real feature it is NOT a member of (ADDRESS
+        // has no MIDDLE_NAME) -> the hard NotInFeature, with Python's wording.
+        let err = delete_comparison_call_element(
+            config,
+            CallSelector::Id(7),
+            "MIDDLE_NAME",
+            Some("ADDRESS"),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), crate::error::SzErrorKind::NotInFeature);
+        assert_eq!(err.to_string(), "MIDDLE_NAME is not an element of ADDRESS");
     }
 
     #[test]

--- a/src/calls/distinct.rs
+++ b/src/calls/distinct.rs
@@ -3,7 +3,10 @@
 //! Functions for managing CFG_DFCALL (distinct calls) and CFG_DFBOM
 //! (distinct bill of materials) configuration sections.
 
-use crate::calls::{CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id};
+use crate::calls::{
+    CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id,
+    resolve_feature_element_id,
+};
 use crate::config_rows::{DfbomRow, DfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
@@ -595,12 +598,19 @@ pub fn delete_distinct_call_element(
         dfcall_id,
         "Distinct",
     )?;
-    let felem_id = lookup_element_id(config, element_code)?;
-    // When the element appears under multiple features in this call, the
-    // element's feature disambiguates to the correct BOM row (Python parity).
-    let element_ftype_id = match element_feature {
-        Some(f) => Some(lookup_feature_id(config, f)?),
-        None => None,
+    // When an element feature is given it (a) disambiguates the target BOM row
+    // and (b) requires the element to be a member of that feature — a non-member
+    // is a hard NotInFeature, not the benign NotOnCall (Python parity). Resolve
+    // the feature first, then the element scoped to it.
+    let (felem_id, element_ftype_id) = match element_feature {
+        Some(f) => {
+            let ftype_id = lookup_feature_id(config, f)?;
+            (
+                resolve_feature_element_id(&config_data, config, ftype_id, element_code, f)?,
+                Some(ftype_id),
+            )
+        }
+        None => (lookup_element_id(config, element_code)?, None),
     };
 
     // Derive EXEC_ORDER from the located BOM row (also validates existence).

--- a/src/calls/expression.rs
+++ b/src/calls/expression.rs
@@ -3,7 +3,10 @@
 //! Functions for managing CFG_EFCALL (expression calls) and CFG_EFBOM
 //! (expression bill of materials) configuration sections.
 
-use crate::calls::{CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id};
+use crate::calls::{
+    CallSelector, derive_bom_exec_order, ensure_call_exists, resolve_call_id,
+    resolve_feature_element_id,
+};
 use crate::config_rows::{EfbomRow, EfcallRow};
 use crate::error::{Result, SzConfigError};
 use crate::helpers::{
@@ -624,12 +627,19 @@ pub fn delete_expression_call_element(
         efcall_id,
         "Expression",
     )?;
-    let felem_id = lookup_element_id(config, element_code)?;
-    // When the element appears under multiple features in this call, the
-    // element's feature disambiguates to the correct BOM row (Python parity).
-    let element_ftype_id = match element_feature {
-        Some(f) => Some(lookup_feature_id(config, f)?),
-        None => None,
+    // When an element feature is given it (a) disambiguates the target BOM row
+    // and (b) requires the element to be a member of that feature — a non-member
+    // is a hard NotInFeature, not the benign NotOnCall (Python parity). Resolve
+    // the feature first, then the element scoped to it.
+    let (felem_id, element_ftype_id) = match element_feature {
+        Some(f) => {
+            let ftype_id = lookup_feature_id(config, f)?;
+            (
+                resolve_feature_element_id(&config_data, config, ftype_id, element_code, f)?,
+                Some(ftype_id),
+            )
+        }
+        None => (lookup_element_id(config, element_code)?, None),
     };
 
     // Derive EXEC_ORDER from the located BOM row (also validates existence).
@@ -904,6 +914,10 @@ mod tests {
                 {"FTYPE_ID": 59, "FTYPE_CODE": "EMPLOYER"}
             ],
             "CFG_EFCALL": [{"EFCALL_ID": 97}],
+            "CFG_FBOM": [
+                {"FTYPE_ID": 57, "FELEM_ID": 118, "EXEC_ORDER": 1},
+                {"FTYPE_ID": 59, "FELEM_ID": 118, "EXEC_ORDER": 1}
+            ],
             "CFG_EFBOM": [
                 {"EFCALL_ID": 97, "FTYPE_ID": 57, "FELEM_ID": 118, "EXEC_ORDER": 13},
                 {"EFCALL_ID": 97, "FTYPE_ID": 59, "FELEM_ID": 118, "EXEC_ORDER": 14}
@@ -960,6 +974,10 @@ mod tests {
                 {"FTYPE_ID": 59, "FTYPE_CODE": "EMPLOYER"}
             ],
             "CFG_EFCALL": [{"EFCALL_ID": 97}],
+            "CFG_FBOM": [
+                {"FTYPE_ID": 57, "FELEM_ID": 118, "EXEC_ORDER": 1},
+                {"FTYPE_ID": 59, "FELEM_ID": 118, "EXEC_ORDER": 1}
+            ],
             "CFG_EFBOM": [
                 {"EFCALL_ID": 97, "FTYPE_ID": 57, "FELEM_ID": 118, "EXEC_ORDER": 13},
                 {"EFCALL_ID": 97, "FTYPE_ID": 59, "FELEM_ID": 118, "EXEC_ORDER": 13}

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -194,6 +194,53 @@ pub(crate) fn ensure_call_exists(
     }
 }
 
+/// Resolve an element to its `FELEM_ID`, requiring it to be a member of
+/// `feature_code`'s definition (`CFG_FBOM` for `ftype_id`).
+///
+/// This mirrors Python `prepCallElement`'s feature-scoped branch: when a
+/// call-element op names an element *feature*, the element must first be an
+/// element of that feature (`lookupFeatureElement`). If it is not — whether the
+/// element code does not exist at all, or exists but is not in this feature's
+/// `CFG_FBOM` — that is a hard [`SzConfigError::NotInFeature`]
+/// (`"{element} is not an element of {feature}"`), distinct from the benign
+/// [`SzConfigError::NotOnCall`] returned when the element *is* a feature member
+/// but simply not on this particular call.
+///
+/// (The feature-less path — no element feature given — keeps a plain global
+/// [`crate::helpers::lookup_element_id`] and cannot produce this error, matching
+/// Python's `ftype_id < 0` branch.)
+pub(crate) fn resolve_feature_element_id(
+    root: &Value,
+    config: &str,
+    ftype_id: i64,
+    element_code: &str,
+    feature_code: &str,
+) -> Result<i64> {
+    let not_in_feature = || {
+        SzConfigError::NotInFeature(format!(
+            "{element_code} is not an element of {feature_code}"
+        ))
+    };
+    // The element must exist globally AND be a CFG_FBOM member of the feature.
+    let felem_id =
+        crate::helpers::lookup_element_id(config, element_code).map_err(|_| not_in_feature())?;
+    let in_feature = root
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_FBOM"))
+        .and_then(|v| v.as_array())
+        .is_some_and(|rows| {
+            rows.iter().any(|r| {
+                r.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ftype_id)
+                    && r.get("FELEM_ID").and_then(|v| v.as_i64()) == Some(felem_id)
+            })
+        });
+    if in_feature {
+        Ok(felem_id)
+    } else {
+        Err(not_in_feature())
+    }
+}
+
 // `CallSelector` is exported at the module root so callers can write
 // `calls::CallSelector` regardless of which call family they are addressing.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,17 @@ pub enum SzConfigError {
     /// rows, so there is nothing to delete. Its
     /// [`reason_code`](Self::reason_code) is `"NOT_ON_CALL"`.
     NotOnCall(String),
+    /// A call-element operation named an element that is not part of the
+    /// (element-)feature it was addressed under.
+    ///
+    /// This is the hard-error counterpart to [`NotOnCall`](Self::NotOnCall),
+    /// distinguishing Python's two-tier check: when a call-element delete is
+    /// addressed with an element feature, the element must first be an element of
+    /// that feature (a `CFG_FBOM` member) — if it is not, that is a genuine error
+    /// (mirroring Python's `"{element} is not an element of {feature}"`), not the
+    /// benign "the element is valid but not on this call" ([`NotOnCall`](Self::NotOnCall)).
+    /// Its [`reason_code`](Self::reason_code) is `"NOT_IN_FEATURE"`.
+    NotInFeature(String),
     /// Item already exists
     AlreadyExists(String), // Generic already exists with description
     /// A call or call-element add targeted something that is already present.
@@ -97,6 +108,8 @@ pub enum SzErrorKind {
     NotFound,
     /// A call-element delete targeted an element not on the call. Corresponds to [`SzConfigError::NotOnCall`].
     NotOnCall,
+    /// A call-element operation named an element not in the addressed feature. Corresponds to [`SzConfigError::NotInFeature`].
+    NotInFeature,
     /// An item already exists. Corresponds to [`SzConfigError::AlreadyExists`].
     AlreadyExists,
     /// A call or call-element add targeted something already present. Corresponds to [`SzConfigError::AlreadyPresent`].
@@ -135,6 +148,7 @@ impl SzConfigError {
             Self::JsonParse(_) => SzErrorKind::JsonParse,
             Self::NotFound(_) => SzErrorKind::NotFound,
             Self::NotOnCall(_) => SzErrorKind::NotOnCall,
+            Self::NotInFeature(_) => SzErrorKind::NotInFeature,
             Self::AlreadyExists(_) => SzErrorKind::AlreadyExists,
             Self::AlreadyPresent(_) => SzErrorKind::AlreadyPresent,
             Self::InvalidInput(_) => SzErrorKind::InvalidInput,
@@ -169,6 +183,7 @@ impl SzConfigError {
             Self::JsonParse(_) => "JSON_PARSE",
             Self::NotFound(_) => "NOT_FOUND",
             Self::NotOnCall(_) => "NOT_ON_CALL",
+            Self::NotInFeature(_) => "NOT_IN_FEATURE",
             Self::AlreadyExists(_) => "ALREADY_EXISTS",
             Self::AlreadyPresent(_) => "ALREADY_PRESENT",
             Self::InvalidInput(_) => "INVALID_INPUT",
@@ -193,6 +208,11 @@ impl SzConfigError {
     /// Create a not-on-call error (call-element delete found nothing to remove)
     pub fn not_on_call<S: Into<String>>(msg: S) -> Self {
         Self::NotOnCall(msg.into())
+    }
+
+    /// Create a not-in-feature error (element is not a member of the addressed feature)
+    pub fn not_in_feature<S: Into<String>>(msg: S) -> Self {
+        Self::NotInFeature(msg.into())
     }
 
     /// Create an already exists error
@@ -240,6 +260,7 @@ impl SzConfigError {
             Self::JsonParse(msg)
             | Self::NotFound(msg)
             | Self::NotOnCall(msg)
+            | Self::NotInFeature(msg)
             | Self::AlreadyExists(msg)
             | Self::AlreadyPresent(msg)
             | Self::InvalidInput(msg)
@@ -258,6 +279,7 @@ impl fmt::Display for SzConfigError {
             Self::JsonParse(msg) => write!(f, "JSON parse error: {msg}"),
             Self::NotFound(msg) => write!(f, "{msg}"),
             Self::NotOnCall(msg) => write!(f, "{msg}"),
+            Self::NotInFeature(msg) => write!(f, "{msg}"),
             Self::AlreadyExists(msg) => write!(f, "{msg}"),
             Self::AlreadyPresent(msg) => write!(f, "{msg}"),
             Self::InvalidInput(msg) => write!(f, "Invalid input: {msg}"),
@@ -287,7 +309,7 @@ mod tests {
 
     #[test]
     fn test_kind_and_reason_code_cover_all_variants() {
-        let cases: [(SzConfigError, SzErrorKind, &str); 11] = [
+        let cases: [(SzConfigError, SzErrorKind, &str); 12] = [
             (
                 SzConfigError::JsonParse("x".into()),
                 SzErrorKind::JsonParse,
@@ -302,6 +324,11 @@ mod tests {
                 SzConfigError::NotOnCall("x".into()),
                 SzErrorKind::NotOnCall,
                 "NOT_ON_CALL",
+            ),
+            (
+                SzConfigError::NotInFeature("x".into()),
+                SzErrorKind::NotInFeature,
+                "NOT_IN_FEATURE",
             ),
             (
                 SzConfigError::AlreadyExists("x".into()),

--- a/tests/error_subcases.rs
+++ b/tests/error_subcases.rs
@@ -85,6 +85,43 @@ fn unique_bom_target(v: &Value, bom_section: &str, id_field: &str) -> (i64, i64,
     panic!("no unique (call, felem) BOM row in {bom_section}");
 }
 
+/// A real feature (FTYPE_ID > 0) that has at least one `CFG_FBOM` member.
+fn a_feature_with_fbom(v: &Value) -> (i64, String) {
+    let fbom = rows(v, "CFG_FBOM");
+    for f in v["G2_CONFIG"]["CFG_FTYPE"].as_array().unwrap() {
+        let ftype_id = f["FTYPE_ID"].as_i64().unwrap();
+        if ftype_id > 0
+            && fbom
+                .iter()
+                .any(|r| r["FTYPE_ID"].as_i64() == Some(ftype_id))
+        {
+            return (ftype_id, f["FTYPE_CODE"].as_str().unwrap().to_string());
+        }
+    }
+    panic!("no feature with a CFG_FBOM member");
+}
+
+/// A `felem_id` that exists in `CFG_FELEM` but is NOT a `CFG_FBOM` member of
+/// `ftype_id` — i.e. "not an element of that feature", for the NotInFeature path.
+fn felem_not_in_feature(v: &Value, ftype_id: i64) -> i64 {
+    let members: Vec<i64> = rows(v, "CFG_FBOM")
+        .iter()
+        .filter(|r| r["FTYPE_ID"].as_i64() == Some(ftype_id))
+        .filter_map(|r| r["FELEM_ID"].as_i64())
+        .collect();
+    v["G2_CONFIG"]["CFG_FELEM"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|r| r["FELEM_ID"].as_i64())
+        .find(|id| *id >= 0 && !members.contains(id))
+        .expect("a FELEM not in the chosen feature")
+}
+
+fn first_call_id(v: &Value, section: &str, id_field: &str) -> i64 {
+    rows(v, section)[0][id_field].as_i64().unwrap()
+}
+
 /// A `felem_id` that exists in `CFG_FELEM` but is NOT a BOM row of `call_id`
 /// within `bom_section` — the "not on this call" element used to drive delete.
 fn felem_not_on_call(v: &Value, bom_section: &str, id_field: &str, call_id: i64) -> i64 {
@@ -187,6 +224,55 @@ fn delete_element_missing_call_id_is_not_found_all_families() {
     )
     .unwrap_err();
     assert_eq!(err.kind(), SzErrorKind::NotFound, "standardize");
+}
+
+// ============================================================================
+// NotInFeature (#58): when a call-element delete is addressed WITH an element
+// feature, an element that is not a member of that feature is a hard error
+// (Python "X is not an element of FEATURE"), distinct from the benign NotOnCall
+// used when the element IS a feature member but simply not on the call.
+// ============================================================================
+
+#[test]
+fn delete_element_not_in_feature_is_not_in_feature_all_families() {
+    let config = template();
+    let v = parse(&config);
+    let (ftype_id, fcode) = a_feature_with_fbom(&v);
+    let ecode = felem_code(&v, felem_not_in_feature(&v, ftype_id));
+
+    // The element feature is supplied but the element is not one of its members,
+    // so resolution fails before the call BOM is even consulted.
+    let err = delete_comparison_call_element(
+        &config,
+        CallSelector::Id(first_call_id(&v, "CFG_CFCALL", "CFCALL_ID")),
+        &ecode,
+        Some(&fcode),
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotInFeature, "comparison");
+    assert_eq!(err.reason_code(), "NOT_IN_FEATURE");
+    assert!(
+        err.to_string().contains("is not an element of"),
+        "message: {err}"
+    );
+
+    let err = delete_expression_call_element(
+        &config,
+        CallSelector::Id(first_call_id(&v, "CFG_EFCALL", "EFCALL_ID")),
+        &ecode,
+        Some(&fcode),
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotInFeature, "expression");
+
+    let err = delete_distinct_call_element(
+        &config,
+        CallSelector::Id(first_call_id(&v, "CFG_DFCALL", "DFCALL_ID")),
+        &ecode,
+        Some(&fcode),
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotInFeature, "distinct");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Release v0.8.0 — `NotInFeature` delete sub-case (#58)

Resolves **#58** from the CLI's v0.7.0 delete re-delegation. Verified against Python `sz_configtool` 4.4.0 (`prepCallElement`) and the stock Senzing v4 template, and adversarially reviewed by two subagent passes (neither could produce a classification defect). **Breaking** (new non-exhaustive `SzConfigError` variant).

### What & why

`delete_*_call_element` collapsed two situations Python classifies with **opposite severity** into a single `NotOnCall`, so a consumer couldn't tell them apart from `kind()`:
1. **Element is not part of the addressed feature** → Python **red error** `"{element} is not an element of {feature}"`.
2. **Element is a valid feature member but not on this call** → Python **yellow warning** `"Feature/element not found for call"`.

Now, when a call-element delete is addressed **with an element feature** (`element_feature: Some`), the element must first be a `CFG_FBOM` member of that feature — a non-member (or nonexistent element code) is a hard **`SzConfigError::NotInFeature`** (`SzErrorKind::NotInFeature`, `reason_code` `"NOT_IN_FEATURE"`), leaving `NotOnCall` for the benign case. The feature-less path (`None`) keeps a plain global lookup and cannot raise it — matching Python's `ftype_id < 0` branch.

### Details
- Shared `resolve_feature_element_id` guard in `calls/mod.rs`; wired into the three delete paths.
- Feature is resolved **before** the element (Python's order), so a delete naming both a missing feature and a missing element reports the feature first (an incidental parity improvement over v0.7.0).
- Library emits the core `"{element} is not an element of {feature}"`; the CLI-specific `(use command "getFeature ...")` hint is left to the CLI (no display logic in the library).
- Standardize is out of scope — it has no call/BOM split and Python's `prepCallElement` excludes it; its miss stays `NotFound`.

### Gates
- `cargo test`: **380 test cases + 82 doctests**, 0 failures. New template-backed `NotInFeature` coverage across all three families + a unit test separating the two tiers (`in-feature-not-on-call` → `NotOnCall`; `other-feature` → `NotInFeature`).
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo fmt --check`: clean.
- No dependency changes beyond the version bump (0.7.0 → 0.8.0).

### Out-of-scope observations from review (not fixed here — flagged for follow-up)
- **Add-path membership asymmetry:** Python's `prepCallElement` is shared by *add*, so Python also rejects a feature + non-member element on add. The SDK's `add_*_call_element` are ID-based (numeric `ftype_id`/`felem_id`, no code→id resolution), so there's nothing to enforce membership on. Pre-existing API-shape difference; a candidate for a separate parity ticket.
- **`None`-path FTYPE-blind delete:** deleting by `(call, element)` with `element_feature: None` matches the unique row regardless of its `FTYPE_ID`; Python (no `FEATURE`) requires `FTYPE_ID = -1`. This is the deliberate #40 call-addressed ergonomics and the CLI always passes a feature, so it isn't hit in practice. Noted, not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
