### PR TITLE
Release v0.9.0: structured generic-threshold validation errors (#59) + feature-code resolver messages (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-08-31
+
+Structured generic-threshold validation errors (#59, **breaking**) plus a cosmetic
+resolver-message fix (#61), coordinated with the downstream `sz_configtool` CLI. Verified
+against Python `sz_configtool` 4.4.0 (`validateGenericThreshold`, `do_addGenericThreshold`,
+`do_setGenericThreshold`, `lookupBehaviorCode`) and the stock Senzing v4 template.
+
+### Added
+
+- **`SzConfigError::ValidationErrors(Vec<ValidationFailure>)` / `SzErrorKind::ValidationErrors`
+  (`reason_code` `"VALIDATION_ERRORS"`) — structured, aggregated field validation (#59).**
+  Generic-threshold add/set no longer flatten field failures into a lossy `"; "`-joined
+  `InvalidInput` string. Instead every failure is carried as DATA in a `ValidationFailure`
+  (`field`, `reason_code`, `offending_value`), aggregated in canonical order
+  `[behavior, sendToRedo]`, so a consumer reproduces its own wording without sniffing prose.
+  - New public types `ValidationFailure` and `ValidationReason` (a `#[non_exhaustive]`,
+    DATA-only taxonomy: `Missing | WrongType | OutOfDomain | UnknownReferenceCode | NotFound |
+    Duplicate`; only `UnknownReferenceCode` for a non-canonical behaviour and `OutOfDomain` for
+    a `sendToRedo` outside `[Yes, No]` are emitted today). `SzConfigError::validation_failures()`
+    recovers the vector. `Display` re-creates a `"; "`-joined summary for logs/FFI (wording is
+    **not** contract).
+  - **`thresholds::validate_generic_threshold(...) -> Result<GenericThresholdCheck>`** — a
+    validate-only orchestration surface returning every staged outcome as `Ok(..)` DATA
+    (`NotFound { which: GenericThresholdRef, value }` fatal-first for plan/feature, `Duplicate`
+    warning-success, `Invalid(Vec<ValidationFailure>)`, `Ok`), mirroring Python's staging order
+    (plan → feature → duplicate → behaviour+`sendToRedo` aggregate). Reserves `Err` for genuine
+    internal errors (unparseable config).
+  - `add_generic_threshold` now returns `ValidationErrors` for behaviour/`sendToRedo` failures
+    (plan/feature stay `NotFound`; duplicate stays `AlreadyExists` on the direct-call path).
+    `set_generic_threshold` now validates `sendToRedo` **after** the row lookup (Python order: a
+    missing row wins over a bad `sendToRedo`) and aggregates it into `ValidationErrors` — a
+    behaviour change from the previous scalar `InvalidInput`. An unknown behaviour on SET remains
+    `NotFound` (behaviour is part of the lookup key, never re-validated as a reference code —
+    matching Python, whose merged-record behaviour is always canonical).
+  - Caps stay strictly typed `i64` at both the Rust (`optional_i64`) and FFI boundaries; a
+    non-numeric or boolean cap remains a scalar `InvalidInput("... must be an integer")` and is
+    **never** folded into `ValidationErrors` (bool-as-int rejection is a deliberate divergence
+    from Python — Ant 17/08/2026).
+  - **FFI:** new `SzConfigTool_getLastErrorReasonCode()` (discriminate the error kind at the C
+    boundary — match this first, only then fetch details) and `SzConfigTool_getLastErrorDetails()`
+    (versioned, namespaced JSON: `{"schema":"sz-configtool.validation-errors/v1","failures":[...]}`).
+    New `SzConfigTool_validateGenericThreshold(...)` returns the staged `GenericThresholdCheck` as
+    versioned JSON (`schema` `"sz-configtool.generic-threshold-check/v1"`). Every library error
+    now also populates the reason code across the boundary.
+  - **Breaking:** `SzConfigError` is not `#[non_exhaustive]`, so the new variant adds an arm to
+    exhaustive downstream matches (minor bump under 0.x semver).
+
+### Changed
+
+- **Resolver error messages name the feature CODE, not the internal `ftype_id` (#61).**
+  `resolve_call_id_for_feature` (comparison/distinct/standardize/expression) now reverse-maps
+  `FTYPE_ID` to `FTYPE_CODE` via `CFG_FTYPE`, emitting `"No comparison call found for feature NAME"`
+  / `"Ambiguous ... for feature NAME"`, falling back to `"feature id {n}"` only when no `CFG_FTYPE`
+  row matches. Non-breaking: the variant (`NotFound` / `InvalidInput`), `kind()`, and
+  `reason_code()` are unchanged; only the (non-contract) `Display` wording improves.
+
 ## [0.8.0] - 2026-08-25
 
 Resolves #58 from the CLI's v0.7.0 delete re-delegation. Verified against Python `sz_configtool`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "sz_configtool_lib"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz_configtool_lib"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Brian Macy <bmacy@senzing.com>"]

--- a/examples/feature_operations.rs
+++ b/examples/feature_operations.rs
@@ -12,6 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start with config that has some elements
     let mut config = r#"{
   "G2_CONFIG": {
+    "CFG_FBOM": [],
     "CFG_FELEM": [
       {
         "FELEM_ID": 1,

--- a/include/libSzConfigTool.h
+++ b/include/libSzConfigTool.h
@@ -52,6 +52,34 @@ const char *SzConfigTool_getLastError(void);
 int64_t SzConfigTool_getLastErrorCode(void);
 
 /**
+ * Get the last error's stable reason code (e.g. "VALIDATION_ERRORS").
+ *
+ * Callers should discriminate the error KIND on this string FIRST, and only
+ * fetch structured details (below) when it is "VALIDATION_ERRORS".
+ *
+ * # Returns
+ * Pointer to the reason-code string (do not free), or null if there is no
+ * error or no classified reason.
+ */
+const char *SzConfigTool_getLastErrorReasonCode(void);
+
+/**
+ * Get versioned, namespaced JSON details for the last error.
+ *
+ * Populated only when the last error is a validation-errors aggregate (reason
+ * code "VALIDATION_ERRORS"); null otherwise. Payload shape:
+ *   {"schema":"sz-configtool.validation-errors/v1",
+ *    "failures":[{"field":...,"reasonCode":...,"offendingValue":...}]}
+ * The "schema" string is the stability contract: a future field addition bumps
+ * it to /v2 rather than silently breaking the parse.
+ *
+ * # Returns
+ * Pointer to the JSON string (do not free), or null if the last error carries
+ * no structured details.
+ */
+const char *SzConfigTool_getLastErrorDetails(void);
+
+/**
  * Clear the last error
  */
 void SzConfigTool_clearLastError(void);
@@ -472,6 +500,17 @@ struct SzConfigTool_result SzConfigTool_addGenericThreshold(
     const char *behavior,
     int64_t scoring_cap,
     int64_t candidate_cap,
+    const char *send_to_redo,
+    const char *feature  // NULL = "ALL"
+);
+// Validate a generic-threshold ADD without mutating the config. Returns the
+// staged check as versioned JSON (schema "sz-configtool.generic-threshold-check/v1")
+// in `response` with returnCode 0; returnCode is negative only for a
+// boundary/internal error (null/invalid-UTF-8 argument or unparseable config).
+struct SzConfigTool_result SzConfigTool_validateGenericThreshold(
+    const char *config_json,
+    const char *plan,
+    const char *behavior,
     const char *send_to_redo,
     const char *feature  // NULL = "ALL"
 );

--- a/src/calls/mod.rs
+++ b/src/calls/mod.rs
@@ -14,7 +14,7 @@
 //! # Execution-order policy
 //!
 //! Every add path that writes an `EXEC_ORDER` resolves it through one shared
-//! helper, [`crate::helpers::get_desired_or_next_order`], so the behaviour is
+//! helper, `crate::helpers::get_desired_or_next_order`, so the behaviour is
 //! uniform across the SDK. The three intents are:
 //!
 //! - **Auto-allocate** (`exec_order: None`): the next free order *within the

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -649,7 +649,7 @@ pub fn set_feature_element_derived(
 /// Resolves the feature and element codes to their ids, rejects a duplicate
 /// `(FTYPE_ID, FELEM_ID)` mapping with `AlreadyExists`, allocates a fresh
 /// `EXEC_ORDER` from the whole CFG_FBOM table, and writes a complete
-/// [`FbomRow`](crate::config_rows) (every key present). `DISPLAY_LEVEL` and
+/// `FbomRow` (internal `config_rows` module; every key present). `DISPLAY_LEVEL` and
 /// `DERIVED` are checked with the canonical validators (D25).
 ///
 /// # Arguments

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,102 @@ pub enum SzConfigError {
     InvalidConfig(String),
     /// Not implemented
     NotImplemented(String),
+    /// One or more field-level validation failures collected together.
+    ///
+    /// This mirrors Python `validateGenericThreshold`'s aggregated `errorList`:
+    /// rather than failing fast on the first bad field, every failure is
+    /// collected into one [`ValidationFailure`] per offending field and reported
+    /// together. Each failure carries the field tag and a machine-readable
+    /// [`ValidationReason`] as **data**, so a caller (notably the CLI) can
+    /// reproduce its own user-facing wording without sniffing prose. Its
+    /// [`reason_code`](Self::reason_code) is `"VALIDATION_ERRORS"`; use
+    /// [`validation_failures`](Self::validation_failures) to recover the vector.
+    ///
+    /// The `Display` text re-creates a `"; "`-joined summary for logs/FFI, but
+    /// that wording is **not** part of the stable contract — branch on
+    /// [`kind`](Self::kind)/[`validation_failures`](Self::validation_failures).
+    ValidationErrors(Vec<ValidationFailure>),
+}
+
+/// Stable, DATA-only taxonomy of *why* a single field failed validation.
+///
+/// This is a machine-readable classifier, never user-facing wording: a consumer
+/// (notably the CLI adapter) maps a `(field, reason_code)` pair to its own
+/// display text. The enum is `#[non_exhaustive]` so future reason codes can be
+/// added without a breaking change.
+///
+/// Only [`OutOfDomain`](Self::OutOfDomain) (a `sendToRedo` outside `[Yes, No]`)
+/// and [`UnknownReferenceCode`](Self::UnknownReferenceCode) (a behaviour not in
+/// the canonical set) are emitted today; the remaining codes are reserved for a
+/// stable taxonomy (presence is caller-owned, plan/feature stay fatal-first
+/// [`NotFound`](SzConfigError::NotFound), duplicates stay warning-success, and
+/// caps are rejected strictly upstream as scalar [`InvalidInput`](SzConfigError::InvalidInput)).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ValidationReason {
+    /// A required field was absent (reserved — presence is caller-owned).
+    Missing,
+    /// A field was present but of the wrong scalar type (reserved — caps are
+    /// rejected strictly upstream today).
+    WrongType,
+    /// A value fell outside a fixed enumerated domain (e.g. `sendToRedo` not in
+    /// `[Yes, No]`).
+    OutOfDomain,
+    /// A value was not a member of a canonical reference-code set (e.g. a
+    /// behaviour not in the canonical behaviour codes).
+    UnknownReferenceCode,
+    /// A referenced entity was not found (reserved — plan/feature lookups stay
+    /// fatal-first [`NotFound`](SzConfigError::NotFound)).
+    NotFound,
+    /// A duplicate was detected (reserved — duplicates stay warning-success).
+    Duplicate,
+}
+
+impl ValidationReason {
+    /// Return the stable `SCREAMING_SNAKE_CASE` reason-code string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "MISSING",
+            Self::WrongType => "WRONG_TYPE",
+            Self::OutOfDomain => "OUT_OF_DOMAIN",
+            Self::UnknownReferenceCode => "UNKNOWN_REFERENCE_CODE",
+            Self::NotFound => "NOT_FOUND",
+            Self::Duplicate => "DUPLICATE",
+        }
+    }
+}
+
+/// A single field-level validation failure, carried as DATA (never prose).
+///
+/// Aggregated inside [`SzConfigError::ValidationErrors`]. The struct is
+/// `#[non_exhaustive]` so future fields (e.g. a row index) can be added without
+/// a breaking change.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationFailure {
+    /// Canonical camelCase field tag, e.g. `"behavior"`, `"sendToRedo"` — the
+    /// CLI/JSON attribute name, not the on-disk column.
+    pub field: &'static str,
+    /// The stable reason this field failed.
+    pub reason_code: ValidationReason,
+    /// The offending value verbatim, for echoing; `None` when the failure is not
+    /// tied to a specific scalar value.
+    pub offending_value: Option<String>,
+}
+
+impl ValidationFailure {
+    /// Construct a validation failure from its parts.
+    pub fn new(
+        field: &'static str,
+        reason_code: ValidationReason,
+        offending_value: Option<String>,
+    ) -> Self {
+        Self {
+            field,
+            reason_code,
+            offending_value,
+        }
+    }
 }
 
 /// Stable, variant-level discriminant for [`SzConfigError`].
@@ -126,6 +222,9 @@ pub enum SzErrorKind {
     InvalidConfig,
     /// The operation is not implemented. Corresponds to [`SzConfigError::NotImplemented`].
     NotImplemented,
+    /// One or more field-level validation failures were aggregated. Corresponds
+    /// to [`SzConfigError::ValidationErrors`].
+    ValidationErrors,
 }
 
 impl SzConfigError {
@@ -157,6 +256,7 @@ impl SzConfigError {
             Self::MissingField(_) => SzErrorKind::MissingField,
             Self::InvalidConfig(_) => SzErrorKind::InvalidConfig,
             Self::NotImplemented(_) => SzErrorKind::NotImplemented,
+            Self::ValidationErrors(_) => SzErrorKind::ValidationErrors,
         }
     }
 
@@ -192,6 +292,7 @@ impl SzConfigError {
             Self::MissingField(_) => "MISSING_FIELD",
             Self::InvalidConfig(_) => "INVALID_CONFIG",
             Self::NotImplemented(_) => "NOT_IMPLEMENTED",
+            Self::ValidationErrors(_) => "VALIDATION_ERRORS",
         }
     }
 
@@ -269,6 +370,37 @@ impl SzConfigError {
             | Self::MissingField(msg)
             | Self::InvalidConfig(msg)
             | Self::NotImplemented(msg) => msg,
+            // ValidationErrors carries a Vec, not a single String payload, so it
+            // cannot join into a borrowed &str. Return a fixed summary; callers
+            // wanting detail use validation_failures() or Display.
+            Self::ValidationErrors(_) => "one or more validation failures",
+        }
+    }
+
+    /// Return the aggregated [`ValidationFailure`]s when this is a
+    /// [`ValidationErrors`](Self::ValidationErrors), else `None`.
+    ///
+    /// This lets Rust callers recover the structured, DATA-only failures without
+    /// matching on the variant or parsing the `Display` text.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sz_configtool_lib::{SzConfigError, error::{ValidationFailure, ValidationReason}};
+    ///
+    /// let err = SzConfigError::ValidationErrors(vec![ValidationFailure::new(
+    ///     "sendToRedo",
+    ///     ValidationReason::OutOfDomain,
+    ///     Some("perhaps".into()),
+    /// )]);
+    /// let failures = err.validation_failures().unwrap();
+    /// assert_eq!(failures[0].field, "sendToRedo");
+    /// assert_eq!(failures[0].reason_code, ValidationReason::OutOfDomain);
+    /// ```
+    pub fn validation_failures(&self) -> Option<&[ValidationFailure]> {
+        match self {
+            Self::ValidationErrors(failures) => Some(failures),
+            _ => None,
         }
     }
 }
@@ -288,6 +420,19 @@ impl fmt::Display for SzConfigError {
             Self::MissingField(field) => write!(f, "Missing required field: {field}"),
             Self::InvalidConfig(msg) => write!(f, "Invalid configuration: {msg}"),
             Self::NotImplemented(msg) => write!(f, "Not implemented: {msg}"),
+            // Re-create the old `"; "`-joined summary so logs/FFI stay readable.
+            // This wording is explicitly NOT part of the stable contract.
+            Self::ValidationErrors(failures) => {
+                let joined = failures
+                    .iter()
+                    .map(|fail| match &fail.offending_value {
+                        Some(v) => format!("{} {} '{v}'", fail.field, fail.reason_code.as_str()),
+                        None => format!("{} {}", fail.field, fail.reason_code.as_str()),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                write!(f, "Invalid input: {joined}")
+            }
         }
     }
 }
@@ -309,7 +454,7 @@ mod tests {
 
     #[test]
     fn test_kind_and_reason_code_cover_all_variants() {
-        let cases: [(SzConfigError, SzErrorKind, &str); 12] = [
+        let cases: [(SzConfigError, SzErrorKind, &str); 13] = [
             (
                 SzConfigError::JsonParse("x".into()),
                 SzErrorKind::JsonParse,
@@ -370,6 +515,15 @@ mod tests {
                 SzErrorKind::NotImplemented,
                 "NOT_IMPLEMENTED",
             ),
+            (
+                SzConfigError::ValidationErrors(vec![ValidationFailure::new(
+                    "behavior",
+                    ValidationReason::UnknownReferenceCode,
+                    Some("BOGUS".into()),
+                )]),
+                SzErrorKind::ValidationErrors,
+                "VALIDATION_ERRORS",
+            ),
         ];
 
         for (err, kind, code) in cases {
@@ -380,8 +534,9 @@ mod tests {
 
     #[test]
     fn test_message_returns_bare_payload_for_all_variants() {
-        // message() is the raw inner payload for every variant, with none of the
-        // category prefixes Display prepends.
+        // message() is the raw inner payload for every single-String variant,
+        // with none of the category prefixes Display prepends. ValidationErrors
+        // carries a Vec (no bare payload) and is asserted separately below.
         let variants: [SzConfigError; 11] = [
             SzConfigError::JsonParse("p".into()),
             SzConfigError::NotFound("p".into()),
@@ -413,6 +568,67 @@ mod tests {
                 .to_string(),
             "Feature/element already exists for call"
         );
+    }
+
+    #[test]
+    fn test_validation_errors_accessor_and_display_join() {
+        let err = SzConfigError::ValidationErrors(vec![
+            ValidationFailure::new(
+                "behavior",
+                ValidationReason::UnknownReferenceCode,
+                Some("BOGUS".into()),
+            ),
+            ValidationFailure::new(
+                "sendToRedo",
+                ValidationReason::OutOfDomain,
+                Some("perhaps".into()),
+            ),
+        ]);
+
+        // validation_failures() recovers the structured DATA in canonical order.
+        let failures = err.validation_failures().expect("is ValidationErrors");
+        assert_eq!(failures.len(), 2);
+        assert_eq!(failures[0].field, "behavior");
+        assert_eq!(
+            failures[0].reason_code,
+            ValidationReason::UnknownReferenceCode
+        );
+        assert_eq!(failures[0].offending_value.as_deref(), Some("BOGUS"));
+        assert_eq!(failures[1].field, "sendToRedo");
+        assert_eq!(failures[1].reason_code, ValidationReason::OutOfDomain);
+
+        // Display re-creates a "; "-joined summary (wording is non-contract).
+        let text = err.to_string();
+        assert!(
+            text.contains("behavior UNKNOWN_REFERENCE_CODE 'BOGUS'"),
+            "{text}"
+        );
+        assert!(text.contains("; "), "failures should be joined: {text}");
+        assert!(
+            text.contains("sendToRedo OUT_OF_DOMAIN 'perhaps'"),
+            "{text}"
+        );
+
+        // message() is a fixed summary; other variants return None from the accessor.
+        assert_eq!(err.message(), "one or more validation failures");
+        assert!(
+            SzConfigError::not_found("x")
+                .validation_failures()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_validation_reason_as_str_stable() {
+        assert_eq!(ValidationReason::Missing.as_str(), "MISSING");
+        assert_eq!(ValidationReason::WrongType.as_str(), "WRONG_TYPE");
+        assert_eq!(ValidationReason::OutOfDomain.as_str(), "OUT_OF_DOMAIN");
+        assert_eq!(
+            ValidationReason::UnknownReferenceCode.as_str(),
+            "UNKNOWN_REFERENCE_CODE"
+        );
+        assert_eq!(ValidationReason::NotFound.as_str(), "NOT_FOUND");
+        assert_eq!(ValidationReason::Duplicate.as_str(), "DUPLICATE");
     }
 
     #[test]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -22,6 +22,16 @@ use crate::error::SzConfigError;
 // Thread-safe error storage
 static LAST_ERROR: Mutex<Option<String>> = Mutex::new(None);
 static LAST_ERROR_CODE: Mutex<i64> = Mutex::new(0);
+/// Stable `reason_code()` string of the last error (e.g. "VALIDATION_ERRORS"),
+/// so a C caller can discriminate the error KIND at the boundary — matching on
+/// this FIRST and only parsing structured details when it is "VALIDATION_ERRORS"
+/// — without string-sniffing the human message. Stored NUL-terminated so the
+/// borrowed pointer handed to C is a valid C string.
+static LAST_ERROR_REASON: Mutex<Option<CString>> = Mutex::new(None);
+/// Versioned, namespaced JSON details for the last error when it is a
+/// `ValidationErrors`, else `None`. See [`validation_details_json`]. Stored
+/// NUL-terminated for the same reason as [`LAST_ERROR_REASON`].
+static LAST_ERROR_DETAILS: Mutex<Option<CString>> = Mutex::new(None);
 
 /// Platform-specific export macro
 #[cfg(target_os = "windows")]
@@ -83,11 +93,47 @@ pub extern "C" fn SzConfigTool_getLastErrorCode() -> i64 {
     *LAST_ERROR_CODE.lock().unwrap()
 }
 
+/// Get the last error's stable reason code (e.g. "VALIDATION_ERRORS")
+///
+/// # Returns
+/// Pointer to the reason-code string (do not free), or null if no error / no
+/// classified reason. Callers discriminate on THIS before fetching details.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_getLastErrorReasonCode() -> *const c_char {
+    let reason = LAST_ERROR_REASON.lock().unwrap();
+    match reason.as_ref() {
+        Some(r) => r.as_ptr(),
+        None => std::ptr::null(),
+    }
+}
+
+/// Get versioned, namespaced JSON details for the last error.
+///
+/// Populated only when the last error is a `ValidationErrors` (reason code
+/// "VALIDATION_ERRORS"); returns null otherwise. The payload is:
+/// `{"schema":"sz-configtool.validation-errors/v1","failures":[{"field":...,
+/// "reasonCode":...,"offendingValue":...}]}`. The `schema` string is the FFI
+/// stability contract — a future field addition bumps it to /v2.
+///
+/// # Returns
+/// Pointer to the JSON string (do not free), or null if the last error carries
+/// no structured details.
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_getLastErrorDetails() -> *const c_char {
+    let details = LAST_ERROR_DETAILS.lock().unwrap();
+    match details.as_ref() {
+        Some(d) => d.as_ptr(),
+        None => std::ptr::null(),
+    }
+}
+
 /// Clear the last error
 #[unsafe(no_mangle)]
 pub extern "C" fn SzConfigTool_clearLastError() {
     *LAST_ERROR.lock().unwrap() = None;
     *LAST_ERROR_CODE.lock().unwrap() = 0;
+    *LAST_ERROR_REASON.lock().unwrap() = None;
+    *LAST_ERROR_DETAILS.lock().unwrap() = None;
 }
 
 // ============================================================================
@@ -114,7 +160,7 @@ macro_rules! handle_result {
                 }
             }
             Err(e) => {
-                set_error(format!("{}", e), -2);
+                set_error_from(&e);
                 SzConfigTool_result {
                     response: std::ptr::null_mut(),
                     returnCode: -2,
@@ -127,11 +173,53 @@ macro_rules! handle_result {
 fn set_error(msg: String, code: i64) {
     *LAST_ERROR.lock().unwrap() = Some(msg);
     *LAST_ERROR_CODE.lock().unwrap() = code;
+    // Scalar/boundary errors (null pointer, bad UTF-8) carry no classified
+    // reason or structured details.
+    *LAST_ERROR_REASON.lock().unwrap() = None;
+    *LAST_ERROR_DETAILS.lock().unwrap() = None;
+}
+
+/// Record a library `SzConfigError`: the flattened `Display` message (code -2,
+/// unchanged), plus its stable `reason_code()` for boundary discrimination and,
+/// when it is a `ValidationErrors`, the versioned structured details JSON.
+fn set_error_from(e: &SzConfigError) {
+    *LAST_ERROR.lock().unwrap() = Some(e.to_string());
+    *LAST_ERROR_CODE.lock().unwrap() = -2;
+    // Store NUL-terminated so the borrowed pointers handed to C are valid C
+    // strings. reason_code() is a fixed SCREAMING_SNAKE literal and the details
+    // JSON never contains an interior NUL, so CString::new cannot fail here.
+    *LAST_ERROR_REASON.lock().unwrap() = CString::new(e.reason_code()).ok();
+    *LAST_ERROR_DETAILS.lock().unwrap() = e
+        .validation_failures()
+        .map(validation_details_json)
+        .and_then(|json| CString::new(json).ok());
+}
+
+/// Build the versioned, namespaced JSON details payload for a set of
+/// validation failures (see [`SzConfigTool_getLastErrorDetails`]).
+fn validation_details_json(failures: &[crate::error::ValidationFailure]) -> String {
+    let arr: Vec<serde_json::Value> = failures
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "field": f.field,
+                "reasonCode": f.reason_code.as_str(),
+                "offendingValue": f.offending_value,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "schema": "sz-configtool.validation-errors/v1",
+        "failures": arr,
+    })
+    .to_string()
 }
 
 fn clear_error() {
     *LAST_ERROR.lock().unwrap() = None;
     *LAST_ERROR_CODE.lock().unwrap() = 0;
+    *LAST_ERROR_REASON.lock().unwrap() = None;
+    *LAST_ERROR_DETAILS.lock().unwrap() = None;
 }
 
 // ============================================================================
@@ -4699,6 +4787,114 @@ pub extern "C" fn SzConfigTool_addGenericThreshold(
             feature: feature_opt,
         },
     ))
+}
+
+/// Render a [`GenericThresholdCheck`](crate::thresholds::GenericThresholdCheck)
+/// as a versioned, namespaced JSON payload for the C boundary.
+fn generic_threshold_check_json(check: &crate::thresholds::GenericThresholdCheck) -> String {
+    use crate::thresholds::{GenericThresholdCheck, GenericThresholdRef};
+    let body = match check {
+        GenericThresholdCheck::Ok => serde_json::json!({"result": "ok"}),
+        GenericThresholdCheck::Duplicate => serde_json::json!({"result": "duplicate"}),
+        GenericThresholdCheck::NotFound { which, value } => {
+            let which_str = match which {
+                GenericThresholdRef::Plan => "plan",
+                GenericThresholdRef::Feature => "feature",
+            };
+            serde_json::json!({"result": "notFound", "which": which_str, "value": value})
+        }
+        GenericThresholdCheck::Invalid(failures) => {
+            let arr: Vec<serde_json::Value> = failures
+                .iter()
+                .map(|f| {
+                    serde_json::json!({
+                        "field": f.field,
+                        "reasonCode": f.reason_code.as_str(),
+                        "offendingValue": f.offending_value,
+                    })
+                })
+                .collect();
+            serde_json::json!({"result": "invalid", "failures": arr})
+        }
+    };
+    let mut obj = serde_json::json!({"schema": "sz-configtool.generic-threshold-check/v1"});
+    if let (Some(dst), Some(src)) = (obj.as_object_mut(), body.as_object()) {
+        for (k, v) in src {
+            dst.insert(k.clone(), v.clone());
+        }
+    }
+    obj.to_string()
+}
+
+/// Validate a generic-threshold ADD without mutating the config.
+///
+/// Returns the staged [`GenericThresholdCheck`](crate::thresholds::GenericThresholdCheck)
+/// as a versioned JSON payload (`schema` = "sz-configtool.generic-threshold-check/v1")
+/// in `response` with `returnCode` 0. `returnCode` is negative only for a
+/// boundary/internal error (null/invalid-UTF-8 argument or unparseable config).
+#[unsafe(no_mangle)]
+pub extern "C" fn SzConfigTool_validateGenericThreshold(
+    config_json: *const c_char,
+    plan: *const c_char,
+    behavior: *const c_char,
+    send_to_redo: *const c_char,
+    feature: *const c_char, // Null = "ALL"
+) -> SzConfigTool_result {
+    macro_rules! required_str {
+        ($ptr:expr, $name:expr) => {
+            unsafe {
+                if $ptr.is_null() {
+                    set_error(format!("{} is null", $name), -1);
+                    return SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -1,
+                    };
+                }
+                match CStr::from_ptr($ptr).to_str() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        set_error(format!("Invalid UTF-8 in {}: {e}", $name), -2);
+                        return SzConfigTool_result {
+                            response: std::ptr::null_mut(),
+                            returnCode: -2,
+                        };
+                    }
+                }
+            }
+        };
+    }
+
+    let config = required_str!(config_json, "config_json");
+    let plan_str = required_str!(plan, "plan");
+    let behavior_str = required_str!(behavior, "behavior");
+    let redo_str = required_str!(send_to_redo, "send_to_redo");
+    let feature_opt = if feature.is_null() {
+        None
+    } else {
+        unsafe {
+            match CStr::from_ptr(feature).to_str() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    set_error(format!("Invalid UTF-8 in feature: {e}"), -2);
+                    return SzConfigTool_result {
+                        response: std::ptr::null_mut(),
+                        returnCode: -2,
+                    };
+                }
+            }
+        }
+    };
+
+    handle_result!(
+        crate::thresholds::validate_generic_threshold(
+            config,
+            plan_str,
+            behavior_str,
+            redo_str,
+            feature_opt,
+        )
+        .map(|check| generic_threshold_check_json(&check))
+    )
 }
 
 /// Delete a generic threshold

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -130,7 +130,7 @@ fn python_repr_str(s: &str) -> String {
 /// Render a JSON value the way CPython's `repr` renders the equivalent object.
 ///
 /// `null`/`true`/`false` become `None`/`True`/`False`; strings are
-/// single-quoted (see [`python_repr_str`]); containers use `", "`/`": "`
+/// single-quoted (see the internal `python_repr_str` helper); containers use `", "`/`": "`
 /// spacing. Nesting is handled recursively.
 ///
 /// # Example
@@ -192,7 +192,7 @@ fn python_str_string(value: &Value) -> String {
 /// `do_listComparisonThresholds` filters against.
 ///
 /// For an object, its **values** (keys dropped) are each rendered via Python
-/// `str()` semantics (see [`python_str_string`]) and joined with a single space,
+/// `str()` semantics (see the internal `python_str_string` helper) and joined with a single space,
 /// reproducing `" ".join(str(v) for v in record.values())`. Any non-object value
 /// renders as a single `str()`-rendered value.
 ///

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -929,13 +929,33 @@ fn resolve_call_id_for_feature(
         .filter_map(|row| row.get(id_field).and_then(|v| v.as_i64()))
         .collect();
 
+    // Reverse-map ftype_id -> FTYPE_CODE for human-facing messages (#61), so the
+    // error names the feature ("feature NAME") instead of leaking the internal
+    // numeric id. The "feature id {ftype_id}" fallback is defensive: real callers
+    // derive `ftype_id` from a prior successful feature lookup, so a matching
+    // CFG_FTYPE row normally exists — it only fires for a config that lacks the
+    // matching row (e.g. a partial or synthetic config).
+    let feature_label = config
+        .get("G2_CONFIG")
+        .and_then(|g| g.get("CFG_FTYPE"))
+        .and_then(|v| v.as_array())
+        .and_then(|ftypes| {
+            ftypes
+                .iter()
+                .find(|r| r.get("FTYPE_ID").and_then(|v| v.as_i64()) == Some(ftype_id))
+        })
+        .and_then(|r| r.get("FTYPE_CODE"))
+        .and_then(|v| v.as_str())
+        .map(|code| format!("feature {code}"))
+        .unwrap_or_else(|| format!("feature id {ftype_id}"));
+
     match matches.as_slice() {
         [] => Err(SzConfigError::NotFound(format!(
-            "No {label} call found for feature id {ftype_id}"
+            "No {label} call found for {feature_label}"
         ))),
         [id] => Ok(*id),
         many => Err(SzConfigError::InvalidInput(format!(
-            "Ambiguous {label} call for feature id {ftype_id}: {} calls match; address the call by id instead",
+            "Ambiguous {label} call for {feature_label}: {} calls match; address the call by id instead",
             many.len()
         ))),
     }
@@ -1110,6 +1130,58 @@ mod tests {
         let err = resolve_sfcall_id_for_feature(&cfg, 1).unwrap_err();
         assert_eq!(err.kind(), SzConfigError::validation("").kind());
         assert!(err.to_string().contains("Ambiguous"));
+    }
+
+    #[test]
+    fn test_resolvers_zero_match_names_feature_code() {
+        // With a CFG_FTYPE row, the NotFound message names the FEATURE CODE
+        // (#61) rather than leaking the internal ftype_id.
+        let cfg = json!({"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 7, "FTYPE_CODE": "NAME"}],
+            "CFG_CFCALL": []
+        }});
+        let err = resolve_cfcall_id_for_feature(&cfg, 7).unwrap_err();
+        assert_eq!(err.kind(), SzConfigError::not_found("").kind());
+        assert!(
+            err.to_string().contains("feature NAME"),
+            "message should name the feature code: {err}"
+        );
+        assert!(
+            !err.to_string().contains("feature id"),
+            "message must not leak the numeric id: {err}"
+        );
+    }
+
+    #[test]
+    fn test_resolvers_ambiguous_names_feature_code() {
+        // Two standardize calls for the same feature -> ambiguous, message names
+        // the FEATURE CODE (#61).
+        let cfg = json!({"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 7, "FTYPE_CODE": "ADDRESS"}],
+            "CFG_SFCALL": [
+                {"SFCALL_ID": 1, "FTYPE_ID": 7, "SFUNC_ID": 1},
+                {"SFCALL_ID": 2, "FTYPE_ID": 7, "SFUNC_ID": 2}
+            ]
+        }});
+        let err = resolve_sfcall_id_for_feature(&cfg, 7).unwrap_err();
+        assert!(err.to_string().contains("feature ADDRESS"), "{err}");
+        assert!(err.to_string().contains("Ambiguous"), "{err}");
+    }
+
+    #[test]
+    fn test_resolvers_zero_match_falls_back_to_feature_id() {
+        // No CFG_FTYPE row matches the ftype_id -> the message falls back to the
+        // numeric id rather than a code. Defensive branch: real callers always
+        // have a matching row, so this only exercises the fallback formatting.
+        let cfg = json!({"G2_CONFIG": {
+            "CFG_FTYPE": [{"FTYPE_ID": 3, "FTYPE_CODE": "DOB"}],
+            "CFG_CFCALL": []
+        }});
+        let err = resolve_cfcall_id_for_feature(&cfg, 7).unwrap_err();
+        assert!(
+            err.to_string().contains("feature id 7"),
+            "unmatched ftype_id should fall back to the numeric id: {err}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub mod calls;
 pub mod functions;
 
 // Re-export commonly used types
-pub use error::{Result, SzConfigError, SzErrorKind};
+pub use error::{Result, SzConfigError, SzErrorKind, ValidationFailure, ValidationReason};
 
 // Re-export shared domain items so consumers can use them without the
 // fully-qualified module path.
@@ -124,6 +124,7 @@ pub use helpers::{
     resolve_sfcall_id_for_feature,
 };
 pub use settings::set_setting;
+pub use thresholds::{GenericThresholdCheck, GenericThresholdRef, validate_generic_threshold};
 pub use validation::validate_config;
 
 // C FFI module

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -1,4 +1,4 @@
-use crate::error::{Result, SzConfigError};
+use crate::error::{Result, SzConfigError, ValidationFailure, ValidationReason};
 use crate::helpers;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -814,6 +814,178 @@ pub fn list_comparison_thresholds(config_json: &str) -> Result<Vec<Value>> {
 
 // ===== Generic Thresholds (CFG_GENERIC_THRESHOLD) =====
 
+/// Which reference lookup failed while staging a generic-threshold validation.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenericThresholdRef {
+    /// The generic plan (`CFG_GPLAN`) was not found.
+    Plan,
+    /// The feature (`CFG_FTYPE`) was not found.
+    Feature,
+}
+
+/// The staged outcome of [`validate_generic_threshold`] for the ADD path.
+///
+/// Every variant is returned as `Ok(..)` DATA — only a genuinely internal error
+/// (e.g. unparseable config JSON) is an `Err`. This mirrors Python
+/// `do_addGenericThreshold`'s staging order: a fatal-first plan lookup, then a
+/// fatal-first feature lookup, then a warning-success duplicate check, and only
+/// then the aggregated behaviour + `sendToRedo` field validation.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GenericThresholdCheck {
+    /// A plan or feature reference was not found (fatal-first): the command must
+    /// stop here (Python emits only "Plan/Feature X not found" and never runs
+    /// the field validator).
+    NotFound {
+        /// Which reference lookup failed.
+        which: GenericThresholdRef,
+        /// The (upper-cased) code that was not found.
+        value: String,
+    },
+    /// The `(plan, behavior, feature)` tuple already exists. Python treats this
+    /// as a warning and the command still *succeeds* (a no-op add), so this is
+    /// deliberately NOT an error.
+    Duplicate,
+    /// One or more of the aggregated fields (`behavior`, `sendToRedo`) failed
+    /// validation, in canonical order `[behavior, sendToRedo]`.
+    Invalid(Vec<ValidationFailure>),
+    /// All checks passed; the add would succeed.
+    Ok,
+}
+
+/// Build the aggregated behaviour + `sendToRedo` validation failures for a
+/// generic-threshold ADD, in canonical order `[behavior, sendToRedo]`.
+///
+/// Shared by [`validate_generic_threshold`] and [`add_generic_threshold`] so the
+/// two never drift. Mirrors Python `validateGenericThreshold`'s two SDK-relevant
+/// checks (the two cap checks are enforced strictly upstream as scalar
+/// [`SzConfigError::InvalidInput`], never folded in here):
+///
+///   1. `behavior_upper` must be one of the canonical behaviour codes
+///      (`behavior_domain::behavior_position`, the exact set Python's
+///      `lookupBehaviorCode` checks) -> `UnknownReferenceCode`.
+///   2. `send_to_redo` must canonicalise to `"Yes"`/`"No"` -> `OutOfDomain`.
+///
+/// `behavior_upper` must already be upper-cased by the caller; its verbatim
+/// (upper-cased) value is echoed as the offending value.
+fn collect_generic_threshold_failures(
+    behavior_upper: &str,
+    send_to_redo: &str,
+) -> Vec<ValidationFailure> {
+    let mut failures = Vec::new();
+    if crate::behavior_domain::behavior_position(behavior_upper).is_none() {
+        failures.push(ValidationFailure::new(
+            "behavior",
+            ValidationReason::UnknownReferenceCode,
+            Some(behavior_upper.to_string()),
+        ));
+    }
+    if send_to_redo_canonical(send_to_redo).is_err() {
+        failures.push(ValidationFailure::new(
+            "sendToRedo",
+            ValidationReason::OutOfDomain,
+            Some(send_to_redo.to_string()),
+        ));
+    }
+    failures
+}
+
+/// Validate a generic-threshold ADD without mutating the config.
+///
+/// This is the CLI's orchestration surface: it stages the checks in Python
+/// `do_addGenericThreshold` order and returns every staged outcome as
+/// [`GenericThresholdCheck`] DATA (`Ok(..)`), reserving `Err` for genuinely
+/// internal failures (e.g. unparseable config JSON):
+///
+/// 1. **plan lookup** (fatal-first) -> [`GenericThresholdCheck::NotFound`]
+///    with [`GenericThresholdRef::Plan`].
+/// 2. **feature lookup** (fatal-first, unless the feature is absent or `"all"`)
+///    -> [`GenericThresholdCheck::NotFound`] with [`GenericThresholdRef::Feature`].
+/// 3. **duplicate** `(plan, behavior, feature)` -> [`GenericThresholdCheck::Duplicate`]
+///    (warning-success; the command still succeeds as a no-op).
+/// 4. **field aggregate** (`behavior` + `sendToRedo`) -> [`GenericThresholdCheck::Invalid`],
+///    else [`GenericThresholdCheck::Ok`].
+///
+/// Caps are deliberately not taken here: they are typed `i64` at the API/FFI
+/// boundary and rejected strictly upstream, so they never reach this staging.
+pub fn validate_generic_threshold(
+    config_json: &str,
+    plan: &str,
+    behavior: &str,
+    send_to_redo: &str,
+    feature: Option<&str>,
+) -> Result<GenericThresholdCheck> {
+    let config: Value =
+        serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
+
+    let plan_upper = plan.to_uppercase();
+    let behavior_upper = behavior.to_uppercase();
+    let feature_upper = feature.unwrap_or("ALL").to_uppercase();
+
+    // Stage 1: plan lookup (fatal-first).
+    let gplan_id = match config["G2_CONFIG"]["CFG_GPLAN"]
+        .as_array()
+        .and_then(|rows| {
+            rows.iter()
+                .find(|p| p["GPLAN_CODE"].as_str() == Some(plan_upper.as_str()))
+        })
+        .and_then(|p| p["GPLAN_ID"].as_i64())
+    {
+        Some(id) => id,
+        None => {
+            return Ok(GenericThresholdCheck::NotFound {
+                which: GenericThresholdRef::Plan,
+                value: plan_upper,
+            });
+        }
+    };
+
+    // Stage 2: feature lookup (fatal-first); "ALL" is the 0 sentinel.
+    let ftype_id = if feature_upper == "ALL" {
+        0
+    } else {
+        match config["G2_CONFIG"]["CFG_FTYPE"]
+            .as_array()
+            .and_then(|rows| {
+                rows.iter()
+                    .find(|f| f["FTYPE_CODE"].as_str() == Some(feature_upper.as_str()))
+                    .and_then(|f| f["FTYPE_ID"].as_i64())
+            }) {
+            Some(id) => id,
+            None => {
+                return Ok(GenericThresholdCheck::NotFound {
+                    which: GenericThresholdRef::Feature,
+                    value: feature_upper,
+                });
+            }
+        }
+    };
+
+    // Stage 3: duplicate (warning-success).
+    let is_duplicate = config["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+        .as_array()
+        .map(|rows| {
+            rows.iter().any(|record| {
+                record["GPLAN_ID"].as_i64() == Some(gplan_id)
+                    && record["BEHAVIOR"].as_str() == Some(behavior_upper.as_str())
+                    && record["FTYPE_ID"].as_i64() == Some(ftype_id)
+            })
+        })
+        .unwrap_or(false);
+    if is_duplicate {
+        return Ok(GenericThresholdCheck::Duplicate);
+    }
+
+    // Stage 4: aggregated field validation (behavior + sendToRedo).
+    let failures = collect_generic_threshold_failures(&behavior_upper, send_to_redo);
+    if failures.is_empty() {
+        Ok(GenericThresholdCheck::Ok)
+    } else {
+        Ok(GenericThresholdCheck::Invalid(failures))
+    }
+}
+
 /// Add a new generic threshold (CFG_GENERIC_THRESHOLD record)
 ///
 /// # Arguments
@@ -822,6 +994,14 @@ pub fn list_comparison_thresholds(config_json: &str) -> Result<Vec<Value>> {
 ///
 /// # Returns
 /// Modified configuration JSON string
+///
+/// # Duplicates
+/// A duplicate `(plan, behavior, feature)` tuple is rejected here with
+/// [`SzConfigError::AlreadyExists`]. This differs from Python's
+/// `do_addGenericThreshold`, which treats a duplicate as a warning and succeeds
+/// without writing. Callers wanting that Python-parity behaviour should call
+/// [`validate_generic_threshold`] first and skip the add when it returns
+/// [`GenericThresholdCheck::Duplicate`].
 pub fn add_generic_threshold(
     config_json: &str,
     params: AddGenericThresholdParams,
@@ -904,39 +1084,23 @@ pub fn add_generic_threshold(
         )));
     }
 
-    // Collect-all validity block, mirroring Python `validateGenericThreshold`
+    // Aggregated validity block, mirroring Python `validateGenericThreshold`
     // (which appends every failure to one `errorList` and reports them together
-    // AFTER the plan/feature/duplicate checks). Two things are validated here:
-    //
-    //   1. BEHAVIOR must be one of the canonical 17 codes. We use
-    //      `behavior_domain::behavior_position` (backed by `BEHAVIOR_CODES`),
-    //      the EXACT set Python's `lookupBehaviorCode` checks against — NOT the
-    //      broader `parse_behavior_code`, which also accepts variants that are
-    //      not valid generic-threshold behaviours.
-    //   2. SEND_TO_REDO must canonicalise to "Yes"/"No" via
-    //      `send_to_redo_canonical`.
-    //
-    // The caps are already `i64` (typed at the API/FFI boundary via
+    // AFTER the plan/feature/duplicate checks). The two SDK-relevant checks —
+    // BEHAVIOR against the canonical domain and SEND_TO_REDO against [Yes, No] —
+    // are built by the shared `collect_generic_threshold_failures` so this
+    // producer and `validate_generic_threshold` never drift. Each failure is
+    // carried as structured DATA in `SzConfigError::ValidationErrors`
+    // (canonical order [behavior, sendToRedo]) rather than a lossy joined
+    // string. The caps are already `i64` (typed at the API/FFI boundary via
     // `optional_i64`), so Python's `isinstance(int)` cap checks are enforced
     // upstream and need no runtime check here.
-    let mut validity_errors: Vec<String> = Vec::new();
-    if crate::behavior_domain::behavior_position(&behavior_upper).is_none() {
-        validity_errors.push(format!(
-            "Invalid behavior code '{behavior_upper}'. Valid codes: {}",
-            crate::behavior_domain::BEHAVIOR_CODES.join(", ")
-        ));
+    let failures = collect_generic_threshold_failures(&behavior_upper, send_to_redo);
+    if !failures.is_empty() {
+        return Err(SzConfigError::ValidationErrors(failures));
     }
-    let redo_canonical = match send_to_redo_canonical(send_to_redo) {
-        Ok(v) => Some(v),
-        Err(e) => {
-            validity_errors.push(e.to_string());
-            None
-        }
-    };
-    if !validity_errors.is_empty() {
-        return Err(SzConfigError::InvalidInput(validity_errors.join("; ")));
-    }
-    let redo_canonical = redo_canonical.expect("no validity errors implies redo canonicalised");
+    let redo_canonical = send_to_redo_canonical(send_to_redo)
+        .expect("no validity errors implies redo canonicalised");
 
     // Build a complete row via GenericThresholdRow so every
     // CFG_GENERIC_THRESHOLD key is present.
@@ -1049,13 +1213,6 @@ pub fn set_generic_threshold(
     // never a value to write. Defaults to the all-features (0) sentinel.
     let ftype_id = resolve_ftype_id_or_all(config_json, params.feature.unwrap_or("ALL"))?;
 
-    // Canonicalise sendToRedo up front so an invalid value is rejected before
-    // any mutation (case-insensitive validation, title-case storage).
-    let redo_canonical = match params.send_to_redo {
-        Some(v) => Some(send_to_redo_canonical(v)?),
-        None => None,
-    };
-
     let mut config: Value =
         serde_json::from_str(config_json).map_err(|e| SzConfigError::JsonParse(e.to_string()))?;
 
@@ -1066,10 +1223,16 @@ pub fn set_generic_threshold(
         .ok_or_else(|| SzConfigError::MissingSection("CFG_GENERIC_THRESHOLD".to_string()))?;
 
     // Match on the FULL triple (GPLAN_ID, BEHAVIOR, FTYPE_ID) so per-feature
-    // rows that share a (plan, behaviour) are distinguished by feature.
-    let gthresh = gthresh_array
-        .iter_mut()
-        .find(|item| {
+    // rows that share a (plan, behaviour) are distinguished by feature. BEHAVIOR
+    // is part of this lookup KEY, so an unknown/non-canonical behaviour surfaces
+    // here as NotFound (row absent) — it is NOT re-validated as a reference
+    // code. This mirrors Python `do_setGenericThreshold`, which looks the row up
+    // by (plan, behavior, feature) BEFORE running `validateGenericThreshold` on
+    // the merged record (whose BEHAVIOR is copied from the found row and is
+    // therefore always canonical). Only `sendToRedo` is genuinely re-validated.
+    let idx = gthresh_array
+        .iter()
+        .position(|item| {
             item["GPLAN_ID"].as_i64() == Some(gplan_id)
                 && item["BEHAVIOR"].as_str() == Some(behavior_upper.as_str())
                 && item["FTYPE_ID"].as_i64() == Some(ftype_id)
@@ -1079,6 +1242,28 @@ pub fn set_generic_threshold(
                 "Generic threshold not found: GPLAN_ID={gplan_id}, BEHAVIOR={behavior_upper}, FTYPE_ID={ftype_id}"
             ))
         })?;
+
+    // Validate sendToRedo AFTER the row lookup (Python ordering: a missing row
+    // wins over a bad sendToRedo). A bad value aggregates into ValidationErrors
+    // — one uniform structured surface across ADD and SET for the CLI — rather
+    // than the old scalar InvalidInput.
+    let redo_canonical = match params.send_to_redo {
+        Some(v) => match send_to_redo_canonical(v) {
+            Ok(canonical) => Some(canonical),
+            Err(_) => {
+                return Err(SzConfigError::ValidationErrors(vec![
+                    ValidationFailure::new(
+                        "sendToRedo",
+                        ValidationReason::OutOfDomain,
+                        Some(v.to_string()),
+                    ),
+                ]));
+            }
+        },
+        None => None,
+    };
+
+    let gthresh = &mut gthresh_array[idx];
 
     // In-place update of a complete existing row; all keys preserved.
     // FTYPE_ID is a lookup key and must never be overwritten here.
@@ -1419,7 +1604,14 @@ mod tests {
 
         let params = AddGenericThresholdParams::new("INGEST", "NAME", 20, 10, "maybe");
         let err = add_generic_threshold(config, params).unwrap_err();
-        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+        assert_eq!(err.kind(), crate::error::SzErrorKind::ValidationErrors);
+        let failures = err.validation_failures().unwrap();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].field, "sendToRedo");
+        assert_eq!(
+            failures[0].reason_code,
+            crate::error::ValidationReason::OutOfDomain
+        );
     }
 
     /// Rows sharing (GPLAN_ID, BEHAVIOR) but differing by FTYPE_ID must be
@@ -1511,7 +1703,10 @@ mod tests {
             send_to_redo: Some("nope"),
         };
         let err = set_generic_threshold(config, params).unwrap_err();
-        assert_eq!(err.kind(), crate::error::SzErrorKind::InvalidInput);
+        assert_eq!(err.kind(), crate::error::SzErrorKind::ValidationErrors);
+        let failures = err.validation_failures().unwrap();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].field, "sendToRedo");
     }
 
     /// delete_comparison_threshold must match the full 3-key identity and leave

--- a/tests/ffi_validation_errors.rs
+++ b/tests/ffi_validation_errors.rs
@@ -1,0 +1,89 @@
+//! C-boundary coverage for the structured validation-error surface (#59):
+//! a bogus-behaviour add must set the `VALIDATION_ERRORS` reason code and carry
+//! the versioned, namespaced JSON details, and the validate entry point must
+//! return the staged check as versioned JSON. Exercised against the REAL Senzing
+//! v4 template, not synthetic config.
+//!
+//! All assertions live in a SINGLE test: the FFI last-error store is a
+//! process-global static, so keeping the calls sequential within one test avoids
+//! races with any other FFI call in this binary.
+
+use std::ffi::{CStr, CString};
+
+use sz_configtool_lib::ffi::{
+    SzConfigTool_addGenericThreshold, SzConfigTool_free, SzConfigTool_getLastErrorDetails,
+    SzConfigTool_getLastErrorReasonCode, SzConfigTool_validateGenericThreshold,
+};
+
+fn template() -> String {
+    let path = format!(
+        "{}/tests/fixtures/g2config_template.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"))
+}
+
+fn cstr(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+#[test]
+fn ffi_validation_errors_surface_reason_code_and_details() {
+    let config = cstr(&template());
+    let plan = cstr("INGEST");
+    let bogus = cstr("BOGUS");
+    let redo = cstr("No");
+
+    // (1) Bogus behaviour add -> error return, VALIDATION_ERRORS reason code,
+    // versioned structured details.
+    let res = SzConfigTool_addGenericThreshold(
+        config.as_ptr(),
+        plan.as_ptr(),
+        bogus.as_ptr(),
+        20,
+        10,
+        redo.as_ptr(),
+        std::ptr::null(),
+    );
+    assert!(
+        res.returnCode < 0,
+        "bogus behaviour must be an error return"
+    );
+    assert!(res.response.is_null());
+
+    let reason = SzConfigTool_getLastErrorReasonCode();
+    assert!(!reason.is_null(), "reason code must be set");
+    let reason_str = unsafe { CStr::from_ptr(reason) }.to_str().unwrap();
+    assert_eq!(reason_str, "VALIDATION_ERRORS");
+
+    let details = SzConfigTool_getLastErrorDetails();
+    assert!(!details.is_null(), "structured details must be set");
+    let details_str = unsafe { CStr::from_ptr(details) }.to_str().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(details_str).unwrap();
+    assert_eq!(parsed["schema"], "sz-configtool.validation-errors/v1");
+    let failures = parsed["failures"].as_array().unwrap();
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0]["field"], "behavior");
+    assert_eq!(failures[0]["reasonCode"], "UNKNOWN_REFERENCE_CODE");
+    assert_eq!(failures[0]["offendingValue"], "BOGUS");
+
+    // (2) validate entry point returns the staged check as versioned JSON.
+    let redo_ok = cstr("Yes");
+    let name = cstr("NAME");
+    let res2 = SzConfigTool_validateGenericThreshold(
+        config.as_ptr(),
+        plan.as_ptr(),
+        name.as_ptr(),
+        redo_ok.as_ptr(),
+        std::ptr::null(),
+    );
+    assert_eq!(res2.returnCode, 0, "validate must succeed as data");
+    assert!(!res2.response.is_null());
+    let check_str = unsafe { CStr::from_ptr(res2.response) }.to_str().unwrap();
+    let check: serde_json::Value = serde_json::from_str(check_str).unwrap();
+    assert_eq!(check["schema"], "sz-configtool.generic-threshold-check/v1");
+    // INGEST/NAME/all exists in the template -> duplicate (warning-success).
+    assert_eq!(check["result"], "duplicate");
+    unsafe { SzConfigTool_free(res2.response) };
+}

--- a/tests/generic_threshold_validation.rs
+++ b/tests/generic_threshold_validation.rs
@@ -13,10 +13,11 @@
 //!    and turning the update into a no-op.
 
 use serde_json::{Value, json};
-use sz_configtool_lib::error::SzErrorKind;
+use sz_configtool_lib::error::{SzErrorKind, ValidationReason};
 use sz_configtool_lib::thresholds::{
-    AddGenericThresholdParams, SetGenericThresholdParams, add_generic_threshold,
-    set_generic_threshold,
+    AddGenericThresholdParams, GenericThresholdCheck, GenericThresholdRef,
+    SetGenericThresholdParams, add_generic_threshold, set_generic_threshold,
+    validate_generic_threshold,
 };
 
 fn template() -> String {
@@ -28,20 +29,69 @@ fn template() -> String {
         .unwrap_or_else(|e| panic!("cannot read config fixture '{path}': {e}"))
 }
 
-/// (a) A bogus behaviour code on an existing plan must be rejected as
-/// `InvalidInput` — the tightened validity block, not a silent add.
+/// (a) A bogus behaviour code on an existing plan is now a structured
+/// `ValidationErrors` with a single `behavior`/`UnknownReferenceCode` failure
+/// echoing the offending (upper-cased) code.
 #[test]
 fn add_generic_threshold_rejects_bogus_behavior_on_template() {
     let config = template();
 
-    // INGEST is a real plan; "BOGUS" is not one of the canonical 17 codes.
+    // INGEST is a real plan; "BOGUS" is not one of the canonical behaviour codes.
     let params = AddGenericThresholdParams::new("INGEST", "BOGUS", 20, 10, "No");
     let err = add_generic_threshold(&config, params).unwrap_err();
-    assert_eq!(err.kind(), SzErrorKind::InvalidInput);
-    assert!(
-        err.to_string().contains("BOGUS"),
-        "error should name the offending code: {err}"
+    assert_eq!(err.kind(), SzErrorKind::ValidationErrors);
+
+    let failures = err.validation_failures().expect("structured failures");
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].field, "behavior");
+    assert_eq!(
+        failures[0].reason_code,
+        ValidationReason::UnknownReferenceCode
     );
+    assert_eq!(failures[0].offending_value.as_deref(), Some("BOGUS"));
+}
+
+/// (a2) BOTH a bad behaviour AND a bad sendToRedo aggregate into TWO failures in
+/// canonical order [behavior, sendToRedo] — proving the aggregate survives (the
+/// old lossy `join("; ")` is gone).
+#[test]
+fn add_generic_threshold_aggregates_behavior_and_send_to_redo_on_template() {
+    let config = template();
+
+    let params = AddGenericThresholdParams::new("INGEST", "BOGUS", 20, 10, "perhaps");
+    let err = add_generic_threshold(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::ValidationErrors);
+
+    let failures = err.validation_failures().expect("structured failures");
+    assert_eq!(failures.len(), 2, "both fields should fail: {failures:?}");
+    // Canonical order: behavior first, sendToRedo second.
+    assert_eq!(failures[0].field, "behavior");
+    assert_eq!(
+        failures[0].reason_code,
+        ValidationReason::UnknownReferenceCode
+    );
+    assert_eq!(failures[1].field, "sendToRedo");
+    assert_eq!(failures[1].reason_code, ValidationReason::OutOfDomain);
+    assert_eq!(failures[1].offending_value.as_deref(), Some("perhaps"));
+}
+
+/// (a3) A bad sendToRedo ONLY (valid behaviour) yields a single
+/// `sendToRedo`/`OutOfDomain` failure.
+#[test]
+fn add_generic_threshold_rejects_bad_send_to_redo_only_on_template() {
+    let config = template();
+
+    // Use the known-absent (SEARCH, NAME, NAME-feature) tuple so the duplicate
+    // check (which fires before field validation) does not pre-empt it.
+    let mut params = AddGenericThresholdParams::new("SEARCH", "NAME", 20, 10, "perhaps");
+    params.feature = Some("NAME");
+    let err = add_generic_threshold(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::ValidationErrors);
+
+    let failures = err.validation_failures().expect("structured failures");
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].field, "sendToRedo");
+    assert_eq!(failures[0].reason_code, ValidationReason::OutOfDomain);
 }
 
 /// (b) A genuinely new (plan, behavior, feature) tuple must be added. The
@@ -137,4 +187,187 @@ fn set_generic_threshold_wrong_typed_cap_errors_on_template() {
         })
         .expect("INGEST/NAME/all row must exist");
     assert_eq!(row["CANDIDATE_CAP"], json!(500));
+}
+
+/// (d2) A boolean cap must be rejected as a scalar `InvalidInput` at the strict
+/// `optional_i64` boundary (Python accepts `isinstance(False, int)`; we
+/// deliberately do NOT — Ant ruling 17/08/2026). It must NOT become a
+/// `ValidationErrors`.
+#[test]
+fn set_generic_threshold_bool_cap_rejected_as_scalar_invalid_input() {
+    let updates = json!({"candidateCap": true});
+    let err = SetGenericThresholdParams::try_from(&updates).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::InvalidInput);
+    assert!(
+        err.validation_failures().is_none(),
+        "a bad cap is a scalar InvalidInput, never a ValidationErrors aggregate"
+    );
+}
+
+// ===== SET path parity (Python `do_setGenericThreshold`) =====
+//
+// Python looks the row up by (plan, behavior, feature) BEFORE running
+// `validateGenericThreshold` on the merged record, so an unknown behaviour
+// (part of the lookup KEY) surfaces as a row NotFound — it is NOT re-validated
+// as a reference code. Only `sendToRedo` is genuinely re-validated, and it
+// aggregates into `ValidationErrors` for a uniform surface with ADD.
+
+/// SET with an unknown behaviour hits the row lookup and returns `NotFound`
+/// (behaviour is a key, not a re-validated reference code).
+#[test]
+fn set_generic_threshold_unknown_behavior_is_not_found_on_template() {
+    let config = template();
+    let params = SetGenericThresholdParams {
+        plan: Some("INGEST"),
+        behavior: Some("BOGUS"),
+        feature: None,
+        candidate_cap: Some(5),
+        scoring_cap: None,
+        send_to_redo: None,
+    };
+    let err = set_generic_threshold(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::NotFound);
+}
+
+/// SET with a bad `sendToRedo` on a real row aggregates into `ValidationErrors`.
+#[test]
+fn set_generic_threshold_bad_send_to_redo_is_validation_errors_on_template() {
+    let config = template();
+    // INGEST/NAME/all (FTYPE_ID 0) exists in the template.
+    let params = SetGenericThresholdParams {
+        plan: Some("INGEST"),
+        behavior: Some("NAME"),
+        feature: None,
+        candidate_cap: None,
+        scoring_cap: None,
+        send_to_redo: Some("perhaps"),
+    };
+    let err = set_generic_threshold(&config, params).unwrap_err();
+    assert_eq!(err.kind(), SzErrorKind::ValidationErrors);
+    let failures = err.validation_failures().unwrap();
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].field, "sendToRedo");
+    assert_eq!(failures[0].reason_code, ValidationReason::OutOfDomain);
+}
+
+/// SET ordering: a missing row (behaviour is the lookup KEY) wins over a bad
+/// `sendToRedo`. Pins that the row lookup runs BEFORE `sendToRedo` validation —
+/// matching Python's lookup-by-(plan,behavior,feature) before
+/// `validateGenericThreshold`. A regression reordering these would return
+/// `ValidationErrors` instead of `NotFound`.
+#[test]
+fn set_generic_threshold_missing_row_wins_over_bad_send_to_redo_on_template() {
+    let config = template();
+    let params = SetGenericThresholdParams {
+        plan: Some("INGEST"),
+        behavior: Some("BOGUS"), // no such (plan, behavior, feature) row
+        feature: None,
+        candidate_cap: None,
+        scoring_cap: None,
+        send_to_redo: Some("perhaps"), // also invalid, but must be suppressed
+    };
+    let err = set_generic_threshold(&config, params).unwrap_err();
+    assert_eq!(
+        err.kind(),
+        SzErrorKind::NotFound,
+        "missing row must win over bad sendToRedo (row lookup precedes redo validation)"
+    );
+    assert!(
+        err.validation_failures().is_none(),
+        "must not surface sendToRedo as a validation failure when the row is missing"
+    );
+}
+
+/// SET happy path still mutates a real template row.
+#[test]
+fn set_generic_threshold_happy_path_mutates_on_template() {
+    let config = template();
+    let params = SetGenericThresholdParams {
+        plan: Some("INGEST"),
+        behavior: Some("NAME"),
+        feature: None,
+        candidate_cap: None,
+        scoring_cap: None,
+        send_to_redo: Some("no"),
+    };
+    let modified = set_generic_threshold(&config, params).unwrap();
+    let after: Value = serde_json::from_str(&modified).unwrap();
+    let row = after["G2_CONFIG"]["CFG_GENERIC_THRESHOLD"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| {
+            r["GPLAN_ID"].as_i64() == Some(1)
+                && r["BEHAVIOR"].as_str() == Some("NAME")
+                && r["FTYPE_ID"].as_i64() == Some(0)
+        })
+        .expect("INGEST/NAME/all row must exist");
+    // Lower-case "no" canonicalises to title-case "No".
+    assert_eq!(row["SEND_TO_REDO"], json!("No"));
+}
+
+// ===== validate_generic_threshold (the CLI orchestration surface) =====
+
+/// Plan lookup is fatal-first -> NotFound{Plan}.
+#[test]
+fn validate_generic_threshold_not_found_plan_on_template() {
+    let config = template();
+    let check = validate_generic_threshold(&config, "NOPLAN", "NAME", "Yes", None).unwrap();
+    assert_eq!(
+        check,
+        GenericThresholdCheck::NotFound {
+            which: GenericThresholdRef::Plan,
+            value: "NOPLAN".to_string(),
+        }
+    );
+}
+
+/// Feature lookup is fatal-first -> NotFound{Feature}.
+#[test]
+fn validate_generic_threshold_not_found_feature_on_template() {
+    let config = template();
+    let check =
+        validate_generic_threshold(&config, "INGEST", "NAME", "Yes", Some("NOFEATURE")).unwrap();
+    assert_eq!(
+        check,
+        GenericThresholdCheck::NotFound {
+            which: GenericThresholdRef::Feature,
+            value: "NOFEATURE".to_string(),
+        }
+    );
+}
+
+/// An existing (plan, behavior, feature) tuple -> Duplicate (warning-success),
+/// which must NEVER be an error.
+#[test]
+fn validate_generic_threshold_duplicate_on_template() {
+    let config = template();
+    // INGEST/NAME/all exists in the template.
+    let check = validate_generic_threshold(&config, "INGEST", "NAME", "Yes", None).unwrap();
+    assert_eq!(check, GenericThresholdCheck::Duplicate);
+}
+
+/// A bad behaviour on a non-duplicate tuple -> Invalid with the aggregated
+/// failures.
+#[test]
+fn validate_generic_threshold_invalid_on_template() {
+    let config = template();
+    let check = validate_generic_threshold(&config, "INGEST", "BOGUS", "perhaps", None).unwrap();
+    match check {
+        GenericThresholdCheck::Invalid(failures) => {
+            assert_eq!(failures.len(), 2);
+            assert_eq!(failures[0].field, "behavior");
+            assert_eq!(failures[1].field, "sendToRedo");
+        }
+        other => panic!("expected Invalid, got {other:?}"),
+    }
+}
+
+/// A genuinely new, valid tuple -> Ok. The template ships no
+/// (SEARCH, NAME, NAME-feature) row.
+#[test]
+fn validate_generic_threshold_ok_on_template() {
+    let config = template();
+    let check = validate_generic_threshold(&config, "SEARCH", "NAME", "Yes", Some("NAME")).unwrap();
+    assert_eq!(check, GenericThresholdCheck::Ok);
 }


### PR DESCRIPTION
## Summary

Ships the two deferred v0.9.0 backlog items, co-designed with the downstream `sz_configtool` CLI and parity-graded clean against the Python 4.4.0 oracle.

### #59 — structured generic-threshold validation errors (**BREAKING**)
- New `SzConfigError::ValidationErrors(Vec<ValidationFailure>)` + `SzErrorKind::ValidationErrors` (`reason_code() == "VALIDATION_ERRORS"`).
- New public types `ValidationReason` (`Missing | WrongType | OutOfDomain | UnknownReferenceCode | NotFound | Duplicate`) and `ValidationFailure { field, reason_code, offending_value }` — both `#[non_exhaustive]`. Failures are carried as **DATA** (field tag + reason code), never SDK-worded prose; the CLI maps them to Python-style wording.
- New `validate_generic_threshold() -> GenericThresholdCheck` (`NotFound{which,value} | Duplicate | Invalid(Vec) | Ok`) — a no-write staging entry mirroring Python's ordering (plan → feature → duplicate → 4-field aggregate) so the CLI can sequence outcomes without passing typed caps through the strict boundary.
- `add`/`set_generic_threshold` emit the structured failures; SET keeps Python parity (behaviour is the lookup key → unknown behaviour is `NotFound`, only `sendToRedo` re-validated, after the row lookup).
- Caps stay **strictly typed** — non-numeric, digit-string, **and bool** caps rejected as scalar `InvalidInput`, never folded into the aggregate (deliberate divergences from Python, per Ant's rulings).
- FFI: `SzConfigTool_getLastErrorReasonCode` / `getLastErrorDetails` / `validateGenericThreshold`, with **versioned, namespaced** JSON payloads (`sz-configtool.validation-errors/v1`, `sz-configtool.generic-threshold-check/v1`) as an explicit stability contract. Header + docs updated.

`SzConfigError` is deliberately **not** `#[non_exhaustive]`, so the new variant is a breaking change → **minor** bump under 0.x semver.

### #61 — feature-code in resolver messages (non-breaking)
`resolve_call_id_for_feature` names the feature code (`"feature NAME"`) via `CFG_FTYPE` reverse-lookup instead of leaking the internal `ftype_id`, falling back to `"feature id {n}"` only when no row matches. `kind()`/`reason_code()` unchanged — Display-only.

### Release-gate fixes surfaced during prep
- Repaired 4 pre-existing rustdoc private-item intra-doc links (`filter.rs`, `calls/mod.rs`, `elements.rs`) so `cargo doc -D warnings` is clean.
- Added `CFG_FBOM` to the `feature_operations` example's inline config so it runs to exit 0 (previously failed on `main`).

## Test plan
- `cargo test` — **399 passed, 0 failed** (254 unit + 62 integration + 83 doctests). New: `tests/ffi_validation_errors.rs`, extended `tests/generic_threshold_validation.rs` (16 cases).
- All new #59/#61 tests are **template-backed** against `tests/fixtures/g2config_template.json` (never synthetic-only), including the two-entry aggregate ordering, bool/digit-string cap rejection, the SET "missing-row-wins-over-bad-sendToRedo" ordering, and all five `GenericThresholdCheck` arms.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-targets`, `cargo doc --no-deps` — all clean.
- Two adversarial review passes (correctness/parity + API/FFI/JSON-safety) found no high-severity defects; three low/medium findings fixed.
- **Note:** `cargo deny`/`cargo audit` were not runnable locally (tooling absent on the dev VM); the dependency graph is byte-identical to v0.8.0 and CI `security.yml` enforces both on this PR.

Closes #59
Closes #61
